### PR TITLE
Living prompts + per-subtask context brief

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Specify is a Laravel 13 system where humans approve AI actions on code repos. **
 | Add or change an Executor | [ADR-0003](docs/adr/0003-pluggable-executor-interface.md), `app/Services/Executors/` |
 | Touch PR creation | [ADR-0004](docs/adr/0004-pr-after-push-is-non-fatal.md), `app/Services/PullRequests/` |
 | Add an MCP tool | `app/Mcp/Tools/` (follow the existing `#[Description]` + `handle()` shape) |
+| Edit an agent's system prompt | `prompts/*.md` (loaded by `App\Services\Prompts\PromptLoader`) |
+| Tune the per-subtask context brief | `app/Services/Context/` (`ContextBuilder` interface + `RecencyContextBuilder`) |
 | Run the suite | `composer test` (Pint check + Pest) |
 
 ## Specify-specific rules

--- a/app/Ai/Agents/SubtaskExecutor.php
+++ b/app/Ai/Agents/SubtaskExecutor.php
@@ -13,6 +13,7 @@ use App\Ai\Tools\Sandbox;
 use App\Ai\Tools\WriteFile;
 use App\Models\Repo;
 use App\Models\Subtask;
+use App\Services\Prompts\PromptLoader;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\MaxTokens;
@@ -69,63 +70,7 @@ class SubtaskExecutor implements Agent, HasStructuredOutput, HasTools
 
     public function instructions(): string
     {
-        return <<<'INSTRUCTIONS'
-You are the execution agent for Specify. A human has approved a Story and its
-task list; your job is to execute one Subtask against the working copy of the
-repository that has already been checked out for you on the working branch.
-
-You have these tools — use them to inspect and modify the working tree:
-
-- ReadFile(path, offset?, limit?)
-- WriteFile(path, content)
-- EditFile(path, edits[]) — each edit has `old_string`, `new_string`, optional `replace_all`
-- Bash(command, timeout?) — runs in the working directory
-- Grep(pattern, path?, glob?, ignore_case?, literal?, context?, limit?)
-- Find(pattern, path?, limit?)
-- Ls(path?, limit?)
-
-You MUST use these tools to do the work. Reading a file with ReadFile and
-then writing a modified version is the basic pattern; for surgical changes
-prefer EditFile. Do not just describe what should happen — actually run the
-tools. When you are satisfied that the working tree contains the changes
-the Subtask requires, call output_structured_data with your summary.
-
-Workflow:
-1. Use Ls, Find, Grep, ReadFile to orient yourself in the repo.
-2. Use EditFile for surgical changes, WriteFile for whole-file replacements.
-3. Use Bash to run tests, formatters, or build steps. Do not commit, push,
-   open PRs, or switch branches — those are handled by the orchestrator.
-4. When the Subtask is satisfied, return your structured summary.
-
-Constraints:
-- Make only the changes the Subtask requires. Do not refactor unrelated code.
-- Paths in tool calls are relative to the working directory (the repo root).
-
-You are a collaborator, not a worker. Two voice channels are available in the
-structured output and you should use them deliberately:
-
-- `clarifications` — if the Subtask is ambiguous, conflicts with another part
-  of the Story, you found missing context, or you would have chosen
-  differently than what was specified, **execute the smallest reasonable
-  interpretation AND record a clarification**. Each clarification has a
-  `kind` (one of `ambiguity`, `conflict`, `missing-context`, `disagreement`),
-  a `message`, and an optional `proposed` describing what you think should
-  change. The human reviewer sees these alongside the diff. Do not invent
-  clarifications to look thoughtful — only record real signal.
-- `proposed_subtasks` — if completing this Subtask reveals additional work
-  needed to finish the parent Task (not the whole Story; just the Task),
-  propose follow-up Subtasks. Each entry has `name`, `description`, and
-  `reason`. They are appended to the parent Task and execute after this
-  Subtask succeeds. Cap: at most three proposed Subtasks per run; surplus is
-  discarded. Use this when you discover required work, not as a backlog
-  dumping ground.
-
-Return a structured summary of what was done. List each file you touched
-(use the same paths you passed to write/edit). Provide a one-line commit
-message in conventional-commit form (e.g. "feat: add CSV export endpoint").
-Leave `clarifications` and `proposed_subtasks` empty when there is nothing
-real to report.
-INSTRUCTIONS;
+        return app(PromptLoader::class)->load('subtask-executor');
     }
 
     public function buildPrompt(): string

--- a/app/Ai/Agents/TasksGenerator.php
+++ b/app/Ai/Agents/TasksGenerator.php
@@ -3,6 +3,7 @@
 namespace App\Ai\Agents;
 
 use App\Models\Story;
