### PR TITLE
AI-strategy proposals + Bucket-1 kill-list fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See `docs/adr/` for the load-bearing decisions in detail.
 
 ```
 Story approved
-  → Tasks generated (GenerateTasksJob → PlanGenerator agent, structured output)
+  → Tasks generated (GenerateTasksJob → TasksGenerator agent, structured output)
   → Story re-approved (any task edit resets to PendingApproval)
   → Subtasks dispatched (ExecuteSubtaskJob)
       → SubtaskRunPipeline: prepare workdir → checkout branch → executor edits

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -60,11 +60,36 @@ class CliExecutor implements Executor
         $files = $this->changedFiles($workingDir);
 
         return new ExecutionResult(
-            summary: trim($stdout),
+            summary: $this->buildSummary($stdout),
             filesChanged: $files,
             commitMessage: $this->commitMessageFor($subtask),
             executorLog: $this->buildExecutorLog($stdout, $stderr),
         );
+    }
+
+    /**
+     * Reduce the CLI's stdout to the trailing chunk a reviewer cares about.
+     *
+     * Agent CLIs typically print streaming progress and end with a final
+     * summary; we keep the tail (≤ 4 KB at a newline boundary) so the value
+     * embedded in PR bodies stays bounded. The full transcript lives on
+     * `executor_log`.
+     */
+    private function buildSummary(string $stdout): string
+    {
+        $trimmed = trim($stdout);
+        $limit = 4_096;
+        if (strlen($trimmed) <= $limit) {
+            return $trimmed;
+        }
+
+        $tail = substr($trimmed, -$limit);
+        $nl = strpos($tail, "\n");
+        if ($nl !== false && $nl < $limit - 64) {
+            $tail = substr($tail, $nl + 1);
+        }
+
+        return $tail;
     }
 
     /**

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -56,13 +56,36 @@ class CliExecutor implements Executor
         }
 
         $stdout = $process->getOutput();
+        $stderr = $process->getErrorOutput();
         $files = $this->changedFiles($workingDir);
 
         return new ExecutionResult(
             summary: trim($stdout),
             filesChanged: $files,
             commitMessage: $this->commitMessageFor($subtask),
+            executorLog: $this->buildExecutorLog($stdout, $stderr),
         );
+    }
+
+    /**
+     * Capture the agent's full transcript so debugging a run does not require
+     * re-running the model. Truncates at 64 KB to keep AgentRun.output bounded.
+     */
+    private function buildExecutorLog(string $stdout, string $stderr): ?string
+    {
+        $combined = trim($stdout);
+        $stderr = trim($stderr);
+        if ($stderr !== '') {
+            $combined .= ($combined === '' ? '' : "\n\n").'--- stderr ---'."\n".$stderr;
+        }
+        if ($combined === '') {
+            return null;
+        }
+        if (strlen($combined) > 65_536) {
+            $combined = substr($combined, 0, 65_536)."\n[truncated]";
+        }
+
+        return $combined;
     }
 
     private function buildPrompt(Subtask $subtask, ?Repo $repo, ?string $workingBranch): string

--- a/app/Services/Executors/ExecutionResult.php
+++ b/app/Services/Executors/ExecutionResult.php
@@ -11,24 +11,35 @@ class ExecutionResult
 {
     /**
      * @param  list<string>  $filesChanged
+     * @param  string|null  $executorLog  Optional full executor transcript (CLI stdout+stderr,
+     *                                    or richer trace from in-process executors). Persisted
+     *                                    verbatim on AgentRun.output for debugging; never used
+     *                                    by the pipeline for control flow.
      */
     public function __construct(
         public string $summary,
         public array $filesChanged,
         public string $commitMessage,
+        public ?string $executorLog = null,
     ) {}
 
     /**
      * Serialise to the JSON-friendly shape stored on AgentRun.output.
      *
-     * @return array{summary: string, files_changed: list<string>, commit_message: string}
+     * @return array{summary: string, files_changed: list<string>, commit_message: string, executor_log?: string}
      */
     public function toArray(): array
     {
-        return [
+        $out = [
             'summary' => $this->summary,
             'files_changed' => $this->filesChanged,
             'commit_message' => $this->commitMessage,
         ];
+
+        if ($this->executorLog !== null && $this->executorLog !== '') {
+            $out['executor_log'] = $this->executorLog;
+        }
+
+        return $out;
     }
 }

--- a/app/Services/PullRequests/PrPayloadBuilder.php
+++ b/app/Services/PullRequests/PrPayloadBuilder.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services\PullRequests;
+
+use App\Models\Subtask;
+
+/**
+ * Renders the title and body for a Subtask's pull request.
+ *
+ * Extracted from SubtaskRunPipeline so it can be unit-tested without spinning
+ * up the queue/git/HTTP harness. The output is the human-facing surface of
+ * every Specify run; keep it scannable, AC-anchored, and bounded in size.
+ */
+class PrPayloadBuilder
+{
+    /**
+     * Build a scannable PR title that locates the work in the Story/AC tree.
+     *
+     * Reviewers triaging a queue of agent PRs benefit from the story id and
+     * AC position — the bare subtask name does not place the change.
+     */
+    public static function title(Subtask $subtask): string
+    {
+        $task = $subtask->task;
+        $story = $task?->story;
+        $acPos = $task?->acceptanceCriterion?->position;
+
+        $tag = $story && $acPos !== null
+            ? sprintf('[Story #%d AC#%d]', $story->getKey(), $acPos)
+            : ($story ? sprintf('[Story #%d]', $story->getKey()) : '');
+
+        return $tag !== ''
+            ? sprintf('Specify %s: %s', $tag, (string) $subtask->name)
+            : sprintf('Specify: %s', (string) $subtask->name);
+    }
+
+    /**
+     * Render a structured PR body so reviewers see what changed, why it
+     * satisfies the acceptance criterion, and which files to look at.
+     *
+     * The "What changed" section is defensively truncated at 8 KB to avoid
+     * provider-side body-size limits when an executor emits a large summary;
+     * the full transcript lives on AgentRun.output.executor_log instead.
+     *
+     * @param  array<string, mixed>  $output
+     */
+    public static function body(Subtask $subtask, array $output): string
+    {
+        $task = $subtask->task;
+        $story = $task?->story;
+        $criterion = $task?->acceptanceCriterion?->criterion;
+        $summary = self::clamp(trim((string) ($output['summary'] ?? '')), 8_192);
+        $files = (array) ($output['files_changed'] ?? []);
+
+        $sections = [];
+
+        if ($story !== null) {
+            $sections[] = "## Story\n".$story->name;
+        }
+
+        if ($criterion !== null && $criterion !== '') {
+            $sections[] = "## Acceptance Criterion\n".$criterion;
+        }
+
+        $sections[] = "## What changed\n".($summary !== '' ? $summary : '_(no summary provided)_');
+
+        if ($files !== []) {
+            $list = implode("\n", array_map(fn ($f) => '- `'.$f.'`', $files));
+            $sections[] = "## Files\n".$list;
+        }
+
+        $clarifications = (array) ($output['clarifications'] ?? []);
+        if ($clarifications !== []) {
+            $rendered = [];
+            foreach ($clarifications as $c) {
+                if (is_array($c) && isset($c['message'])) {
+                    $kind = isset($c['kind']) ? '['.$c['kind'].'] ' : '';
+                    $rendered[] = '- '.$kind.$c['message'];
+                }
+            }
+            if ($rendered !== []) {
+                $sections[] = "## Open questions\n".implode("\n", $rendered);
+            }
+        }
+
+        $sections[] = '_Specify: human approval recorded on the Story; this PR is the diff-review surface._';
+
+        return implode("\n\n", $sections);
+    }
+
+    /**
+     * Trim a string to at most $limit bytes, preferring a newline boundary
+     * near the tail and tagging the truncation explicitly.
+     */
+    private static function clamp(string $value, int $limit): string
+    {
+        if (strlen($value) <= $limit) {
+            return $value;
+        }
+
+        $tail = substr($value, -$limit);
+        $nl = strpos($tail, "\n");
+        if ($nl !== false && $nl < $limit - 64) {
+            $tail = substr($tail, $nl + 1);
+        }
+
+        return "_(summary truncated; see AgentRun.output.executor_log for the full transcript)_\n\n".$tail;
+    }
+}

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -6,6 +6,7 @@ use App\Models\AgentRun;
 use App\Models\Repo;
 use App\Models\Subtask;
 use App\Services\Executors\Executor;
+use App\Services\PullRequests\PrPayloadBuilder;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
 use Throwable;
@@ -140,8 +141,8 @@ class SubtaskRunPipeline
                 repo: $repo,
                 head: $branch,
                 base: $repo->default_branch,
-                title: $this->prTitle($subtask),
-                body: $this->prBody($subtask, $output),
+                title: PrPayloadBuilder::title($subtask),
+                body: PrPayloadBuilder::body($subtask, $output),
             );
 
             return [
@@ -151,76 +152,6 @@ class SubtaskRunPipeline
         } catch (Throwable $e) {
             return ['pull_request_error' => $e->getMessage()];
         }
-    }
-
-    /**
-     * Build a scannable PR title that locates the work in the Story/AC tree.
-     *
-     * Reviewers triaging a queue of agent PRs benefit from the story id and
-     * AC position — the bare subtask name does not place the change.
-     */
-    private function prTitle(Subtask $subtask): string
-    {
-        $task = $subtask->task;
-        $story = $task?->story;
-        $acPos = $task?->acceptanceCriterion?->position;
-
-        $tag = $story && $acPos
-            ? sprintf('[Story #%d AC#%d]', $story->getKey(), $acPos)
-            : ($story ? sprintf('[Story #%d]', $story->getKey()) : '');
-
-        return trim('Specify '.$tag.': '.$subtask->name);
-    }
-
-    /**
-     * Render a structured PR body so reviewers see what changed, why it
-     * satisfies the acceptance criterion, and which files to look at — in
-     * place of a single opaque summary line.
-     *
-     * @param  array<string, mixed>  $output
-     */
-    private function prBody(Subtask $subtask, array $output): string
-    {
-        $task = $subtask->task;
-        $story = $task?->story;
-        $criterion = $task?->acceptanceCriterion?->criterion;
-        $summary = trim((string) ($output['summary'] ?? ''));
-        $files = (array) ($output['files_changed'] ?? []);
-
-        $sections = [];
-
-        if ($story !== null) {
-            $sections[] = "## Story\n".$story->name;
-        }
-
-        if ($criterion !== null && $criterion !== '') {
-            $sections[] = "## Acceptance Criterion\n".$criterion;
-        }
-
-        $sections[] = "## What changed\n".($summary !== '' ? $summary : '_(no summary provided)_');
-
-        if ($files !== []) {
-            $list = implode("\n", array_map(fn ($f) => '- `'.$f.'`', $files));
-            $sections[] = "## Files\n".$list;
-        }
-
-        $clarifications = (array) ($output['clarifications'] ?? []);
-        if ($clarifications !== []) {
-            $rendered = [];
-            foreach ($clarifications as $c) {
-                if (is_array($c) && isset($c['message'])) {
-                    $kind = isset($c['kind']) ? '['.$c['kind'].'] ' : '';
-                    $rendered[] = '- '.$kind.$c['message'];
-                }
-            }
-            if ($rendered !== []) {
-                $sections[] = "## Open questions\n".implode("\n", $rendered);
-            }
-        }
-
-        $sections[] = '_Specify: human approval recorded on the Story; this PR is the diff-review surface._';
-
-        return implode("\n\n", $sections);
     }
 
     private function branchFor(AgentRun $agentRun): string

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -140,8 +140,8 @@ class SubtaskRunPipeline
                 repo: $repo,
                 head: $branch,
                 base: $repo->default_branch,
-                title: 'Specify: '.$subtask->name,
-                body: trim((string) ($output['summary'] ?? '')),
+                title: $this->prTitle($subtask),
+                body: $this->prBody($subtask, $output),
             );
 
             return [
@@ -151,6 +151,76 @@ class SubtaskRunPipeline
         } catch (Throwable $e) {
             return ['pull_request_error' => $e->getMessage()];
         }
+    }
+
+    /**
+     * Build a scannable PR title that locates the work in the Story/AC tree.
+     *
+     * Reviewers triaging a queue of agent PRs benefit from the story id and
+     * AC position — the bare subtask name does not place the change.
+     */
+    private function prTitle(Subtask $subtask): string
+    {
+        $task = $subtask->task;
+        $story = $task?->story;
+        $acPos = $task?->acceptanceCriterion?->position;
+
+        $tag = $story && $acPos
+            ? sprintf('[Story #%d AC#%d]', $story->getKey(), $acPos)
+            : ($story ? sprintf('[Story #%d]', $story->getKey()) : '');
+
+        return trim('Specify '.$tag.': '.$subtask->name);
+    }
+
+    /**
+     * Render a structured PR body so reviewers see what changed, why it
+     * satisfies the acceptance criterion, and which files to look at — in
+     * place of a single opaque summary line.
+     *
+     * @param  array<string, mixed>  $output
+     */
+    private function prBody(Subtask $subtask, array $output): string
+    {
+        $task = $subtask->task;
+        $story = $task?->story;
+        $criterion = $task?->acceptanceCriterion?->criterion;
+        $summary = trim((string) ($output['summary'] ?? ''));
+        $files = (array) ($output['files_changed'] ?? []);
+
+        $sections = [];
+
+        if ($story !== null) {
+            $sections[] = "## Story\n".$story->name;
+        }
+
+        if ($criterion !== null && $criterion !== '') {
+            $sections[] = "## Acceptance Criterion\n".$criterion;
+        }
+
+        $sections[] = "## What changed\n".($summary !== '' ? $summary : '_(no summary provided)_');
+
+        if ($files !== []) {
+            $list = implode("\n", array_map(fn ($f) => '- `'.$f.'`', $files));
+            $sections[] = "## Files\n".$list;
+        }
+
+        $clarifications = (array) ($output['clarifications'] ?? []);
+        if ($clarifications !== []) {
+            $rendered = [];
+            foreach ($clarifications as $c) {
+                if (is_array($c) && isset($c['message'])) {
+                    $kind = isset($c['kind']) ? '['.$c['kind'].'] ' : '';
+                    $rendered[] = '- '.$kind.$c['message'];
+                }
+            }
+            if ($rendered !== []) {
+                $sections[] = "## Open questions\n".implode("\n", $rendered);
+            }
+        }
+
+        $sections[] = '_Specify: human approval recorded on the Story; this PR is the diff-review surface._';
+
+        return implode("\n\n", $sections);
     }
 
     private function branchFor(AgentRun $agentRun): string

--- a/docs/proposals/0001-multi-executor-race.md
+++ b/docs/proposals/0001-multi-executor-race.md
@@ -1,0 +1,81 @@
+# Proposal 0001 — Multi-executor race driver
+
+Status: Draft
+Date: 2026-05-01
+Source: AI strategy audit, Bucket 3 #1
+
+## Premise
+
+The `Executor` interface (ADR-0003) is genuinely pluggable, but every run binds to exactly one driver via `specify.executor.driver`. Pre-AI you would never propose "let three engineers solve the same ticket and pick one." With AI, the marginal cost of a parallel attempt is bounded and the human-in-the-loop already exists at the PR review surface. The question we cannot currently answer: *which executor produces the best diff for which shape of subtask?*
+
+## Decision (proposed)
+
+Add a meta-driver `multi` that fans `ExecuteSubtaskJob` across N configured drivers, runs each in its own working directory and on its own branch, and opens N PRs tagged with the executor that produced them. The reviewer picks one (merges it), declines the others (closes them). The choice is the data.
+
+## Concrete shape
+
+### Configuration
+
+```php
+// config/specify.php
+'executor' => [
+    'driver' => env('SPECIFY_EXECUTOR_DRIVER', 'laravel-ai'),
+    'multi' => [
+        'drivers' => array_filter(explode(',', (string) env('SPECIFY_EXECUTOR_MULTI', ''))),
+        // Each entry must be a fully-resolvable driver name registered elsewhere
+        // in this config block. e.g. SPECIFY_EXECUTOR_MULTI=laravel-ai,cli-claude,cli-codex
+    ],
+    'cli' => [ /* existing */ ],
+],
+```
+
+### New executor
+
+`app/Services/Executors/MultiExecutor.php`
+
+- `needsWorkingDirectory(): true`
+- `execute(...)`: dispatches `N` child `ExecuteSubtaskJob`s via `Bus::batch()`, one per child driver. Each child job receives the *same* `Subtask` but a derived `working_branch` (e.g. `specify/story-{id}-v{rev}-task-{pos}-by-{driver}`). Returns an `ExecutionResult` whose `summary` is "raced N executors; see batch {id}".
+- The pipeline already opens one PR per `AgentRun`; multi creates one `AgentRun` per child driver, each with its own branch. The reviewer sees N PRs side-by-side.
+
+### Capability flag (prerequisite — Bucket 2 #3)
+
+Extend the `Executor` interface with:
+
+```php
+public function capabilities(): ExecutorCapabilities; // { streaming, multi-attempt, ... }
+```
+
+`MultiExecutor::capabilities()` declares `multi-attempt: true`. The pipeline checks this before deciding whether to dispatch one child run or fan out.
+
+### Branch naming
+
+Existing convention: `specify/story-{id}-v{revision}-task-{position}`.
+Race convention: append `-by-{driver-slug}`. Drivers register a slug (`laravel-ai`, `cli-claude`, `cli-codex`).
+
+### PR titles
+
+Existing: `'Specify: '.$subtask->name`.
+Race: `'Specify [{driver-slug}]: '.$subtask->name` so the reviewer sees the source at a glance.
+
+## First experiment (one sprint)
+
+1. Add capability flags + `MultiExecutor` (no UI changes).
+2. Configure two drivers (`laravel-ai` and `cli-claude`).
+3. Run on the next 5 stories opted-in via a `story.use_multi_executor` boolean.
+4. Tag the merged PR with `winner=<driver>`. After 5 stories, query: which driver wins, and on what kind of subtask?
+
+## Failure modes and mitigations
+
+- **Cost blow-up.** Two executor calls per subtask doubles AI spend. Mitigation: opt-in per story; cap multi-mode to N drivers; surface aggregate cost on the run.
+- **Reviewer fatigue from N near-identical PRs.** Mitigation: a follow-up tool that posts a *diff-of-diffs* comment on the lead PR ("compared to PR #B, this one omits X, adds Y"). That *is* Bucket 3 #3 (multi-persona review) wearing a hat.
+- **Branch noise on the host repo.** Closed-not-merged branches accumulate. Mitigation: pipeline deletes the losing branches after merge of the winner via a webhook handler.
+
+## Reversibility
+
+Pure additive: new driver name, new branch suffix, no schema changes. Removing it deletes one file and one config key.
+
+## Open questions
+
+- Do we open all N PRs immediately, or open only the winner after the model self-judges? (First version: open all N. Self-judging is a separate proposal.)
+- Should the losers' AgentRuns be marked `Cancelled` or `Succeeded with no merge`? (First version: `Succeeded`; the merge state lives on the PR, not the run.)
+- Should we record the *reviewer's* choice as a structured signal (e.g. `agent_run.race_outcome = won|lost|tied`) for later analysis? (Yes — minimal column, big payoff for Bucket 3 #4.)

--- a/docs/proposals/0002-adr-conformance-reviewer.md
+++ b/docs/proposals/0002-adr-conformance-reviewer.md
@@ -1,0 +1,99 @@
+# Proposal 0002 — ADR-conformance review agent
+
+Status: Draft
+Date: 2026-05-01
+Source: AI strategy audit, Bucket 3 #3 (scoped to one persona)
+
+## Premise
+
+ADR-0001 says "Story is the only approval gate." ADR-0002 says "Plan is retired; never reintroduce it." ADR-0003 says the executor interface is pluggable. None of these rules are checked anywhere — they live in prose and depend on humans remembering them at PR review time. AI can read prose and code together at a price that makes per-PR enforcement viable.
+
+This proposal carves a single, narrow Bucket-3 idea out of the broader "multi-persona review" concept: one reviewer, one job — flag PRs whose diffs contradict an accepted ADR.
+
+## Decision (proposed)
+
+Introduce a `ReviewProvider` interface mirroring `PullRequestProvider`. Implement one driver (`GithubReviewProvider`) and one persona (`AdrConformanceReviewer`). When `SubtaskRunPipeline` finishes opening a PR, it dispatches a `ReviewPullRequestJob` that runs the reviewer and posts review comments on the PR.
+
+Specify becomes its own first customer.
+
+## Concrete shape
+
+### Interface
+
+```php
+// app/Services/Reviews/ReviewProvider.php
+interface ReviewProvider
+{
+    /**
+     * Post a review (with line-level comments if supported) on a PR.
+     *
+     * @param  list<ReviewComment>  $comments
+     */
+    public function postReview(Repo $repo, int $prNumber, string $summary, array $comments): void;
+}
+
+// app/Services/Reviews/ReviewComment.php — value object
+final class ReviewComment {
+    public function __construct(
+        public string $path,
+        public int $line,
+        public string $body,
+        public string $severity = 'warning', // info|warning|error
+    ) {}
+}
+```
+
+### Reviewer agent
+
+`app/Ai/Agents/AdrConformanceReviewer.php`
+
+- Inputs: list of accepted ADRs (markdown contents), the diff of the PR, the list of changed files.
+- Tool: `ReadFile` (sandboxed to the working dir of the AgentRun).
+- Output (structured): `{ overall: pass|warn|fail, summary: string, violations: list<{adr: string, file: string, line: int, reason: string}> }`.
+
+The reviewer is given *one* job: "Find concrete contradictions between the diff and an accepted ADR. Cite ADR section. Quote the violated line." No general code review — that's a different persona, deliberately not in scope here.
+
+### Pipeline hook
+
+After `SubtaskRunPipeline::openPullRequest()` succeeds, queue `ReviewPullRequestJob` (non-fatal, like PR opening — ADR-0004 pattern). The job:
+
+1. Loads accepted ADRs from `docs/adr/`.
+2. Fetches the PR diff via the provider's API.
+3. Runs `AdrConformanceReviewer`.
+4. Posts the review with up to N comments (cap at 10 to avoid spam).
+5. Records `review_url` / `review_error` on the AgentRun.
+
+### Configuration
+
+```php
+'review' => [
+    'enabled' => filter_var(env('SPECIFY_REVIEW_ENABLED', false), FILTER_VALIDATE_BOOLEAN),
+    'personas' => array_filter(explode(',', (string) env('SPECIFY_REVIEW_PERSONAS', 'adr-conformance'))),
+],
+```
+
+Off by default; flip on per-environment.
+
+## First experiment (one sprint)
+
+1. Implement `ReviewProvider`, `GithubReviewProvider`, `AdrConformanceReviewer`, `ReviewPullRequestJob`.
+2. Enable on this repo only (`SPECIFY_REVIEW_ENABLED=true` in dev).
+3. Re-review the last 10 merged PRs offline (don't post; log only). Manually score: how many real ADR violations did it catch? How many false positives?
+4. If precision ≥ 70%, enable for live PRs. If not, iterate the prompt — and *capture rejected reviewer comments as Bucket-3 #4 signal*.
+
+## Failure modes and mitigations
+
+- **Hallucinated ADR citations.** Mitigation: structured output requires an `adr` field that must match a filename under `docs/adr/`. Validate before posting.
+- **Comment spam.** Mitigation: cap at 10 comments per PR, severity-sorted.
+- **False positive on intentional ADR amendments.** Mitigation: if the PR diff *modifies* an ADR file, downgrade related violations to `info`. The reviewer is reading prose; let it tell us when it sees a deliberate update.
+- **Reviewer becomes a gate by accident.** Mitigation: this is Bucket 1 if we ever block merge on a non-deterministic AI signal. Keep it advisory. Human is still the only approver.
+
+## Reversibility
+
+Additive: new interface, new job, new env flag. Disabling it sets `SPECIFY_REVIEW_ENABLED=false`. Removing it deletes one folder and one config block.
+
+## Open questions
+
+- Does the reviewer see *only* the diff or the surrounding file? (First version: diff only — keeps cost bounded. Add file context behind a flag if precision suffers.)
+- Should reviewer comments survive in `AgentRun.output` for analysis, or live only on the PR? (Both — the PR is the human surface, the AgentRun is the analytics surface.)
+- Per-ADR opt-out? (Add a frontmatter field `review.enforce: false` on ADRs that are advisory. Default: enforce.)

--- a/docs/proposals/0003-per-subtask-context-brief.md
+++ b/docs/proposals/0003-per-subtask-context-brief.md
@@ -1,0 +1,89 @@
+# Proposal 0003 — Per-subtask context brief
+
+Status: Draft
+Date: 2026-05-01
+Source: AI strategy audit, Bucket 3 #6
+
+## Premise
+
+`SubtaskExecutor::instructions()` is a static heredoc. Every Subtask, on every Story, in every Repo, gets the same system prompt. The article's "static artefact" trap, in code form. AI thrives on repo-aware context but the executor goes in blind beyond the prompt and the working directory.
+
+## Decision (proposed)
+
+Introduce a `ContextBuilder` callable invoked in `SubtaskRunPipeline::run()` *between* workdir checkout and `Executor::execute()`. It returns a `string $contextBlock` that the pipeline injects into the executor (via `Subtask::contextBrief` set transiently or a new parameter on `Executor::execute()`).
+
+Start with the cheapest possible signal. Add layers only if they pay.
+
+## Concrete shape
+
+### Interface
+
+```php
+// app/Services/Context/ContextBuilder.php
+interface ContextBuilder
+{
+    /**
+     * Produce a per-subtask context brief, injected into the executor prompt.
+     */
+    public function build(Subtask $subtask, ?string $workingDir, ?Repo $repo): string;
+}
+```
+
+### Default implementation — `RecencyContextBuilder`
+
+Three signals, all cheap:
+
+1. **Files mentioned in the Subtask description.** Grep the description for path-like tokens; verify they exist; include a one-line `wc -l` of each.
+2. **Files touched recently.** `git log --name-only --since=30.days --pretty=format:` in the working dir; intersect with the description-mentioned set; show the top 10 with their last-touched commit message.
+3. **Prior runs on this same Subtask.** Read `AgentRun` rows where `runnable` is this Subtask and status is `Failed` or `NoDiff`; include their `summary` and `commit_message`.
+
+Render as a markdown block prepended to the executor's prompt, marked with `<context-brief>...</context-brief>` tags so the executor knows where it ends.
+
+### Pipeline integration
+
+```php
+// SubtaskRunPipeline::run()
+$contextBrief = app(ContextBuilder::class)->build($subtask, $workingDir, $repo);
+$result = $this->executor->execute($subtask, $workingDir, $repo, $branch, $contextBrief);
+```
+
+`Executor::execute()` gains a final `?string $contextBrief = null` parameter (default `null` keeps existing tests green). `LaravelAiExecutor` and `CliExecutor` both inject it before the existing prompt. `FakeExecutor` ignores it.
+
+### Configuration
+
+```php
+'context' => [
+    'builder' => env('SPECIFY_CONTEXT_BUILDER', 'recency'),
+    'recency' => [
+        'window' => env('SPECIFY_CONTEXT_WINDOW', '30.days'),
+        'max_files' => (int) env('SPECIFY_CONTEXT_MAX_FILES', 10),
+    ],
+],
+```
+
+## First experiment (one sprint)
+
+1. Implement `ContextBuilder` interface + `RecencyContextBuilder` + `NullContextBuilder` (returns empty string).
+2. Add the `?string $contextBrief = null` parameter to the `Executor` interface; default null keeps every test passing.
+3. Bind `RecencyContextBuilder` in production, `NullContextBuilder` in tests.
+4. Pick 5 recent Subtasks, run them twice (once with brief, once without), compare:
+   - Time-to-first-Edit-tool-call (proxy for "agent oriented faster").
+   - Number of `ReadFile` calls before the first edit (proxy for thrashing).
+   - Final diff cleanliness (does it touch unrelated files?).
+5. If 3 of 5 improve, ship it.
+
+## Failure modes and mitigations
+
+- **Context bloat blowing prompt budget.** Mitigation: hard cap on brief size (4 KB). Truncate the lowest-value signal first (prior-run summaries before recency before mentions).
+- **Wrong files highlighted.** Mitigation: false positives are recoverable — the executor can ignore the brief. The brief is a hint, not a constraint.
+- **Builder becomes a bottleneck.** Mitigation: stays out of the hot path (per-subtask, not per-tool-call). Time-budget at 1 second; if it exceeds, fall back to `NullContextBuilder`.
+
+## Reversibility
+
+Pure additive: new interface + default param. Disabling is `SPECIFY_CONTEXT_BUILDER=null`. Removing is two file deletes.
+
+## Open questions
+
+- Should the brief be visible in the run audit log? (Yes — log it as a structured field on the AgentRun. It's part of what the executor saw.)
+- Should the brief itself be AI-generated (a context-summarisation agent) rather than mechanical? (Not in V1. Mechanical first; if precision plateaus, layer an AI summariser on top.)
+- Should failed-run summaries from *other* Subtasks in the same Story be included? (Yes — same Story implies shared context. Already cheap to query.)

--- a/docs/proposals/0004-executor-voice-clarifications.md
+++ b/docs/proposals/0004-executor-voice-clarifications.md
@@ -1,0 +1,103 @@
+# Proposal 0004 — Give the executor a voice
+
+Status: Draft
+Date: 2026-05-01
+Source: AI strategy audit, Identity check #2
+
+## Premise
+
+Today `SubtaskExecutor` has tools but no voice. Its instructions tell it: "If the Subtask is ambiguous, prefer the smallest interpretation that satisfies it." This trains the agent to *suppress* signal the system would benefit from hearing — exactly the article's "performing transformation while internally resisting reinvention."
+
+The architecture treats the AI as a worker. This proposal converts it into a collaborator with the smallest possible change.
+
+## Decision (proposed)
+
+Add a `clarifications` field to `ExecutionResult` and to the executor's structured output schema. Surface clarifications back to the human as a `RequestStoryChanges`-style signal on the AgentRun. The executor can still execute — clarifications coexist with a successful diff. They are *information*, not a halt condition.
+
+## Concrete shape
+
+### Schema changes
+
+```php
+// app/Services/Executors/ExecutionResult.php
+final class ExecutionResult
+{
+    /**
+     * @param  list<string>             $filesChanged
+     * @param  list<ExecutorClarification>  $clarifications
+     */
+    public function __construct(
+        public string $summary,
+        public array $filesChanged,
+        public string $commitMessage,
+        public array $clarifications = [],
+    ) {}
+}
+
+// app/Services/Executors/ExecutorClarification.php
+final class ExecutorClarification
+{
+    public function __construct(
+        public string $kind,        // ambiguity|conflict|missing-context|disagreement
+        public string $message,     // free text from the agent
+        public ?string $proposed = null, // optional: what the agent did instead, or what it thinks should change
+    ) {}
+}
+```
+
+### Agent output schema
+
+`SubtaskExecutor::schema()` adds:
+
+```php
+'clarifications' => $schema->array()
+    ->items(
+        $schema->object(fn ($schema) => [
+            'kind' => $schema->string()
+                ->enum(['ambiguity', 'conflict', 'missing-context', 'disagreement'])
+                ->required(),
+            'message' => $schema->string()->required(),
+            'proposed' => $schema->string(),
+        ])
+    ),
+```
+
+### Instruction change
+
+Replace:
+
+> If the Subtask is ambiguous, prefer the smallest interpretation that satisfies it.
+
+with:
+
+> If the Subtask is ambiguous, conflicts with another part of the Story, or you would have chosen differently than what was specified, **execute the smallest reasonable interpretation AND record a clarification**. The clarification will be surfaced to the human reviewer alongside the diff. You are a collaborator, not a worker.
+
+### Pipeline surfacing
+
+`SubtaskRunPipeline` writes clarifications into `AgentRun.output['clarifications']` (already a JSON column). The PR body (Bucket-1 #3 fix) renders them as a `## Open questions` section, so the reviewer sees them in the natural place — next to the diff.
+
+### Story-level signal (optional, V2)
+
+If `clarifications` is non-empty *and* contains any `kind=conflict`, automatically flip the Story's status to `ChangesRequested` after the run completes. The rest of the run still succeeds (ADR-0004 pattern). For V1: surface them, don't auto-act on them.
+
+## First experiment (one sprint)
+
+1. V1: schema + clarifications field + PR body rendering. No automation, no auto-flips.
+2. Watch 10 runs. Count: how many had clarifications? How many of those clarifications were *real signal* (caught a real ambiguity) vs noise (model overthinking)?
+3. If real-signal rate ≥ 50%, ship V2 (auto-flip on conflicts).
+
+## Failure modes and mitigations
+
+- **The model produces noise to look thoughtful.** Mitigation: the kind enum is small and the prompt is firm — only four legitimate kinds. Reject runs with > 3 clarifications and log for prompt iteration.
+- **Reviewers ignore the clarifications.** Mitigation: render them prominently in the PR body. If they're still ignored, that's the review process being broken, not the feature.
+- **Clarifications drift into being a second approval gate.** Mitigation: ADR-0001 is the lodestone. Clarifications are *information*. The Story is still the only gate.
+
+## Reversibility
+
+Pure additive: optional field, optional output. Existing tests pass with no change. Removing it deletes one class and one schema entry.
+
+## Open questions
+
+- Should the clarification list be visible to the *next* Subtask's executor (via the context brief — Proposal 0003)? (Yes. Same Story, same context.)
+- Should there be a "decline" kind where the executor can refuse a Subtask outright? (Not yet. That's a real halt and needs more design — propose separately if a refusal-rate signal warrants it.)
+- Does this make sense for `CliExecutor` where the agent can't emit structured output? (Provide a sentinel: if the CLI's stdout contains `CLARIFY: <kind>: <message>` lines, parse them out. Otherwise, no clarifications. Not perfect, but consistent.)

--- a/docs/proposals/0005-bucket1-kill-list.md
+++ b/docs/proposals/0005-bucket1-kill-list.md
@@ -1,0 +1,93 @@
+# Proposal 0005 — Bucket 1 kill-list
+
+Status: Draft (items 3–5 implemented on this branch; items 1–2 deferred as RFC)
+Date: 2026-05-01
+Source: AI strategy audit, Bucket 1
+
+## Premise
+
+Five Bucket-1 findings from the AI strategy audit. Three are tractable as code edits in one PR; two are larger redesigns that need their own ADRs. This document covers all five so the kill-list is not lost.
+
+## Items implemented on this branch
+
+### #3 — PR title/body should answer the AC, not echo the subtask name
+
+**Before**: every PR's title is `'Specify: '.$subtask->name`; the body is the raw `summary` field from the executor's structured output.
+
+**After**: the body is rendered as a structured markdown block:
+
+```
+## Acceptance Criterion
+{ac.text}
+
+## What changed
+{summary}
+
+## Files
+- {file 1}
+- ...
+
+## Open questions
+{clarifications, if any — Proposal 0004}
+```
+
+Title remains short but adds the AC position so reviewers can scan a queue: `'Specify [Story #{id} AC#{pos}]: '.$subtask->name`.
+
+**File**: `app/Services/SubtaskRunPipeline.php`.
+
+### #4 — `CliExecutor` should preserve the agent's stdout
+
+**Before**: stdout was returned as the `summary` of the `ExecutionResult`, but anything beyond the trimmed final output was thrown away. Tool calls, retries, and "I tried X but it failed" notes are lost.
+
+**After**: full stdout (and stderr if non-empty) is captured and persisted on `AgentRun.output['executor_log']` (truncated at 64 KB). The `summary` becomes the *last* paragraph of stdout (best-effort), not the entire blob.
+
+**File**: `app/Services/Executors/CliExecutor.php` and `app/Services/SubtaskRunPipeline.php`.
+
+### #5 (partial) — fix `PlanGenerator` ghost reference in README
+
+**Before**: README says "GenerateTasksJob → PlanGenerator agent" but the actual class is `TasksGenerator`.
+
+**After**: README says "GenerateTasksJob → TasksGenerator agent". One-line doc fix; not an API change.
+
+**File**: `README.md`.
+
+The MCP tool slug rename (`generate-plan` → `generate-tasks`) is **deferred** because it's a public-API break for any MCP client. See "Deferred — needs an ADR" below.
+
+## Deferred — needs an ADR
+
+### #1 — Up-front plan as a frozen artefact
+
+This is the largest finding from the audit. The current shape (TasksGenerator runs once per Story; edits reset approval) is a deliberate, ADR-documented design — replacing it requires a counter-ADR, not a kill-list edit.
+
+Sketch of the redesign worth proposing in a follow-up ADR:
+
+- **Plan as running hypothesis.** Generate the task list lazily on the first Subtask execution, not eagerly on Story approval. Re-generate at the start of each subsequent Subtask using the current repo state.
+- **Mid-run plan amendment.** Let `SubtaskExecutor` propose new Subtasks (via a new clarification kind, building on Proposal 0004). Append-only — never edits prior Subtasks.
+- **Story re-approval as notification, not blocker.** When the plan grows mid-run, notify the approver but don't halt the run. The Story-as-only-gate property is preserved (ADR-0001) because the *initial* approval still authorises the work; growth is incremental.
+
+This is a real ADR, not a kill-list line. Recommend opening it as `ADR-0005-running-hypothesis-plans.md` with explicit reference to ADR-0001's invariants.
+
+### #2 — Subtasks run linearly with no agent feedback path
+
+Same shape as #1: the linear pipeline is a deliberate design that an ADR should redesign, not a code edit. The voice-for-the-executor work in Proposal 0004 is the smallest first step that opens this door without contradicting ADR-0001.
+
+### #5 (full) — Rename `generate-plan` MCP tool to `generate-tasks`
+
+**Why deferred**: every MCP client that currently calls `generate-plan` would break. Need to:
+
+1. Add `generate-tasks` as an alias that forwards to the same handler.
+2. Update internal docs and clients.
+3. Deprecate `generate-plan` with a console warning for one minor version.
+4. Remove `generate-plan` after the deprecation window.
+
+Recommend opening as a separate small PR with the alias-and-deprecate dance. ADR-0002 already promised this with a deprecation period.
+
+## Risk and reversibility
+
+The three implemented items are all reversible and low-blast-radius:
+
+- The PR body change reverts to a one-liner with one commit.
+- The CLI executor stdout passthrough is additive — no removed fields.
+- The README fix is a doc-only change.
+
+The three deferred items are intentionally not implemented here. Each gets its own ADR or follow-up PR.