+use App\Services\Prompts\PromptLoader;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Provider;
@@ -23,32 +24,7 @@ class TasksGenerator implements Agent, HasStructuredOutput
 
     public function instructions(): string
     {
-        return <<<'INSTRUCTIONS'
-You are the planning agent for Specify, a system where humans approve AI actions
-before they are executed. Your job is to take a Story (the spec) and produce a
-task list: one Task per Acceptance Criterion, each broken down into 1+ ordered
-Subtasks that the executor will run one at a time.
-
-Constraints:
-- Produce exactly one Task per Acceptance Criterion. Reference the criterion by
-  the exact position number shown next to it in the prompt, using
-  `acceptance_criterion_position`. Do not renumber.
-- Each Subtask must be self-contained and small enough for a coding agent to
-  execute in a single run (≤ 30 minutes of focused work).
-- Use Subtask `position` to give a stable in-task ordering (1-based, ascending).
-- Use Task `position` for the overall task ordering (1-based, ascending).
-- Use Task `depends_on` to record blocking dependencies between tasks. A Task
-  may only start once every Task whose position is listed has finished. Subtasks
-  themselves run sequentially within their parent Task — there are no subtask
-  dependencies.
-- Never duplicate work. If two Tasks would touch the same surface in conflicting
-  ways, sequence them via `depends_on`.
-- The summary should be a single paragraph capturing the overall strategy.
-
-Do not include implementation snippets, code, or shell commands in Task or
-Subtask descriptions; describe the change in plain language and leave
-implementation details for the executing coding agent.
-INSTRUCTIONS;
+        return app(PromptLoader::class)->load('tasks-generator');
     }
 
     public function buildPrompt(): string

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,7 +30,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->singleton(PromptLoader::class, fn () => new PromptLoader(base_path('prompts')));
+        // Scoped, not singleton: the loader caches in-memory, but we want
+        // edits to prompts/*.md to be picked up between requests / queue
+        // jobs in long-lived workers (Octane, queue:work) without a
+        // process restart. `scoped` ties the cache lifetime to a single
+        // request/job.
+        $this->app->scoped(PromptLoader::class, fn () => new PromptLoader(base_path('prompts')));
 
         $this->app->singleton(WorkspaceRunner::class, fn () => WorkspaceRunner::fromConfig());
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Services\Executors\CliExecutor;
 use App\Services\Executors\Executor;
 use App\Services\Executors\FakeExecutor;
 use App\Services\Executors\LaravelAiExecutor;
+use App\Services\Prompts\PromptLoader;
 use App\Services\WorkspaceRunner;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
@@ -26,6 +27,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->app->singleton(PromptLoader::class, fn () => new PromptLoader(base_path('prompts')));
+
         $this->app->singleton(WorkspaceRunner::class, fn () => WorkspaceRunner::fromConfig());
 
         $this->app->bind(Executor::class, function ($app) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Services\Context\ContextBuilder;
+use App\Services\Context\NullContextBuilder;
+use App\Services\Context\RecencyContextBuilder;
 use App\Services\Executors\CliExecutor;
 use App\Services\Executors\Executor;
 use App\Services\Executors\FakeExecutor;
@@ -30,6 +33,19 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(PromptLoader::class, fn () => new PromptLoader(base_path('prompts')));
 
         $this->app->singleton(WorkspaceRunner::class, fn () => WorkspaceRunner::fromConfig());
+
+        $this->app->bind(ContextBuilder::class, function () {
+            $driver = config('specify.context.builder', 'recency');
+
+            return match ($driver) {
+                'recency' => new RecencyContextBuilder(
+                    window: (string) config('specify.context.recency.window', '30.days'),
+                    maxFiles: (int) config('specify.context.recency.max_files', 10),
+                ),
+                'null', null, '' => new NullContextBuilder,
+                default => throw new InvalidArgumentException("Unknown context builder [{$driver}]."),
+            };
+        });
 
         $this->app->bind(Executor::class, function ($app) {
             $driver = config('specify.executor.driver', 'laravel-ai');

--- a/app/Services/Context/ContextBuilder.php
+++ b/app/Services/Context/ContextBuilder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Models\Repo;
+use App\Models\Subtask;
+
+/**
+ * Layered, repo-aware context injected into the executor's prompt before each
+ * Subtask runs. Composes on top of the static markdown prompts in `prompts/`
+ * (loaded by PromptLoader) — those describe *how the agent works*; this
+ * describes *what the agent is about to touch*.
+ *
+ * Implementations must be cheap (≤ 1s wall-clock budget) and bounded in
+ * output size; callers prepend the result verbatim into a finite prompt.
+ */
+interface ContextBuilder
+{
+    /**
+     * Produce a per-subtask context brief, or empty string when nothing
+     * useful is available (e.g. no working directory, or builder disabled).
+     */
+    public function build(Subtask $subtask, ?string $workingDir, ?Repo $repo): string;
+}

--- a/app/Services/Context/NullContextBuilder.php
+++ b/app/Services/Context/NullContextBuilder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Models\Repo;
+use App\Models\Subtask;
+
+/**
+ * Returns an empty brief. Bound in tests and as a safe default when
+ * `specify.context.builder = null`.
+ */
+class NullContextBuilder implements ContextBuilder
+{
+    public function build(Subtask $subtask, ?string $workingDir, ?Repo $repo): string
+    {
+        return '';
+    }
+}

--- a/app/Services/Context/RecencyContextBuilder.php
+++ b/app/Services/Context/RecencyContextBuilder.php
@@ -16,11 +16,13 @@ use Throwable;
  *   1. Files the Subtask description mentions by path (verified to exist).
  *   2. Files recently touched in the working directory's git history,
  *      intersected with that mentioned set.
- *   3. Prior `AgentRun`s for this Subtask that ended in Failed or noDiff —
- *      so the executor can learn from its own history.
+ *   3. Prior `AgentRun`s for this Subtask that ended in `Failed` (which
+ *      includes the `noDiff` and `pullRequestFailed` outcomes — see
+ *      `ExecuteSubtaskJob` for the outcome → status mapping). The
+ *      executor can learn from its own history.
  *
  * Output is capped at 4 KB. Failures are non-fatal: a builder should never
- * tank a run, so any exception logs and returns the partial brief.
+ * tank a run, so any exception logs and returns an empty brief.
  */
 class RecencyContextBuilder implements ContextBuilder
 {
@@ -107,7 +109,9 @@ class RecencyContextBuilder implements ContextBuilder
 
     /**
      * For each mentioned file, record the most recent commit subject from
-     * the configured window. Returns at most `maxFiles` entries.
+     * the configured window. Single `git log` invocation across all files
+     * with a strict overall timeout — keeps the builder inside the ≤ 1s
+     * wall-clock budget the interface promises.
      *
      * @param  list<string>  $mentioned
      * @return array<string, string> file path => one-line note
@@ -118,24 +122,46 @@ class RecencyContextBuilder implements ContextBuilder
             return [];
         }
 
+        $files = array_values(array_slice($mentioned, 0, $this->maxFiles));
+        $marker = '__RECENCY_COMMIT__ ';
+
+        $proc = new Process([
+            'git', 'log',
+            '--since='.$this->window,
+            '--pretty=format:'.$marker.'%h %s',
+            '--name-only',
+            '--',
+            ...$files,
+        ], $workingDir);
+        $proc->setTimeout(2);
+
+        try {
+            $proc->run();
+        } catch (Throwable) {
+            return [];
+        }
+
+        $wanted = array_fill_keys($files, true);
         $out = [];
-        foreach ($mentioned as $file) {
-            $proc = new Process([
-                'git', 'log',
-                '--since='.$this->window,
-                '-n', '1',
-                '--pretty=%h %s',
-                '--', $file,
-            ], $workingDir);
-            $proc->setTimeout(5);
-            try {
-                $proc->run();
-            } catch (Throwable) {
+        $currentCommit = null;
+
+        foreach (preg_split('/\R/', (string) $proc->getOutput()) ?: [] as $line) {
+            $line = trim($line);
+            if ($line === '') {
                 continue;
             }
-            $line = trim($proc->getOutput());
-            if ($line !== '') {
-                $out[$file] = $line;
+
+            if (str_starts_with($line, $marker)) {
+                $currentCommit = substr($line, strlen($marker));
+
+                continue;
+            }
+
+            if ($currentCommit !== null && isset($wanted[$line]) && ! isset($out[$line])) {
+                $out[$line] = $currentCommit;
+                if (count($out) >= count($files)) {
+                    break;
+                }
             }
         }
 
@@ -180,10 +206,16 @@ class RecencyContextBuilder implements ContextBuilder
 
     private function clamp(string $value, int $limit): string
     {
+        $suffix = "\n[brief truncated]";
+
         if (strlen($value) <= $limit) {
             return $value;
         }
 
-        return substr($value, 0, $limit)."\n[brief truncated]";
+        if ($limit <= strlen($suffix)) {
+            return substr($suffix, 0, $limit);
+        }
+
+        return substr($value, 0, $limit - strlen($suffix)).$suffix;
     }
 }

--- a/app/Services/Context/RecencyContextBuilder.php
+++ b/app/Services/Context/RecencyContextBuilder.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Models\Repo;
+use App\Models\Subtask;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+/**
+ * Three cheap signals layered into a markdown brief:
+ *
+ *   1. Files the Subtask description mentions by path (verified to exist).
+ *   2. Files recently touched in the working directory's git history,
+ *      intersected with that mentioned set.
+ *   3. Prior `AgentRun`s for this Subtask that ended in Failed or noDiff —
+ *      so the executor can learn from its own history.
+ *
+ * Output is capped at 4 KB. Failures are non-fatal: a builder should never
+ * tank a run, so any exception logs and returns the partial brief.
+ */
+class RecencyContextBuilder implements ContextBuilder
+{
+    public function __construct(
+        public string $window = '30.days',
+        public int $maxFiles = 10,
+    ) {}
+
+    public function build(Subtask $subtask, ?string $workingDir, ?Repo $repo): string
+    {
+        try {
+            $sections = [];
+
+            $mentioned = $this->mentionedFiles($subtask, $workingDir);
+            if ($mentioned !== []) {
+                $sections[] = "## Files the subtask description mentions\n".implode("\n", array_map(
+                    fn ($f) => '- `'.$f.'`',
+                    $mentioned,
+                ));
+            }
+
+            $recent = $this->recentlyTouched($workingDir, $mentioned);
+            if ($recent !== []) {
+                $rendered = [];
+                foreach ($recent as $file => $note) {
+                    $rendered[] = '- `'.$file.'` — '.$note;
+                }
+                $sections[] = "## Recently touched (last {$this->window})\n".implode("\n", $rendered);
+            }
+
+            $priorRuns = $this->priorRunSummaries($subtask);
+            if ($priorRuns !== []) {
+                $sections[] = "## Prior runs on this Subtask that did not complete\n".implode("\n\n", $priorRuns);
+            }
+
+            if ($sections === []) {
+                return '';
+            }
+
+            $brief = "<context-brief>\n\n".implode("\n\n", $sections)."\n\n</context-brief>";
+
+            return $this->clamp($brief, 4_096);
+        } catch (Throwable $e) {
+            Log::warning('specify.context.builder.failed', [
+                'subtask_id' => $subtask->getKey(),
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            return '';
+        }
+    }
+
+    /**
+     * Path-like tokens in the Subtask description that exist on disk.
+     *
+     * @return list<string>
+     */
+    private function mentionedFiles(Subtask $subtask, ?string $workingDir): array
+    {
+        $description = (string) $subtask->description;
+        if ($description === '' || $workingDir === null) {
+            return [];
+        }
+
+        if (! preg_match_all('#\b([A-Za-z0-9_./\\-]+\.[A-Za-z0-9]+)\b#', $description, $matches)) {
+            return [];
+        }
+
+        $candidates = array_unique($matches[1]);
+        $existing = [];
+        foreach ($candidates as $rel) {
+            if (str_contains($rel, '..')) {
+                continue;
+            }
+            $abs = $workingDir.DIRECTORY_SEPARATOR.$rel;
+            if (is_file($abs)) {
+                $existing[] = $rel;
+            }
+        }
+
+        return array_slice($existing, 0, $this->maxFiles);
+    }
+
+    /**
+     * For each mentioned file, record the most recent commit subject from
+     * the configured window. Returns at most `maxFiles` entries.
+     *
+     * @param  list<string>  $mentioned
+     * @return array<string, string> file path => one-line note
+     */
+    private function recentlyTouched(?string $workingDir, array $mentioned): array
+    {
+        if ($workingDir === null || $mentioned === [] || ! is_dir($workingDir.'/.git')) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($mentioned as $file) {
+            $proc = new Process([
+                'git', 'log',
+                '--since='.$this->window,
+                '-n', '1',
+                '--pretty=%h %s',
+                '--', $file,
+            ], $workingDir);
+            $proc->setTimeout(5);
+            try {
+                $proc->run();
+            } catch (Throwable) {
+                continue;
+            }
+            $line = trim($proc->getOutput());
+            if ($line !== '') {
+                $out[$file] = $line;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Summaries from prior AgentRuns on this Subtask that ended in a state
+     * the executor can learn from (Failed). Capped at 3 entries.
+     *
+     * @return list<string>
+     */
+    private function priorRunSummaries(Subtask $subtask): array
+    {
+        $runs = AgentRun::query()
+            ->where('runnable_type', $subtask->getMorphClass())
+            ->where('runnable_id', $subtask->getKey())
+            ->where('status', AgentRunStatus::Failed->value)
+            ->latest('id')
+            ->limit(3)
+            ->get(['id', 'status', 'error_message', 'output']);
+
+        $rendered = [];
+        foreach ($runs as $run) {
+            $error = trim((string) ($run->error_message ?? ''));
+            $summary = '';
+            if (is_array($run->output) && isset($run->output['summary'])) {
+                $summary = trim((string) $run->output['summary']);
+            }
+            $body = $error !== '' ? "Error: {$error}" : '';
+            if ($summary !== '') {
+                $body .= ($body === '' ? '' : "\n").'Summary: '.$summary;
+            }
+            if ($body === '') {
+                continue;
+            }
+            $rendered[] = "Run #{$run->id} — {$run->status->value}\n{$body}";
+        }
+
+        return $rendered;
+    }
+
+    private function clamp(string $value, int $limit): string
+    {
+        if (strlen($value) <= $limit) {
+            return $value;
+        }
+
+        return substr($value, 0, $limit)."\n[brief truncated]";
+    }
+}

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -32,13 +32,16 @@ class CliExecutor implements Executor
      *
      * @throws RuntimeException When `$workingDir` is null or the CLI exits non-zero.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
     {
         if ($workingDir === null) {
             throw new RuntimeException('CliExecutor requires a working directory.');
         }
 
         $prompt = $this->buildPrompt($subtask, $repo, $workingBranch);
+        if ($contextBrief !== null && $contextBrief !== '') {
+            $prompt = $contextBrief."\n\n".$prompt;
+        }
 
         $process = new Process($this->command, $workingDir);
         $process->setTimeout($this->timeout);

--- a/app/Services/Executors/Executor.php
+++ b/app/Services/Executors/Executor.php
@@ -22,6 +22,12 @@ interface Executor
 
     /**
      * Run the executor against a Subtask.
+     *
+     * `$contextBrief`, when non-null, is a markdown block produced by a
+     * `ContextBuilder` describing files the Subtask is likely to touch,
+     * recent activity in the repo, and prior failed runs. Implementations
+     * should prepend it to the user prompt so the model orients faster.
+     * Defaults to null so existing tests and minimal drivers remain valid.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch): ExecutionResult;
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult;
 }

--- a/app/Services/Executors/FakeExecutor.php
+++ b/app/Services/Executors/FakeExecutor.php
@@ -18,7 +18,7 @@ class FakeExecutor implements Executor
         return false;
     }
 
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
     {
         // Pass a real (but throwaway) directory so SubtaskExecutor::tools() can construct
         // a Sandbox during fake/test invocations. The tools are never actually called

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -32,7 +32,7 @@ class LaravelAiExecutor implements Executor
      *                          or when the agent terminates without producing
      *                          summary/files/commit-message fields.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
     {
         $context = [
             'subtask_id' => $subtask->getKey(),
@@ -47,9 +47,13 @@ class LaravelAiExecutor implements Executor
         $start = microtime(true);
 
         $agent = new SubtaskExecutor($subtask, $repo, $workingBranch, $workingDir);
+        $prompt = $agent->buildPrompt();
+        if ($contextBrief !== null && $contextBrief !== '') {
+            $prompt = $contextBrief."\n\n".$prompt;
+        }
 
         try {
-            $response = $agent->prompt($agent->buildPrompt());
+            $response = $agent->prompt($prompt);
         } catch (RequestException $e) {
             $status = $e->response?->status();
             $body = $e->response?->body();

--- a/app/Services/Prompts/PromptLoader.php
+++ b/app/Services/Prompts/PromptLoader.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services\Prompts;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+/**
+ * Loads agent system prompts from `prompts/*.md` at the repo root.
+ *
+ * Lifting prompts into markdown files (instead of static heredocs in PHP
+ * agent classes) lets them participate in code review, be searchable, and
+ * reference ADRs without escape hell. The loader caches each file's contents
+ * within a single PHP request so agents constructed in a tight loop don't
+ * re-read disk.
+ */
+class PromptLoader
+{
+    /** @var array<string, string> */
+    private array $cache = [];
+
+    public function __construct(public string $basePath) {}
+
+    /**
+     * Load a prompt by short name, e.g. `load('subtask-executor')` reads
+     * `prompts/subtask-executor.md`.
+     *
+     * @throws RuntimeException When the file does not exist.
+     */
+    public function load(string $name): string
+    {
+        if (isset($this->cache[$name])) {
+            return $this->cache[$name];
+        }
+
+        $path = $this->basePath.DIRECTORY_SEPARATOR.$name.'.md';
+        if (! File::exists($path)) {
+            throw new RuntimeException("Prompt file not found: {$path}");
+        }
+
+        return $this->cache[$name] = trim(File::get($path));
+    }
+}

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\AgentRun;
 use App\Models\Repo;
 use App\Models\Subtask;
+use App\Services\Context\ContextBuilder;
 use App\Services\Executors\Executor;
 use App\Services\Executors\ProposedSubtask;
 use App\Services\PullRequests\PrPayloadBuilder;
@@ -28,6 +29,7 @@ class SubtaskRunPipeline
         public Executor $executor,
         public WorkspaceRunner $workspace,
         public PlanWriter $planWriter,
+        public ContextBuilder $contextBuilder,
     ) {}
 
     /**
@@ -65,8 +67,18 @@ class SubtaskRunPipeline
             Log::info('specify.subtask.workspace.ready', $logCtx + ['working_dir' => $workingDir]);
         }
 
-        $result = $this->executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch);
+        $contextBrief = $this->contextBuilder->build($subtask, $workingDir, $repo);
+        if ($contextBrief !== '') {
+            Log::info('specify.subtask.context_brief.built', $logCtx + [
+                'bytes' => strlen($contextBrief),
+            ]);
+        }
+
+        $result = $this->executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null);
         $output = $result->toArray();
+        if ($contextBrief !== '') {
+            $output['context_brief'] = $contextBrief;
+        }
 
         if ($workingDir === null) {
             $diff = $result->filesChanged === [] ? null : implode("\n", $result->filesChanged);

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -72,6 +72,13 @@ class SubtaskRunPipeline
             Log::info('specify.subtask.context_brief.built', $logCtx + [
                 'bytes' => strlen($contextBrief),
             ]);
+            // Persist the brief on the AgentRun row immediately so it
+            // survives failure paths — `markFailed` does not touch
+            // `output`, so noDiff / pullRequestFailed runs would otherwise
+            // lose the brief that the agent saw.
+            $agentRun->forceFill([
+                'output' => array_merge((array) $agentRun->output, ['context_brief' => $contextBrief]),
+            ])->save();
         }
 
         $result = $this->executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null);

--- a/config/specify.php
+++ b/config/specify.php
@@ -81,4 +81,24 @@ return [
             'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Context builder
+    |--------------------------------------------------------------------------
+    |
+    | Per-subtask context brief prepended to the executor prompt. "recency"
+    | (default) emits a small markdown block with files mentioned in the
+    | Subtask description, recent commits touching them, and prior failed
+    | runs on the same Subtask. "null" disables the brief entirely.
+    |
+    */
+
+    'context' => [
+        'builder' => env('SPECIFY_CONTEXT_BUILDER', 'recency'),
+        'recency' => [
+            'window' => env('SPECIFY_CONTEXT_WINDOW', '30.days'),
+            'max_files' => (int) env('SPECIFY_CONTEXT_MAX_FILES', 10),
+        ],
+    ],
 ];

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,20 @@
+# Prompts
+
+Agent system-prompts that ship with Specify. Lifted out of `app/Ai/Agents/*.php`
+so they participate in code review, are searchable, and can reference ADRs by
+name.
+
+| File | Loaded by | Purpose |
+|------|-----------|---------|
+| `subtask-executor.md` | `App\Ai\Agents\SubtaskExecutor::instructions()` | System prompt for the per-Subtask execution agent. |
+| `tasks-generator.md`  | `App\Ai\Agents\TasksGenerator::instructions()`  | System prompt for the planning agent that drafts a task list from a Story. |
+
+Both are loaded via `App\Services\Prompts\PromptLoader`, which caches contents
+within a single PHP request. Edit the markdown directly — there is no build
+step, and changes ship the next time the agent is constructed.
+
+Per-subtask, repo-aware context (recent commits, prior runs, files relevant to
+the Subtask description) is layered on top of these prompts at runtime by
+`App\Services\Context\ContextBuilder`. Keep this directory for the
+*invariant* part of each agent's instructions; do not encode per-run state
+here.

--- a/prompts/subtask-executor.md
+++ b/prompts/subtask-executor.md
@@ -1,0 +1,55 @@
+You are the execution agent for Specify. A human has approved a Story and its
+task list; your job is to execute one Subtask against the working copy of the
+repository that has already been checked out for you on the working branch.
+
+You have these tools — use them to inspect and modify the working tree:
+
+- ReadFile(path, offset?, limit?)
+- WriteFile(path, content)
+- EditFile(path, edits[]) — each edit has `old_string`, `new_string`, optional `replace_all`
+- Bash(command, timeout?) — runs in the working directory
+- Grep(pattern, path?, glob?, ignore_case?, literal?, context?, limit?)
+- Find(pattern, path?, limit?)
+- Ls(path?, limit?)
+
+You MUST use these tools to do the work. Reading a file with ReadFile and
+then writing a modified version is the basic pattern; for surgical changes
+prefer EditFile. Do not just describe what should happen — actually run the
+tools. When you are satisfied that the working tree contains the changes
+the Subtask requires, call output_structured_data with your summary.
+
+Workflow:
+1. Use Ls, Find, Grep, ReadFile to orient yourself in the repo.
+2. Use EditFile for surgical changes, WriteFile for whole-file replacements.
+3. Use Bash to run tests, formatters, or build steps. Do not commit, push,
+   open PRs, or switch branches — those are handled by the orchestrator.
+4. When the Subtask is satisfied, return your structured summary.
+
+Constraints:
+- Make only the changes the Subtask requires. Do not refactor unrelated code.
+- Paths in tool calls are relative to the working directory (the repo root).
+
+You are a collaborator, not a worker. Two voice channels are available in the
+structured output and you should use them deliberately:
+
+- `clarifications` — if the Subtask is ambiguous, conflicts with another part
+  of the Story, you found missing context, or you would have chosen
+  differently than what was specified, **execute the smallest reasonable
+  interpretation AND record a clarification**. Each clarification has a
+  `kind` (one of `ambiguity`, `conflict`, `missing-context`, `disagreement`),
+  a `message`, and an optional `proposed` describing what you think should
+  change. The human reviewer sees these alongside the diff. Do not invent
+  clarifications to look thoughtful — only record real signal.
+- `proposed_subtasks` — if completing this Subtask reveals additional work
+  needed to finish the parent Task (not the whole Story; just the Task),
+  propose follow-up Subtasks. Each entry has `name`, `description`, and
+  `reason`. They are appended to the parent Task and execute after this
+  Subtask succeeds (ADR-0005). Cap: at most three proposed Subtasks per run;
+  surplus is discarded. Use this when you discover required work, not as a
+  backlog dumping ground.
+
+Return a structured summary of what was done. List each file you touched
+(use the same paths you passed to write/edit). Provide a one-line commit
+message in conventional-commit form (e.g. "feat: add CSV export endpoint").
+Leave `clarifications` and `proposed_subtasks` empty when there is nothing
+real to report.

--- a/prompts/tasks-generator.md
+++ b/prompts/tasks-generator.md
@@ -1,0 +1,24 @@
+You are the planning agent for Specify, a system where humans approve AI actions
+before they are executed. Your job is to take a Story (the spec) and produce a
+task list: one Task per Acceptance Criterion, each broken down into 1+ ordered
+Subtasks that the executor will run one at a time.
+
+Constraints:
+- Produce exactly one Task per Acceptance Criterion. Reference the criterion by
+  the exact position number shown next to it in the prompt, using
+  `acceptance_criterion_position`. Do not renumber.
+- Each Subtask must be self-contained and small enough for a coding agent to
+  execute in a single run (≤ 30 minutes of focused work).
+- Use Subtask `position` to give a stable in-task ordering (1-based, ascending).
+- Use Task `position` for the overall task ordering (1-based, ascending).
+- Use Task `depends_on` to record blocking dependencies between tasks. A Task
+  may only start once every Task whose position is listed has finished. Subtasks
+  themselves run sequentially within their parent Task — there are no subtask
+  dependencies.
+- Never duplicate work. If two Tasks would touch the same surface in conflicting
+  ways, sequence them via `depends_on`.
+- The summary should be a single paragraph capturing the overall strategy.
+
+Do not include implementation snippets, code, or shell commands in Task or
+Subtask descriptions; describe the change in plain language and leave
+implementation details for the executing coding agent.

--- a/tests/Feature/ContextBuilderTest.php
+++ b/tests/Feature/ContextBuilderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use App\Services\Context\NullContextBuilder;
+use App\Services\Context\RecencyContextBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+
+uses(RefreshDatabase::class);
+
+function makeGitWorkdir(): string
+{
+    $dir = sys_get_temp_dir().'/specify-ctx-'.uniqid();
+    File::ensureDirectoryExists($dir);
+    new Process(['git', '-c', 'init.defaultBranch=main', 'init'], $dir)->mustRun();
+    new Process(['git', 'config', 'user.email', 't@t'], $dir)->mustRun();
+    new Process(['git', 'config', 'user.name', 't'], $dir)->mustRun();
+
+    return $dir;
+}
+
+afterEach(function () {
+    foreach (glob(sys_get_temp_dir().'/specify-ctx-*') as $path) {
+        is_dir($path) && File::deleteDirectory($path);
+    }
+});
+
+test('NullContextBuilder always returns empty', function () {
+    $subtask = Subtask::factory()->create();
+
+    expect((new NullContextBuilder)->build($subtask, sys_get_temp_dir(), null))->toBe('');
+});
+
+test('RecencyContextBuilder returns empty when there is no working dir', function () {
+    $subtask = Subtask::factory()->create(['description' => 'edit app/Foo.php']);
+
+    expect((new RecencyContextBuilder)->build($subtask, null, null))->toBe('');
+});
+
+test('RecencyContextBuilder picks up files mentioned in the description that exist on disk', function () {
+    $dir = makeGitWorkdir();
+    File::ensureDirectoryExists($dir.'/app');
+    File::put($dir.'/app/Exporter.php', "<?php\nclass Exporter {}\n");
+    new Process(['git', 'add', 'app/Exporter.php'], $dir)->mustRun();
+    new Process(['git', 'commit', '-m', 'feat: add Exporter'], $dir)->mustRun();
+
+    $subtask = Subtask::factory()->create([
+        'description' => 'Update app/Exporter.php to support CSV. Also touch nonexistent.txt.',
+    ]);
+
+    $brief = (new RecencyContextBuilder)->build($subtask, $dir, null);
+
+    expect($brief)
+        ->toContain('<context-brief>')
+        ->toContain('## Files the subtask description mentions')
+        ->toContain('`app/Exporter.php`')
+        ->not->toContain('`nonexistent.txt`')
+        ->toContain('## Recently touched')
+        ->toContain('feat: add Exporter');
+});
+
+test('RecencyContextBuilder surfaces prior failed runs on the same Subtask', function () {
+    $subtask = Subtask::factory()->create(['description' => 'no files mentioned here']);
+    AgentRun::create([
+        'runnable_type' => $subtask->getMorphClass(),
+        'runnable_id' => $subtask->getKey(),
+        'status' => AgentRunStatus::Failed,
+        'error_message' => 'compiler exploded',
+        'output' => ['summary' => 'I tried writing a file and got rejected'],
+    ]);
+
+    $brief = (new RecencyContextBuilder)->build($subtask, null, null);
+
+    expect($brief)
+        ->toContain('## Prior runs on this Subtask that did not complete')
+        ->toContain('compiler exploded')
+        ->toContain('I tried writing a file and got rejected');
+});
+
+test('RecencyContextBuilder is a no-op when there is nothing useful to say', function () {
+    $subtask = Subtask::factory()->create(['description' => 'pure prose with no path-like tokens']);
+
+    expect((new RecencyContextBuilder)->build($subtask, null, null))->toBe('');
+});
+
+test('RecencyContextBuilder ignores path traversal attempts in the description', function () {
+    $dir = makeGitWorkdir();
+
+    $subtask = Subtask::factory()->create([
+        'description' => 'malicious mention of ../../etc/passwd should not be surfaced.',
+    ]);
+
+    $brief = (new RecencyContextBuilder)->build($subtask, $dir, null);
+
+    expect($brief)->not->toContain('../etc/passwd');
+});

--- a/tests/Feature/PromptLoaderTest.php
+++ b/tests/Feature/PromptLoaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Ai\Agents\SubtaskExecutor;
+use App\Ai\Agents\TasksGenerator;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Services\Prompts\PromptLoader;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+
+uses(RefreshDatabase::class);
+
+test('PromptLoader reads a markdown file by short name and trims it', function () {
+    $tmp = sys_get_temp_dir().'/specify-prompts-'.uniqid();
+    File::ensureDirectoryExists($tmp);
+    File::put($tmp.'/hello.md', "\n  hi from disk  \n\n");
+
+    $loader = new PromptLoader($tmp);
+
+    expect($loader->load('hello'))->toBe('hi from disk');
+
+    File::deleteDirectory($tmp);
+});
+
+test('PromptLoader caches subsequent loads of the same name', function () {
+    $tmp = sys_get_temp_dir().'/specify-prompts-'.uniqid();
+    File::ensureDirectoryExists($tmp);
+    File::put($tmp.'/x.md', 'first');
+
+    $loader = new PromptLoader($tmp);
+    expect($loader->load('x'))->toBe('first');
+
+    // Mutate the file on disk; the cached value should win.
+    File::put($tmp.'/x.md', 'second');
+    expect($loader->load('x'))->toBe('first');
+
+    File::deleteDirectory($tmp);
+});
+
+test('PromptLoader throws when the file is missing', function () {
+    $loader = new PromptLoader(sys_get_temp_dir().'/does-not-exist-'.uniqid());
+
+    expect(fn () => $loader->load('nope'))->toThrow(RuntimeException::class, 'Prompt file not found');
+});
+
+test('SubtaskExecutor::instructions() pulls from the prompts/subtask-executor.md file', function () {
+    $subtask = Subtask::factory()->create();
+    $instructions = (new SubtaskExecutor($subtask))->instructions();
+
+    expect($instructions)
+        ->toContain('You are the execution agent for Specify.')
+        ->toContain('clarifications')
+        ->toContain('proposed_subtasks');
+});
+
+test('TasksGenerator::instructions() pulls from the prompts/tasks-generator.md file', function () {
+    $story = Story::factory()->create();
+    $instructions = (new TasksGenerator($story))->instructions();
+
+    expect($instructions)
+        ->toContain('You are the planning agent for Specify')
+        ->toContain('one Task per Acceptance Criterion');
+});

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -9,6 +9,7 @@ use App\Models\Repo;
 use App\Models\Story;
 use App\Models\Subtask;
 use App\Models\Task;
+use App\Services\Context\NullContextBuilder;
 use App\Services\Executors\ExecutionResult;
 use App\Services\Executors\Executor;
 use App\Services\Executors\ExecutorClarification;
@@ -151,7 +152,7 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
             return true;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch): ExecutionResult
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'I tried but produced no diff',
@@ -186,7 +187,7 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
         }
     };
 
-    $pipeline = new SubtaskRunPipeline($executor, $workspace, app(PlanWriter::class));
+    $pipeline = new SubtaskRunPipeline($executor, $workspace, app(PlanWriter::class), new NullContextBuilder);
 
     $beforeCount = $task->subtasks()->count();
     $outcome = $pipeline->run($run);

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -9,6 +9,7 @@ use App\Models\Repo;
 use App\Models\Story;
 use App\Models\Subtask;
 use App\Models\Task;
+use App\Services\Context\ContextBuilder;
 use App\Services\Context\NullContextBuilder;
 use App\Services\Executors\ExecutionResult;
 use App\Services\Executors\Executor;
@@ -195,6 +196,74 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
 
     expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_NO_DIFF)
         ->and($afterCount)->toBe($beforeCount);
+});
+
+test('context_brief is persisted on AgentRun.output even when the run ends in noDiff', function () {
+    $task = makeApprovedTask();
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'main', 'position' => 1]);
+    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->getKey(),
+        'repo_id' => $repo->getKey(),
+        'working_branch' => 'specify/test',
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $executor = new class implements Executor
+    {
+        public function needsWorkingDirectory(): bool
+        {
+            return true;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        {
+            return new ExecutionResult(summary: '', filesChanged: [], commitMessage: 'noop');
+        }
+    };
+
+    $workspace = new class extends WorkspaceRunner
+    {
+        public function __construct() {}
+
+        public function prepare(Repo $repo, AgentRun $run): string
+        {
+            return sys_get_temp_dir();
+        }
+
+        public function checkoutBranch(string $workingDir, string $branch, ?string $baseBranch = null): void {}
+
+        public function commit(string $workingDir, string $message): ?string
+        {
+            return null;
+        }
+
+        public function diff(string $workingDir, ?string $base = null): string
+        {
+            return '';
+        }
+    };
+
+    $contextBuilder = new class implements ContextBuilder
+    {
+        public function build(Subtask $subtask, ?string $workingDir, ?Repo $repo): string
+        {
+            return "<context-brief>\n\nSEEN BY AGENT\n\n</context-brief>";
+        }
+    };
+
+    $pipeline = new SubtaskRunPipeline($executor, $workspace, app(PlanWriter::class), $contextBuilder);
+    $outcome = $pipeline->run($run);
+
+    expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_NO_DIFF);
+
+    // Even though the pipeline returns noDiff (which the job will mark
+    // Failed without persisting outcome.output), the brief must already be
+    // on the AgentRun row from the early save so debugging is possible.
+    $persisted = $run->fresh()->output;
+    expect($persisted)->toBeArray()
+        ->and($persisted['context_brief'] ?? null)->toContain('SEEN BY AGENT');
 });
 
 test('PR body renders clarifications with their proposed alternative when present', function () {


### PR DESCRIPTION
## Summary

Two related moves from the AI strategy audit, both Bucket-3:

1. **Recommendation #2 — agent prompts as living documents.** Lift `SubtaskExecutor::instructions()` and `TasksGenerator::instructions()` out of static heredocs into `prompts/*.md`, loaded by a small `PromptLoader`. Now the prompts participate in code review, are searchable, and can reference ADRs without escape hell.
2. **Proposal 0003 — per-subtask context brief.** A `ContextBuilder` callable runs before every Subtask execution and prepends a markdown brief to the executor prompt with three cheap signals: files mentioned in the Subtask description that exist on disk, recent commits touching them, and prior failed runs on the same Subtask. Composes naturally on top of the markdown prompts in #1.

## What's new

- `prompts/{subtask-executor,tasks-generator,README}.md` — invariant agent instructions live in markdown now.
- `App\Services\Prompts\PromptLoader` — reads from `prompts/`, caches per request.
- `App\Services\Context\ContextBuilder` interface, plus `RecencyContextBuilder` (default) and `NullContextBuilder` (test default).
- `Executor::execute()` gains an optional `?string $contextBrief = null` parameter — additive; existing implementations and CLI executors prepend it to their prompt; `FakeExecutor` ignores.
- `SubtaskRunPipeline` calls the builder between workdir checkout and execute, persists the brief on `AgentRun.output.context_brief`.
- Config: `SPECIFY_CONTEXT_BUILDER=recency|null`, `SPECIFY_CONTEXT_WINDOW=30.days`, `SPECIFY_CONTEXT_MAX_FILES=10`.
- AGENTS.md "Where to start" gains rows for editing prompts and tuning the context builder.

## Test plan

- [x] `composer test` — Pint clean, 236 Pest tests, 556 assertions (+11 new). Was 225.
  - 5 new `PromptLoader` tests (read/trim, cache, missing-file, both agents pulling from disk).
  - 6 new `ContextBuilder` tests (NullBuilder always empty, RecencyBuilder no-workdir, mentioned files + recent commits, prior failed runs, no-op when nothing useful, path-traversal hygiene).
- [ ] Manual: run a real Subtask end-to-end and confirm `AgentRun.output.context_brief` is populated and the agent prompt actually contains the `<context-brief>` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)