--- a/docs/proposals/0005-bucket1-kill-list.md
+++ b/docs/proposals/0005-bucket1-kill-list.md
@@ -39,7 +39,7 @@ Title remains short but adds the AC position so reviewers can scan a queue: `'Sp
 
 **Before**: stdout was returned as the `summary` of the `ExecutionResult`, but anything beyond the trimmed final output was thrown away. Tool calls, retries, and "I tried X but it failed" notes are lost.
 
-**After**: full stdout (and stderr if non-empty) is captured and persisted on `AgentRun.output['executor_log']` (truncated at 64 KB). The `summary` becomes the *last* paragraph of stdout (best-effort), not the entire blob.
+**After**: full stdout (and stderr if non-empty) is captured and persisted on `AgentRun.output['executor_log']` (truncated at 64 KB). The `summary` is reduced to the trailing 4 KB of stdout at a newline boundary so it can be safely embedded in PR bodies; the full transcript lives on `executor_log`. `PrPayloadBuilder` further clamps the "What changed" section to 8 KB as a defense-in-depth.
 
 **File**: `app/Services/Executors/CliExecutor.php` and `app/Services/SubtaskRunPipeline.php`.
 

--- a/tests/Feature/CliExecutorTest.php
+++ b/tests/Feature/CliExecutorTest.php
@@ -67,6 +67,73 @@ test('CliExecutor refuses to run when no working directory is provided', functio
         ->toThrow(RuntimeException::class, 'working directory');
 });
 
+test('CliExecutor records the full transcript on executor_log including stderr', function () {
+    $bin = fakeAgentBinary(<<<'BASH'
+        cat > /dev/null
+        echo "step 1: read files"
+        echo "step 2: edit files"
+        echo "warning: skipping mock" >&2
+        echo "done"
+    BASH);
+
+    $workingDir = sys_get_temp_dir().'/specify-cwd-'.uniqid();
+    File::ensureDirectoryExists($workingDir);
+    new Process(['git', '-c', 'init.defaultBranch=main', 'init'], $workingDir)->mustRun();
+    new Process(['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], $workingDir)->mustRun();
+
+    $subtask = Subtask::factory()->create(['name' => 'log test']);
+    $output = (new CliExecutor([$bin]))->execute($subtask, $workingDir, repo: null, workingBranch: null);
+
+    expect($output->executorLog)
+        ->toContain('step 1: read files')
+        ->toContain('step 2: edit files')
+        ->toContain('done')
+        ->toContain('--- stderr ---')
+        ->toContain('warning: skipping mock');
+
+    expect($output->toArray())->toHaveKey('executor_log');
+});
+
+test('CliExecutor clamps the summary to the trailing chunk to keep PR bodies bounded', function () {
+    $bin = fakeAgentBinary(<<<'BASH'
+        cat > /dev/null
+        for i in $(seq 1 1000); do echo "verbose line $i with extra padding to push past the limit"; done
+        echo "FINAL: agent ran successfully"
+    BASH);
+
+    $workingDir = sys_get_temp_dir().'/specify-cwd-'.uniqid();
+    File::ensureDirectoryExists($workingDir);
+    new Process(['git', '-c', 'init.defaultBranch=main', 'init'], $workingDir)->mustRun();
+    new Process(['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], $workingDir)->mustRun();
+
+    $subtask = Subtask::factory()->create(['name' => 'verbose run']);
+    $output = (new CliExecutor([$bin]))->execute($subtask, $workingDir, repo: null, workingBranch: null);
+
+    expect(strlen($output->summary))->toBeLessThanOrEqual(4_096)
+        ->and($output->summary)->toContain('FINAL: agent ran successfully');
+
+    expect(strlen((string) $output->executorLog))->toBeGreaterThan(strlen($output->summary));
+});
+
+test('CliExecutor truncates executor_log at 64 KB', function () {
+    $bin = fakeAgentBinary(<<<'BASH'
+        cat > /dev/null
+        for i in $(seq 1 50000); do echo "line $i ----------------------------------------"; done
+        echo "tail"
+    BASH);
+
+    $workingDir = sys_get_temp_dir().'/specify-cwd-'.uniqid();
+    File::ensureDirectoryExists($workingDir);
+    new Process(['git', '-c', 'init.defaultBranch=main', 'init'], $workingDir)->mustRun();
+    new Process(['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], $workingDir)->mustRun();
+
+    $subtask = Subtask::factory()->create(['name' => 'huge run']);
+    $output = (new CliExecutor([$bin]))->execute($subtask, $workingDir, repo: null, workingBranch: null);
+
+    expect(strlen((string) $output->executorLog))->toBeLessThanOrEqual(65_536 + 32)
+        ->and($output->executorLog)->toContain('[truncated]');
+});
+
 test('CliExecutor surfaces non-zero exit codes as exceptions', function () {
     $bin = fakeAgentBinary(<<<'BASH'
         echo "boom" >&2

--- a/tests/Feature/PrPayloadBuilderTest.php
+++ b/tests/Feature/PrPayloadBuilderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Models\AcceptanceCriterion;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Services\PullRequests\PrPayloadBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeSubtaskWithCriterion(int $acPosition = 3, ?string $criterion = 'Users can export their data as CSV.'): Subtask
+{
+    $story = Story::factory()->create(['name' => 'Add CSV export']);
+    $ac = AcceptanceCriterion::factory()->for($story)->create([
+        'position' => $acPosition,
+        'criterion' => $criterion,
+    ]);
+    $task = Task::factory()->for($story)->create([
+        'name' => 'Wire export endpoint',
+        'position' => 1,
+        'acceptance_criterion_id' => $ac->id,
+    ]);
+
+    return Subtask::factory()->for($task)->create([
+        'name' => 'Add export route and controller',
+        'position' => 1,
+    ]);
+}
+
+test('title locates the subtask in the Story / AC tree', function () {
+    $subtask = makeSubtaskWithCriterion(acPosition: 3);
+
+    expect(PrPayloadBuilder::title($subtask))
+        ->toBe(sprintf('Specify [Story #%d AC#%d]: Add export route and controller', $subtask->task->story_id, 3));
+});
+
+test('title renders AC#0 instead of dropping the AC tag (regression: truthiness check)', function () {
+    $subtask = makeSubtaskWithCriterion(acPosition: 0);
+
+    expect(PrPayloadBuilder::title($subtask))
+        ->toContain('AC#0');
+});
+
+test('title falls back to Story-only tag when AC position is null', function () {
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create([
+        'name' => 'task',
+        'position' => 1,
+        'acceptance_criterion_id' => null,
+    ]);
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'do work']);
+
+    expect(PrPayloadBuilder::title($subtask))
+        ->toBe(sprintf('Specify [Story #%d]: do work', $story->getKey()));
+});
+
+test('body renders Story, AC, summary, files, and Specify footer', function () {
+    $subtask = makeSubtaskWithCriterion();
+
+    $body = PrPayloadBuilder::body($subtask, [
+        'summary' => 'Wired the export endpoint and added the controller test.',
+        'files_changed' => ['app/Http/Controllers/ExportController.php', 'routes/web.php'],
+    ]);
+
+    expect($body)
+        ->toContain('## Story', 'Add CSV export')
+        ->and($body)->toContain('## Acceptance Criterion', 'Users can export their data as CSV.')
+        ->and($body)->toContain('## What changed', 'Wired the export endpoint')
+        ->and($body)->toContain('## Files', '`app/Http/Controllers/ExportController.php`', '`routes/web.php`')
+        ->and($body)->toContain('Specify: human approval recorded on the Story');
+});
+
+test('body renders an Open questions section when clarifications are present', function () {
+    $subtask = makeSubtaskWithCriterion();
+
+    $body = PrPayloadBuilder::body($subtask, [
+        'summary' => 'done',
+        'clarifications' => [
+            ['kind' => 'ambiguity', 'message' => 'Should exports include archived users?'],
+            ['kind' => 'conflict', 'message' => 'AC #3 conflicts with the rate-limit policy in ADR-0007.'],
+        ],
+    ]);
+
+    expect($body)
+        ->toContain('## Open questions')
+        ->and($body)->toContain('[ambiguity] Should exports include archived users?')
+        ->and($body)->toContain('[conflict] AC #3 conflicts with the rate-limit policy');
+});
+
+test('body clamps a giant summary so the PR body stays under provider limits', function () {
+    $subtask = makeSubtaskWithCriterion();
+
+    $body = PrPayloadBuilder::body($subtask, [
+        'summary' => str_repeat("line of agent output\n", 2_000),
+    ]);
+
+    expect(strlen($body))->toBeLessThan(12_000)
+        ->and($body)->toContain('summary truncated');
+});
+
+test('body renders no Files section when none changed', function () {
+    $subtask = makeSubtaskWithCriterion();
+
+    $body = PrPayloadBuilder::body($subtask, ['summary' => 'nothing to file']);
+
+    expect($body)->not->toContain('## Files');
+});


### PR DESCRIPTION
## Summary

- Lands the small-scope Bucket-1 fixes from the AI strategy audit: full CLI executor transcript capture, structured PR title/body, and a README terminology fix.
- Adds five proposal documents (`docs/proposals/0001`–`0005`) covering the Bucket-3 outside-the-box shortlist (multi-executor race, ADR-conformance reviewer, per-subtask context brief), the executor-voice identity-check change, and the deferred Bucket-1 redesigns.
- Defers the larger redesigns (frozen up-front plan, linear no-feedback pipeline, `generate-plan` MCP slug rename) as named follow-ups in proposal 0005 — each needs its own ADR/PR.

## Code changes

- `ExecutionResult` gains an optional `executorLog` field (additive; `toArray()` only emits `executor_log` when set).
- `CliExecutor` now captures full stdout+stderr (truncated at 64 KB) so debugging a run no longer requires re-running the model.
- `SubtaskRunPipeline` renders PR titles as `Specify [Story #X AC#Y]: …` and PR bodies as a structured markdown block (Story / Acceptance Criterion / What changed / Files / Open questions).
- README references the actual `TasksGenerator` class instead of the retired `PlanGenerator` name.

## Test plan

- [x] `composer test` (Pint + 207 Pest tests, 477 assertions) — all green.
- [ ] Manual: run a Subtask end-to-end against a real GitHub repo and confirm the new PR body renders the AC, file list, and the `_Specify: human approval recorded on the Story_` footer.
- [ ] Manual: run a `cli` driver subtask and confirm `AgentRun.output.executor_log` contains the agent's full transcript.

## Source

AI strategy audit at `~/.claude/code-skills/audit-ai-strategy/reports/specify/2026-05-01-ai-strategy.md`, framed by John Cutler's [TBM 420: The AI Playbook Puzzle](https://cutlefish.substack.com/p/tbm-420-the-ai-playbook-puzzle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)