### PR TITLE
Multi-executor race mode (ADR-0006, proposal 0001)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Specify is a Laravel 13 system where humans approve AI actions on code repos. **
 | Touch the approval state machine | [ADR-0001](docs/adr/0001-story-as-the-only-approval-gate.md), `app/Services/ApprovalService.php` |
 | Edit Story / Task / Subtask | [ADR-0002](docs/adr/0002-story-task-subtask-hierarchy.md) |
 | Add or change an Executor | [ADR-0003](docs/adr/0003-pluggable-executor-interface.md), `app/Services/Executors/` |
+| Race executors against each other | [ADR-0006](docs/adr/0006-multi-executor-race-mode.md), `config/specify.php` (`executor.race`), `App\Services\Executors\ExecutorFactory` |
 | Touch PR creation | [ADR-0004](docs/adr/0004-pr-after-push-is-non-fatal.md), `app/Services/PullRequests/` |
 | Touch advisory PR review | `app/Services/Reviews/` (`ReviewProvider`, `GithubReviewProvider`), `app/Jobs/ReviewPullRequestJob.php` — gated on `SPECIFY_REVIEW_ENABLED`, never blocks merge |
 | Add an MCP tool | `app/Mcp/Tools/` (follow the existing `#[Description]` + `handle()` shape) |

--- a/app/Jobs/ExecuteSubtaskJob.php
+++ b/app/Jobs/ExecuteSubtaskJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Models\AgentRun;
 use App\Models\Subtask;
 use App\Services\ExecutionService;
+use App\Services\Executors\ExecutorFactory;
 use App\Services\SubtaskRunOutcome;
 use App\Services\SubtaskRunPipeline;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -15,10 +16,14 @@ use Throwable;
 /**
  * Queue job that runs a single Subtask AgentRun via `SubtaskRunPipeline`.
  *
- * Owns only queue-lifecycle concerns: load the AgentRun, mark Running, hand
- * off to the pipeline, then translate the outcome into a markSucceeded /
- * markFailed call. Exceptions from the pipeline mark Failed and rethrow so
- * the queue can decide whether to retry.
+ * Owns only queue-lifecycle concerns: load the AgentRun, mark Running, resolve
+ * the executor named on the run via `ExecutorFactory`, hand off to the
+ * pipeline, then translate the outcome into a markSucceeded / markFailed
+ * call. Exceptions from the pipeline mark Failed and rethrow so the queue
+ * can decide whether to retry.
+ *
+ * The executor is resolved per-run from `AgentRun.executor_driver` so race-
+ * mode siblings each run on the driver they were dispatched with.
  */
 class ExecuteSubtaskJob implements ShouldQueue
 {
@@ -27,7 +32,7 @@ class ExecuteSubtaskJob implements ShouldQueue
     public function __construct(public int $agentRunId) {}
 
     /** Queue handler — see class docblock. */
-    public function handle(ExecutionService $execution, SubtaskRunPipeline $pipeline): void
+    public function handle(ExecutionService $execution, SubtaskRunPipeline $pipeline, ExecutorFactory $executors): void
     {
         $run = AgentRun::findOrFail($this->agentRunId);
 
@@ -39,12 +44,16 @@ class ExecuteSubtaskJob implements ShouldQueue
 
         $execution->markRunning($run);
 
+        $driver = $run->executor_driver ?? $executors->defaultDriver();
+
         try {
-            $outcome = $pipeline->run($run);
+            $executor = $executors->make($driver);
+            $outcome = $pipeline->run($run, $executor);
         } catch (Throwable $e) {
             Log::error('specify.subtask.run.failed', [
                 'run_id' => $run->getKey(),
                 'subtask_id' => $run->runnable->getKey(),
+                'executor_driver' => $driver,
                 'exception' => $e::class,
                 'message' => $e->getMessage(),
             ]);

--- a/app/Jobs/ExecuteSubtaskJob.php
+++ b/app/Jobs/ExecuteSubtaskJob.php
@@ -63,12 +63,12 @@ class ExecuteSubtaskJob implements ShouldQueue
         }
 
         match ($outcome->state) {
-            SubtaskRunOutcome::STATE_SUCCEEDED => $execution->markSucceeded($run, $outcome->output, $outcome->diff),
-            SubtaskRunOutcome::STATE_NO_DIFF,
-            SubtaskRunOutcome::STATE_PULL_REQUEST_FAILED => $execution->markFailed($run, $outcome->error ?? 'Subtask run failed.'),
+            SubtaskRunOutcome::STATE_SUCCEEDED,
+            SubtaskRunOutcome::STATE_PULL_REQUEST_FAILED => $execution->markSucceeded($run, $outcome->output, $outcome->diff),
+            SubtaskRunOutcome::STATE_NO_DIFF => $execution->markFailed($run, $outcome->error ?? 'Subtask run failed.'),
         };
 
-        if ($outcome->state === SubtaskRunOutcome::STATE_SUCCEEDED) {
+        if ($outcome->isSucceeded()) {
             $this->dispatchAdvisoryReview($run->fresh());
         }
     }

--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -21,7 +21,7 @@ use RuntimeException;
  */
 #[Fillable([
     'runnable_type', 'runnable_id',
-    'repo_id', 'working_branch',
+    'repo_id', 'working_branch', 'executor_driver',
     'authorizing_approval_type', 'authorizing_approval_id',
     'status', 'agent_name', 'model_id',
     'input', 'output', 'diff', 'error_message',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,10 +5,8 @@ namespace App\Providers;
 use App\Services\Context\ContextBuilder;
 use App\Services\Context\NullContextBuilder;
 use App\Services\Context\RecencyContextBuilder;
-use App\Services\Executors\CliExecutor;
 use App\Services\Executors\Executor;
-use App\Services\Executors\FakeExecutor;
-use App\Services\Executors\LaravelAiExecutor;
+use App\Services\Executors\ExecutorFactory;
 use App\Services\Prompts\PromptLoader;
 use App\Services\WorkspaceRunner;
 use Carbon\CarbonImmutable;
@@ -52,19 +50,14 @@ class AppServiceProvider extends ServiceProvider
             };
         });
 
-        $this->app->bind(Executor::class, function ($app) {
-            $driver = config('specify.executor.driver', 'laravel-ai');
+        $this->app->singleton(ExecutorFactory::class, fn ($app) => new ExecutorFactory($app));
 
-            return match ($driver) {
-                'laravel-ai' => new LaravelAiExecutor,
-                'cli' => new CliExecutor(
-                    command: (array) config('specify.executor.cli.command'),
-                    timeout: (int) config('specify.executor.cli.timeout', 1800),
-                ),
-                'fake' => new FakeExecutor,
-                default => throw new InvalidArgumentException("Unknown executor driver [{$driver}]."),
-            };
-        });
+        $this->app->bind(
+            Executor::class,
+            fn ($app) => $app->make(ExecutorFactory::class)->make(
+                $app->make(ExecutorFactory::class)->defaultDriver(),
+            ),
+        );
     }
 
     /**

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -13,6 +13,7 @@ use App\Models\Story;
 use App\Models\StoryApproval;
 use App\Models\Subtask;
 use App\Models\Task;
+use App\Services\Executors\ExecutorFactory;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use RuntimeException;
@@ -24,9 +25,17 @@ use RuntimeException;
  * matching job, and (on completion via `markSucceeded`) advances the cascade
  * down through Subtask → Task → Story status. This class is the only place
  * AgentRun rows should be created.
+ *
+ * When `executor.race` is non-empty the dispatcher fans out to N siblings —
+ * one AgentRun per race driver, each on its own branch. The cascade waits
+ * until every sibling has terminated before deciding the Subtask's status:
+ * Done if any sibling Succeeded, Blocked otherwise. The reviewer picks the
+ * winning PR by merging it; the merge state lives on the PR, not the run.
  */
 class ExecutionService
 {
+    public function __construct(public ExecutorFactory $executors) {}
+
     /**
      * Queue a `GenerateTasksJob` for the given Story and return the AgentRun row.
      */
@@ -48,18 +57,43 @@ class ExecutionService
     /**
      * Queue an `ExecuteSubtaskJob` for the given Subtask.
      *
-     * Resolves the target Repo from the project's primary repo when not supplied,
-     * and pre-computes the working branch name (`specify/{feature-slug}/{story-slug}`).
+     * Single-driver mode (race=[]) creates one AgentRun on
+     * `specify/{feature-slug}/{story-slug}` and returns it.
+     *
+     * Race mode (`executor.race` non-empty) creates *N* AgentRun siblings on
+     * `specify/{feature}/{story}-by-{driver}`, dispatches each, and returns
+     * the *first* sibling so the signature stays stable for single-driver
+     * callers. Callers that need the full set must query
+     * `agent_runs WHERE runnable_id = ?` after dispatch — the cascade gate
+     * (`finalizeSubtaskFromRun`) is the authoritative observer of all
+     * siblings, not this return value.
      */
     public function dispatchSubtaskExecution(Subtask $subtask, ?StoryApproval $approval = null, ?Repo $repo = null): AgentRun
     {
         $repo ??= $subtask->task?->story?->feature?->project?->primaryRepo();
 
+        $race = $this->executors->raceDrivers();
+        if ($race === []) {
+            return $this->createAndDispatchRun($subtask, $approval, $repo, $this->executors->defaultDriver(), null);
+        }
+
+        $first = null;
+        foreach ($race as $driver) {
+            $run = $this->createAndDispatchRun($subtask, $approval, $repo, $driver, $driver);
+            $first ??= $run;
+        }
+
+        return $first;
+    }
+
+    private function createAndDispatchRun(Subtask $subtask, ?StoryApproval $approval, ?Repo $repo, string $driver, ?string $branchSuffix): AgentRun
+    {
         $run = AgentRun::create([
             'runnable_type' => $subtask->getMorphClass(),
             'runnable_id' => $subtask->getKey(),
             'repo_id' => $repo?->getKey(),
-            'working_branch' => $this->workingBranchFor($subtask),
+            'working_branch' => $this->workingBranchFor($subtask, $branchSuffix),
+            'executor_driver' => $driver,
             'authorizing_approval_type' => $approval?->getMorphClass(),
             'authorizing_approval_id' => $approval?->getKey(),
             'status' => AgentRunStatus::Queued,
@@ -70,15 +104,20 @@ class ExecutionService
         return $run;
     }
 
-    private function workingBranchFor(Subtask $subtask): string
+    private function workingBranchFor(Subtask $subtask, ?string $driverSuffix): string
     {
         $story = $subtask->task?->story;
         $feature = $story?->feature;
 
         $featureSlug = $feature?->slug ?? 'feature-'.($feature?->getKey() ?? 'orphan');
         $storySlug = $story?->slug ?? 'story-'.($story?->getKey() ?? 'orphan');
+        $branch = "specify/{$featureSlug}/{$storySlug}";
 
-        return "specify/{$featureSlug}/{$storySlug}";
+        if ($driverSuffix !== null && $driverSuffix !== '') {
+            $branch .= '-by-'.$driverSuffix;
+        }
+
+        return $branch;
     }
 
     /**
@@ -146,11 +185,8 @@ class ExecutionService
     }
 
     /**
-     * Mark an AgentRun Succeeded, persist its output and diff, and cascade.
-     *
-     * For Subtask runs, marks the Subtask Done and dispatches the next
-     * actionable work via `advanceFromSubtask()` — completing all subtasks
-     * of a Task marks the Task Done; completing all Tasks marks the Story Done.
+     * Persist a successful AgentRun and let `finalizeSubtaskFromRun` decide
+     * whether the cascade fires now or waits for racing siblings.
      */
     public function markSucceeded(AgentRun $run, ?array $output = null, ?string $diff = null): void
     {
@@ -162,15 +198,15 @@ class ExecutionService
         ])->save();
 
         if ($run->runnable_type === Subtask::class) {
-            $subtask = Subtask::find($run->runnable_id);
-            if ($subtask) {
-                $subtask->forceFill(['status' => TaskStatus::Done->value])->save();
-                $this->advanceFromSubtask($subtask->fresh(), $run->authorizingApproval);
-            }
+            $this->finalizeSubtaskFromRun($run);
         }
     }
 
-    /** Mark an AgentRun Failed and move its Subtask (if any) to Blocked. */
+    /**
+     * Persist a failed AgentRun. Subtask status is *not* flipped to Blocked
+     * here — `finalizeSubtaskFromRun` decides Done vs Blocked once every
+     * racing sibling has terminated.
+     */
     public function markFailed(AgentRun $run, string $error): void
     {
         $run->forceFill([
@@ -180,12 +216,11 @@ class ExecutionService
         ])->save();
 
         if ($run->runnable_type === Subtask::class) {
-            $subtask = Subtask::find($run->runnable_id);
-            $subtask?->forceFill(['status' => TaskStatus::Blocked->value])->save();
+            $this->finalizeSubtaskFromRun($run);
         }
     }
 
-    /** Mark an AgentRun Aborted (manual cancel) without cascading. */
+    /** Mark an AgentRun Aborted (manual cancel). Aborted siblings count as losers. */
     public function markAborted(AgentRun $run, ?string $reason = null): void
     {
         $run->forceFill([
@@ -193,6 +228,61 @@ class ExecutionService
             'error_message' => $reason,
             'finished_at' => now(),
         ])->save();
+
+        if ($run->runnable_type === Subtask::class) {
+            $this->finalizeSubtaskFromRun($run);
+        }
+    }
+
+    /**
+     * Cascade gate. Called whenever a Subtask AgentRun reaches a terminal
+     * state. Defers if any sibling on the same Subtask is still Queued or
+     * Running. Once all siblings have terminated:
+     *
+     *   - any Succeeded   → Subtask Done, advance the cascade
+     *   - none Succeeded  → Subtask Blocked, no cascade
+     *
+     * Concurrency: not transactionally locked. Two terminal callbacks
+     * arriving simultaneously on the last two siblings *can* both pass the
+     * "no still-open" check — that's intentional. The race is safe because
+     * (a) `forceFill(['status' => Done])` is idempotent under repeat writes
+     * to the same value, and (b) `advanceFromSubtask` re-queries
+     * `Queued|Running` siblings on the next Subtask before dispatching, so
+     * a double cascade cannot double-dispatch downstream work. If the
+     * downstream guard ever changes, this method must move to a row-locked
+     * transaction.
+     */
+    private function finalizeSubtaskFromRun(AgentRun $run): void
+    {
+        $subtask = Subtask::find($run->runnable_id);
+        if (! $subtask) {
+            return;
+        }
+
+        $siblings = AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->where('runnable_id', $subtask->getKey())
+            ->get();
+
+        $stillOpen = $siblings->contains(fn (AgentRun $r) => in_array(
+            $r->status,
+            [AgentRunStatus::Queued, AgentRunStatus::Running],
+            true,
+        ));
+        if ($stillOpen) {
+            return;
+        }
+
+        $anySucceeded = $siblings->contains(fn (AgentRun $r) => $r->status === AgentRunStatus::Succeeded);
+
+        if ($anySucceeded) {
+            $subtask->forceFill(['status' => TaskStatus::Done->value])->save();
+            $this->advanceFromSubtask($subtask->fresh(), $run->authorizingApproval);
+
+            return;
+        }
+
+        $subtask->forceFill(['status' => TaskStatus::Blocked->value])->save();
     }
 
     private function advanceFromSubtask(?Subtask $subtask, $authorizingApproval): void

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -242,47 +242,48 @@ class ExecutionService
      *   - any Succeeded   → Subtask Done, advance the cascade
      *   - none Succeeded  → Subtask Blocked, no cascade
      *
-     * Concurrency: not transactionally locked. Two terminal callbacks
-     * arriving simultaneously on the last two siblings *can* both pass the
-     * "no still-open" check — that's intentional. The race is safe because
-     * (a) `forceFill(['status' => Done])` is idempotent under repeat writes
-     * to the same value, and (b) `advanceFromSubtask` re-queries
-     * `Queued|Running` siblings on the next Subtask before dispatching, so
-     * a double cascade cannot double-dispatch downstream work. If the
-     * downstream guard ever changes, this method must move to a row-locked
-     * transaction.
+     * Concurrency: serialised on the parent Subtask row via
+     * `lockForUpdate` inside a transaction. Without the lock, two terminal
+     * callbacks arriving simultaneously on the last two siblings could both
+     * pass the "no still-open" check, both call `advanceFromSubtask`, and
+     * both dispatch the *next* Subtask before either AgentRun was committed
+     * — duplicating downstream runs. The lock makes the cascade decision
+     * (read siblings → write Subtask status → dispatch next) atomic per
+     * Subtask.
      */
     private function finalizeSubtaskFromRun(AgentRun $run): void
     {
-        $subtask = Subtask::find($run->runnable_id);
-        if (! $subtask) {
-            return;
-        }
+        DB::transaction(function () use ($run) {
+            $subtask = Subtask::query()->whereKey($run->runnable_id)->lockForUpdate()->first();
+            if (! $subtask) {
+                return;
+            }
 
-        $siblings = AgentRun::query()
-            ->where('runnable_type', Subtask::class)
-            ->where('runnable_id', $subtask->getKey())
-            ->get();
+            $siblings = AgentRun::query()
+                ->where('runnable_type', $run->runnable_type)
+                ->where('runnable_id', $subtask->getKey())
+                ->get();
 
-        $stillOpen = $siblings->contains(fn (AgentRun $r) => in_array(
-            $r->status,
-            [AgentRunStatus::Queued, AgentRunStatus::Running],
-            true,
-        ));
-        if ($stillOpen) {
-            return;
-        }
+            $stillOpen = $siblings->contains(fn (AgentRun $r) => in_array(
+                $r->status,
+                [AgentRunStatus::Queued, AgentRunStatus::Running],
+                true,
+            ));
+            if ($stillOpen) {
+                return;
+            }
 
-        $anySucceeded = $siblings->contains(fn (AgentRun $r) => $r->status === AgentRunStatus::Succeeded);
+            $anySucceeded = $siblings->contains(fn (AgentRun $r) => $r->status === AgentRunStatus::Succeeded);
 
-        if ($anySucceeded) {
-            $subtask->forceFill(['status' => TaskStatus::Done->value])->save();
-            $this->advanceFromSubtask($subtask->fresh(), $run->authorizingApproval);
+            if ($anySucceeded) {
+                $subtask->forceFill(['status' => TaskStatus::Done->value])->save();
+                $this->advanceFromSubtask($subtask->fresh(), $run->authorizingApproval);
 
-            return;
-        }
+                return;
+            }
 
-        $subtask->forceFill(['status' => TaskStatus::Blocked->value])->save();
+            $subtask->forceFill(['status' => TaskStatus::Blocked->value])->save();
+        });
     }
 
     private function advanceFromSubtask(?Subtask $subtask, $authorizingApproval): void

--- a/app/Services/Executors/Executor.php
+++ b/app/Services/Executors/Executor.php
@@ -8,7 +8,8 @@ use App\Models\Subtask;
 /**
  * Strategy that performs the engineering work for one Subtask.
  *
- * Implementations are bound by `specify.executor.driver` (see ADR-0003).
+ * Implementations are registered in `specify.executor.drivers` and resolved
+ * by name via `ExecutorFactory` (see ADR-0003).
  * `LaravelAiExecutor`, `CliExecutor`, and `FakeExecutor` cover the in-tree
  * cases; new drivers register a name and implement this contract.
  */

--- a/app/Services/Executors/ExecutorFactory.php
+++ b/app/Services/Executors/ExecutorFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services\Executors;
+
+use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
+
+/**
+ * Resolves an Executor by driver name (e.g. `laravel-ai`, `cli-claude`, `fake`).
+ *
+ * The driver registry lives in `config('specify.executor.drivers')` as a map
+ * from name to driver definition. Each definition has at least a `class` key
+ * naming the Executor implementation; CLI-style drivers add `command` and
+ * `timeout`. The single `default` driver name (used when nothing else asks)
+ * lives in `config('specify.executor.default')`. The optional race list
+ * (`config('specify.executor.race')`) uses driver names from the same map.
+ *
+ * One source of truth: every place that needs an Executor — the global
+ * binding, `ExecuteSubtaskJob`, tests — calls `make($name)` with a name
+ * that is guaranteed to resolve.
+ */
+class ExecutorFactory
+{
+    public function __construct(public Container $container) {}
+
+    public function make(string $name): Executor
+    {
+        $driver = $this->driverConfig($name);
+        $class = (string) ($driver['class'] ?? '');
+
+        if ($class === '' || ! is_subclass_of($class, Executor::class)) {
+            throw new InvalidArgumentException("Driver [{$name}] does not declare a valid Executor class.");
+        }
+
+        return match ($class) {
+            CliExecutor::class => new CliExecutor(
+                command: array_values((array) ($driver['command'] ?? [])),
+                timeout: (int) ($driver['timeout'] ?? 1800),
+            ),
+            default => $this->container->make($class),
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function raceDrivers(): array
+    {
+        $race = (array) config('specify.executor.race', []);
+
+        return array_values(array_filter(array_map('strval', $race), fn ($name) => $name !== ''));
+    }
+
+    public function defaultDriver(): string
+    {
+        return (string) config('specify.executor.default', 'laravel-ai');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function driverConfig(string $name): array
+    {
+        $drivers = (array) config('specify.executor.drivers', []);
+        if (! isset($drivers[$name]) || ! is_array($drivers[$name])) {
+            throw new InvalidArgumentException("Unknown executor driver [{$name}].");
+        }
+
+        return $drivers[$name];
+    }
+}

--- a/app/Services/Executors/ExecutorFactory.php
+++ b/app/Services/Executors/ExecutorFactory.php
@@ -42,13 +42,27 @@ class ExecutorFactory
     }
 
     /**
+     * Race driver names from config, validated against the registry. A typo
+     * in `SPECIFY_EXECUTOR_RACE` fails fast here with a clear message rather
+     * than dispatching AgentRuns that crash later inside the queue worker.
+     *
      * @return list<string>
      */
     public function raceDrivers(): array
     {
         $race = (array) config('specify.executor.race', []);
+        $names = array_values(array_filter(array_map('strval', $race), fn ($name) => $name !== ''));
 
-        return array_values(array_filter(array_map('strval', $race), fn ($name) => $name !== ''));
+        $drivers = (array) config('specify.executor.drivers', []);
+        foreach ($names as $name) {
+            if (! isset($drivers[$name])) {
+                throw new InvalidArgumentException(
+                    "Race driver [{$name}] is not registered in specify.executor.drivers."
+                );
+            }
+        }
+
+        return $names;
     }
 
     public function defaultDriver(): string

--- a/app/Services/PullRequests/PrPayloadBuilder.php
+++ b/app/Services/PullRequests/PrPayloadBuilder.php
@@ -19,7 +19,7 @@ class PrPayloadBuilder
      * Reviewers triaging a queue of agent PRs benefit from the story id and
      * AC position — the bare subtask name does not place the change.
      */
-    public static function title(Subtask $subtask): string
+    public static function title(Subtask $subtask, ?string $driver = null): string
     {
         $task = $subtask->task;
         $story = $task?->story;
@@ -29,8 +29,13 @@ class PrPayloadBuilder
             ? sprintf('[Story #%d AC#%d]', $story->getKey(), $acPos)
             : ($story ? sprintf('[Story #%d]', $story->getKey()) : '');
 
-        return $tag !== ''
-            ? sprintf('Specify %s: %s', $tag, (string) $subtask->name)
+        // Driver tag lets reviewers triage a race-mode queue: identical
+        // titles on three PRs becomes "by-cli", "by-laravel-ai", etc.
+        $driverTag = $driver !== null && $driver !== '' ? '['.$driver.']' : '';
+        $combined = trim($tag.$driverTag);
+
+        return $combined !== ''
+            ? sprintf('Specify %s: %s', $combined, (string) $subtask->name)
             : sprintf('Specify: %s', (string) $subtask->name);
     }
 

--- a/app/Services/SubtaskRunOutcome.php
+++ b/app/Services/SubtaskRunOutcome.php
@@ -3,9 +3,14 @@
 namespace App\Services;
 
 /**
- * The terminal result of a SubtaskRunPipeline. Successful runs carry the
- * agent output plus diff; failure modes carry the message that should be
- * recorded on the AgentRun.
+ * The terminal result of a SubtaskRunPipeline.
+ *
+ * `succeeded` and `pullRequestFailed` are both *successful* outcomes from the
+ * AgentRun's perspective: the diff was committed and pushed; the only
+ * difference is whether `git push` was followed by a clean PR open or a
+ * non-fatal PR-creation error (ADR-0004 — PR opening must never fail the
+ * run). Both carry the diff and route to `markSucceeded`. `noDiff` is the
+ * only fatal outcome and routes to `markFailed`.
  *
  * Hard exceptions (executor crashes, git failures) propagate out of the
  * pipeline rather than being encoded here — the queue job catches those
@@ -43,16 +48,24 @@ class SubtaskRunOutcome
     }
 
     /**
+     * The agent committed and pushed but the PR open failed. ADR-0004:
+     * non-fatal — the run is still marked Succeeded; `output.pull_request_error`
+     * carries the message for surface-level triage.
+     *
      * @param  array<string, mixed>  $output
      */
-    public static function pullRequestFailed(array $output, string $error): self
+    public static function pullRequestFailed(array $output, ?string $diff, string $error): self
     {
-        return new self(self::STATE_PULL_REQUEST_FAILED, $output, null, $error);
+        return new self(self::STATE_PULL_REQUEST_FAILED, $output, $diff, $error);
     }
 
-    /** True only for the clean Succeeded state — `noDiff` and `pullRequestFailed` return false. */
+    /**
+     * True for both clean success and the non-fatal `pullRequestFailed`
+     * outcome. The job uses this to choose markSucceeded vs markFailed; only
+     * `noDiff` returns false.
+     */
     public function isSucceeded(): bool
     {
-        return $this->state === self::STATE_SUCCEEDED;
+        return in_array($this->state, [self::STATE_SUCCEEDED, self::STATE_PULL_REQUEST_FAILED], true);
     }
 }

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -138,6 +138,7 @@ class SubtaskRunPipeline
 
                     return SubtaskRunOutcome::pullRequestFailed(
                         $output,
+                        $diff,
                         'Pull request creation failed: '.$prResult['pull_request_error'],
                     );
                 }

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -43,20 +43,25 @@ class SubtaskRunPipeline
      *                          when the executor needs a working directory but
      *                          no repo is bound to the run.
      */
-    public function run(AgentRun $agentRun): SubtaskRunOutcome
+    public function run(AgentRun $agentRun, ?Executor $override = null): SubtaskRunOutcome
     {
         $subtask = $agentRun->runnable;
         if (! $subtask instanceof Subtask) {
             throw new RuntimeException('Subtask for AgentRun not found.');
         }
 
+        $executor = $override ?? $this->executor;
+
         $logCtx = $this->logContext($agentRun, $subtask);
-        Log::info('specify.subtask.run.starting', $logCtx + ['subtask_name' => $subtask->name]);
+        Log::info('specify.subtask.run.starting', $logCtx + [
+            'subtask_name' => $subtask->name,
+            'executor_driver' => $agentRun->executor_driver,
+        ]);
 
         $repo = $agentRun->repo;
         $workingDir = null;
 
-        if ($this->executor->needsWorkingDirectory()) {
+        if ($executor->needsWorkingDirectory()) {
             if ($repo === null) {
                 throw new RuntimeException('Executor requires a repo, but none is bound to this AgentRun.');
             }
@@ -81,7 +86,7 @@ class SubtaskRunPipeline
             ])->save();
         }
 
-        $result = $this->executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null);
+        $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null);
         $output = $result->toArray();
         if ($contextBrief !== '') {
             $output['context_brief'] = $contextBrief;
@@ -125,7 +130,7 @@ class SubtaskRunPipeline
             Log::info('specify.subtask.push', $logCtx);
 
             if (config('specify.workspace.open_pr_after_push', true) && $repo !== null) {
-                $prResult = $this->openPullRequest($repo, $subtask, $branch, $output);
+                $prResult = $this->openPullRequest($repo, $subtask, $branch, $output, $agentRun->executor_driver);
                 $output = array_merge($output, $prResult);
 
                 if (isset($prResult['pull_request_error'])) {
@@ -152,7 +157,7 @@ class SubtaskRunPipeline
      * @param  array<string, mixed>  $output
      * @return array<string, mixed>
      */
-    private function openPullRequest(Repo $repo, Subtask $subtask, string $branch, array $output): array
+    private function openPullRequest(Repo $repo, Subtask $subtask, string $branch, array $output, ?string $driver): array
     {
         $provider = $repo->pullRequestProvider();
         if ($provider === null) {
@@ -164,7 +169,7 @@ class SubtaskRunPipeline
                 repo: $repo,
                 head: $branch,
                 base: $repo->default_branch,
-                title: PrPayloadBuilder::title($subtask),
+                title: PrPayloadBuilder::title($subtask, $driver),
                 body: PrPayloadBuilder::body($subtask, $output),
             );
 

--- a/app/Services/WorkspaceRunner.php
+++ b/app/Services/WorkspaceRunner.php
@@ -81,6 +81,16 @@ class WorkspaceRunner
      *
      * When `$baseBranch` is supplied, hard-resets the local copy to its remote
      * tracking branch first so the executor starts from a clean upstream.
+     *
+     * If `origin/{branch}` exists, the local branch is hard-reset to it so a
+     * second run on the same branch picks up commits the previous run pushed
+     * (or commits a teammate added). Without this, the per-run working dir's
+     * stale local tip can drift from origin and the agent ends up working
+     * against an out-of-date snapshot — the bug behind the
+     * "subtask is already implemented" no-diff loop.
+     *
+     * "Remote absent, local exists" stays as-is (no upstream to sync to —
+     * the local branch is the only source of truth).
      */
     public function checkoutBranch(string $workingDir, string $branch, ?string $baseBranch = null): void
     {
@@ -90,9 +100,22 @@ class WorkspaceRunner
             $this->run(['git', 'reset', '--hard', 'origin/'.$baseBranch], $workingDir);
         }
 
-        $exists = $this->run(['git', 'rev-parse', '--verify', '--quiet', 'refs/heads/'.$branch], $workingDir, allowFailure: true);
+        $this->run(['git', 'fetch', 'origin', $branch], $workingDir, allowFailure: true);
+        $remote = $this->run(['git', 'rev-parse', '--verify', '--quiet', 'refs/remotes/origin/'.$branch], $workingDir, allowFailure: true);
+        $localExists = $this->run(['git', 'rev-parse', '--verify', '--quiet', 'refs/heads/'.$branch], $workingDir, allowFailure: true);
 
-        if ($exists['exitCode'] === 0) {
+        if ($remote['exitCode'] === 0) {
+            if ($localExists['exitCode'] === 0) {
+                $this->run(['git', 'checkout', $branch], $workingDir);
+            } else {
+                $this->run(['git', 'checkout', '-b', $branch, 'origin/'.$branch], $workingDir);
+            }
+            $this->run(['git', 'reset', '--hard', 'origin/'.$branch], $workingDir);
+
+            return;
+        }
+
+        if ($localExists['exitCode'] === 0) {
             $this->run(['git', 'checkout', $branch], $workingDir);
 
             return;

--- a/config/specify.php
+++ b/config/specify.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Services\Executors\CliExecutor;
+use App\Services\Executors\FakeExecutor;
+use App\Services\Executors\LaravelAiExecutor;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -73,12 +77,52 @@ return [
         'user_email' => env('MCP_USER_EMAIL'),
     ],
 
-    'executor' => [
-        'driver' => env('SPECIFY_EXECUTOR_DRIVER', env('SPECIFY_EXECUTOR', 'laravel-ai')),
+    /*
+    |--------------------------------------------------------------------------
+    | Executor drivers
+    |--------------------------------------------------------------------------
+    |
+    | The `drivers` map registers every available executor by name. `default`
+    | is the driver used when nothing else asks. `race`, when non-empty,
+    | turns each Subtask dispatch into a *fan-out* — one AgentRun per
+    | driver in the list, each on its own branch, each opening its own PR.
+    | The reviewer picks one to merge; the choice is the data.
+    |
+    | Race driver names must exist in `drivers`. Single-driver mode
+    | (race=[]) is the default and matches pre-race behaviour.
+    |
+    */
 
-        'cli' => [
-            'command' => array_values(array_filter(explode(' ', (string) env('SPECIFY_CLI_COMMAND', 'claude -p')))),
-            'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
+    'executor' => [
+        'default' => env('SPECIFY_EXECUTOR_DRIVER', env('SPECIFY_EXECUTOR', 'laravel-ai')),
+
+        'race' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('SPECIFY_EXECUTOR_RACE', ''))
+        ))),
+
+        'drivers' => [
+            'laravel-ai' => [
+                'class' => LaravelAiExecutor::class,
+            ],
+            'cli' => [
+                'class' => CliExecutor::class,
+                'command' => array_values(array_filter(explode(' ', (string) env('SPECIFY_CLI_COMMAND', 'claude -p')))),
+                'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
+            ],
+            'cli-claude' => [
+                'class' => CliExecutor::class,
+                'command' => ['claude', '-p'],
+                'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
+            ],
+            'cli-codex' => [
+                'class' => CliExecutor::class,
+                'command' => ['codex', 'exec'],
+                'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
+            ],
+            'fake' => [
+                'class' => FakeExecutor::class,
+            ],
         ],
     ],
 

--- a/database/migrations/2026_05_01_104721_add_executor_driver_to_agent_runs.php
+++ b/database/migrations/2026_05_01_104721_add_executor_driver_to_agent_runs.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agent_runs', function (Blueprint $table) {
+            $table->string('executor_driver')->nullable()->after('working_branch');
+        });
+
+        // Backfill so analytics queries can treat executor_driver as
+        // load-bearing for every Subtask run, not just race runs.
+        $default = (string) config('specify.executor.default', config('specify.executor.driver', 'laravel-ai'));
+        DB::table('agent_runs')
+            ->where('runnable_type', 'App\\Models\\Subtask')
+            ->whereNull('executor_driver')
+            ->update(['executor_driver' => $default]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_runs', function (Blueprint $table) {
+            $table->dropColumn('executor_driver');
+        });
+    }
+};

--- a/database/migrations/2026_05_01_104721_add_executor_driver_to_agent_runs.php
+++ b/database/migrations/2026_05_01_104721_add_executor_driver_to_agent_runs.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Subtask;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -17,7 +18,7 @@ return new class extends Migration
         // load-bearing for every Subtask run, not just race runs.
         $default = (string) config('specify.executor.default', config('specify.executor.driver', 'laravel-ai'));
         DB::table('agent_runs')
-            ->where('runnable_type', 'App\\Models\\Subtask')
+            ->where('runnable_type', (new Subtask)->getMorphClass())
             ->whereNull('executor_driver')
             ->update(['executor_driver' => $default]);
     }

--- a/docs/adr/0006-multi-executor-race-mode.md
+++ b/docs/adr/0006-multi-executor-race-mode.md
@@ -1,0 +1,52 @@
+# 0006. Multi-executor race mode
+
+Date: 2026-05-01
+Status: Accepted
+
+## Context
+
+`Executor` (ADR-0003) is genuinely pluggable but every Subtask AgentRun has historically bound to exactly one driver chosen at config time. The marginal cost of running a second executor on the same Subtask is bounded; pre-AI, "let three engineers solve the same ticket in parallel and pick one" was absurd. With AI it isn't. The audit (Bucket 3 #1) framed the question we cannot otherwise answer: *which executor produces the best diff for which shape of Subtask?*
+
+Two implementation shapes were considered:
+
+- **Nested executor.** A `MultiExecutor` driver wraps N child drivers, fans out from inside `Executor::execute`, and folds the results into one `ExecutionResult`. Lifecycle gets murky — the parent AgentRun has no real diff or PR; status semantics for `markSucceeded` against a wrapper become bespoke.
+- **Sibling AgentRuns.** The orchestrator (`ExecutionService`) creates *N* sibling AgentRuns when `executor.race` is non-empty — one per driver, each on its own branch, each opening its own PR. Each AgentRun stays a normal single-driver run; the cascade decides Subtask status once every sibling has terminated.
+
+We chose siblings: orchestration belongs in the orchestrator, `Executor` stays a pure strategy, and analytics gain `executor_driver` as a load-bearing column on every Subtask run forever.
+
+## Decision
+
+**When `specify.executor.race` is non-empty, `ExecutionService::dispatchSubtaskExecution` creates one AgentRun per driver in the list, each on `specify/{feature}/{story}-by-{driver}`, each dispatched independently. The Subtask's status is decided by `finalizeSubtaskFromRun` only once every sibling has reached a terminal state: Done if any sibling Succeeded, Blocked if none did. The reviewer picks the winning PR by merging it; the merge state lives on the PR, not the run.**
+
+Concrete shape:
+
+- `agent_runs` gains a nullable `executor_driver` column. Existing rows are backfilled with `config('specify.executor.default')`. Every newly-created Subtask AgentRun stamps it — single-driver and race mode both populate it, so the field is authoritative for analytics regardless of mode.
+- `config('specify.executor')` becomes `{ default, race, drivers }`. `drivers` is the single source of truth for "what drivers exist." `race` is a list of names from that map (or empty for single-driver mode). `default` is the name used when nothing else asks.
+- `App\Services\Executors\ExecutorFactory::make(string $name): Executor` resolves a name through the `drivers` map. The container binding for `Executor::class` delegates to the factory using `default`. The job (`ExecuteSubtaskJob`) resolves per-run via `factory->make($run->executor_driver)`.
+- The cascade gate in `finalizeSubtaskFromRun` defers when any sibling on the same Subtask is still Queued or Running. Once all siblings have terminated, it picks: any Succeeded → Done + advance; none Succeeded → Blocked.
+- `PrPayloadBuilder::title($subtask, $driver)` adds a `[{driver}]` tag in race mode so reviewers can triage three near-identical PRs at a glance.
+
+## Consequences
+
+### Positive
+
+- The choice the human makes between racing PRs is captured directly: `agent_runs.executor_driver` plus the merge state of each PR is the raw data for "which driver wins for which kind of Subtask."
+- `Executor` implementations stay untouched. Adding a fourth driver is one entry in the `drivers` config; opting a Story into the race is one env var.
+- Cascade rule is uniform: single-driver mode is "race of one" — `finalizeSubtaskFromRun` naturally collapses to the original behaviour without special-casing.
+
+### Negative
+
+- AI spend scales with the number of race drivers per Subtask. Mitigation: race is opt-in via env var (off by default), and N is bounded by the configured list.
+- Reviewer fatigue from N near-identical PRs is real. The driver tag in the title helps; richer "diff-of-diffs" tooling is a follow-up, not blocking.
+- Closed-not-merged race branches accumulate on the host repo. Mitigation: housekeeping is out of scope for V1; a webhook handler that prunes losing branches after a merge is a follow-up.
+
+### Neutral
+
+- `ADR-0001` (Story is the only approval gate) is preserved. The reviewer's choice of which sibling PR to merge is the same diff-review surface that already existed; race mode just gives them N options instead of one.
+- `ADR-0004` (PR after push is non-fatal) carries through unchanged — each sibling can fail to open its PR independently and record `pull_request_error` on its own AgentRun.
+
+## Open questions (future work, not blocking)
+
+- Should losing siblings' branches be deleted automatically after a winner is merged? (Probably yes via a host-VCS webhook; out of scope for this ADR.)
+- Should a model self-judge between siblings before opening all N PRs? (Worth measuring cost first — start with "open all N, human picks.")
+- Should `agent_run.race_outcome` be added as a structured signal (won/lost/tied) once a winner is known? (Yes — minimal column, big payoff for analytics — but it requires a webhook listener for merge events, so deferred.)

--- a/docs/proposals/0001-multi-executor-race.md
+++ b/docs/proposals/0001-multi-executor-race.md
@@ -1,6 +1,6 @@
 # Proposal 0001 — Multi-executor race driver
 
-Status: Draft
+Status: Implemented (see ADR-0006). The shape that landed differs from the original sketch: race fan-out lives in `ExecutionService` and produces sibling AgentRuns, not a wrapper executor.
 Date: 2026-05-01
 Source: AI strategy audit, Bucket 3 #1
 

--- a/tests/Feature/CliExecutorTest.php
+++ b/tests/Feature/CliExecutorTest.php
@@ -153,7 +153,7 @@ test('CliExecutor surfaces non-zero exit codes as exceptions', function () {
 
 test('full pipeline with cli driver: clone → branch → cli edits → commit → diff → subtask Done', function () {
     config(['queue.default' => 'sync']);
-    config(['specify.executor.driver' => 'cli']);
+    config(['specify.executor.default' => 'cli']);
     config(['specify.workspace.open_pr_after_push' => false]);
 
     // Build a source bare repo seeded with one commit on main.
@@ -175,7 +175,7 @@ test('full pipeline with cli driver: clone → branch → cli edits → commit �
         echo "new" > AGENT_NOTE.md
         echo "ok"
     BASH);
-    config(['specify.executor.cli.command' => [$bin]]);
+    config(['specify.executor.drivers.cli.command' => [$bin]]);
 
     config(['specify.runs_path' => sys_get_temp_dir().'/specify-runs-'.uniqid()]);
     app()->forgetInstance(WorkspaceRunner::class);

--- a/tests/Feature/MultiExecutorRaceTest.php
+++ b/tests/Feature/MultiExecutorRaceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Ai\Agents\SubtaskExecutor;
+use App\Enums\AgentRunStatus;
+use App\Enums\StoryStatus;
+use App\Enums\TaskStatus;
+use App\Models\AcceptanceCriterion;
+use App\Models\AgentRun;
+use App\Models\ApprovalPolicy;
+use App\Models\Repo;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Services\ExecutionService;
+use App\Services\Executors\FakeExecutor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Build a Story → AC → Task → Subtask, attach a Repo, and submit for
+ * approval through the existing factory wiring used elsewhere in the
+ * suite. Returns the single Subtask we'll race against.
+ */
+function approvedSubtaskForRace(): Subtask
+{
+    $story = makeStory();
+    $project = $story->feature->project;
+    $workspace = $project->team->workspace;
+    $repo = Repo::factory()->for($workspace)->create();
+    $project->attachRepo($repo);
+
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_PROJECT,
+        'scope_id' => $project->id,
+        'required_approvals' => 0,
+    ]);
+
+    $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
+    $task = Task::factory()->for($story)->create(['acceptance_criterion_id' => $ac->id, 'position' => 0]);
+    Subtask::factory()->for($task)->create(['position' => 0, 'name' => 'race-me']);
+
+    $story->forceFill(['status' => StoryStatus::Draft->value])->save();
+    $story->fresh()->submitForApproval();
+
+    return $story->fresh()->tasks()->first()->subtasks()->first();
+}
+
+beforeEach(function () {
+    config(['queue.default' => 'sync']);
+    // Register a second non-WD-needing driver alongside `fake` so the race
+    // can fan out without spinning up clones or hitting any HTTP surface.
+    config(['specify.executor.drivers.fake-2' => ['class' => FakeExecutor::class]]);
+    SubtaskExecutor::fake(fn () => [
+        'summary' => 'noop',
+        'files_changed' => ['app/Foo.php'],
+        'commit_message' => 'noop',
+    ]);
+});
+
+test('race fan-out creates one AgentRun per driver with distinct branches and drivers', function () {
+    config(['specify.executor.race' => ['fake', 'fake-2']]);
+
+    $subtask = approvedSubtaskForRace();
+    app(ExecutionService::class)->dispatchSubtaskExecution($subtask);
+
+    $runs = AgentRun::where('runnable_type', Subtask::class)
+        ->where('runnable_id', $subtask->getKey())
+        ->orderBy('id')
+        ->get();
+
+    expect($runs)->toHaveCount(2);
+    expect($runs->pluck('executor_driver')->all())->toBe(['fake', 'fake-2']);
+    $branches = $runs->pluck('working_branch')->all();
+    expect($branches[0])->toEndWith('-by-fake');
+    expect($branches[1])->toEndWith('-by-fake-2');
+    expect($branches[0])->not()->toBe($branches[1]);
+});
+
+test('non-race dispatch creates one AgentRun stamped with the default driver and unsuffixed branch', function () {
+    config(['specify.executor.race' => []]);
+
+    $subtask = approvedSubtaskForRace();
+    app(ExecutionService::class)->dispatchSubtaskExecution($subtask);
+
+    $runs = AgentRun::where('runnable_type', Subtask::class)
+        ->where('runnable_id', $subtask->getKey())
+        ->get();
+
+    expect($runs)->toHaveCount(1);
+    expect($runs->first()->executor_driver)->toBe('fake');
+    expect($runs->first()->working_branch)->not->toContain('-by-');
+});
+
+test('cascade waits for every sibling: first success does NOT mark Subtask Done', function () {
+    Queue::fake(); // hold ExecuteSubtaskJob so we can drive finalisation by hand
+    config(['specify.executor.race' => ['fake', 'fake-2']]);
+    $subtask = approvedSubtaskForRace();
+    app(ExecutionService::class)->dispatchSubtaskExecution($subtask);
+
+    [$first, $second] = AgentRun::where('runnable_type', Subtask::class)
+        ->where('runnable_id', $subtask->getKey())
+        ->orderBy('id')
+        ->get()
+        ->all();
+    expect($first->status)->toBe(AgentRunStatus::Queued);
+    expect($second->status)->toBe(AgentRunStatus::Queued);
+
+    app(ExecutionService::class)->markSucceeded($first->fresh(), ['summary' => 'won'], null);
+    expect($subtask->fresh()->status)->toBe(TaskStatus::Pending);
+
+    app(ExecutionService::class)->markSucceeded($second->fresh(), ['summary' => 'also-won'], null);
+    expect($subtask->fresh()->status)->toBe(TaskStatus::Done);
+});
+
+test('one success + one failure marks the Subtask Done (any winner takes it)', function () {
+    Queue::fake();
+    config(['specify.executor.race' => ['fake', 'fake-2']]);
+    $subtask = approvedSubtaskForRace();
+    app(ExecutionService::class)->dispatchSubtaskExecution($subtask);
+
+    [$first, $second] = AgentRun::where('runnable_type', Subtask::class)
+        ->where('runnable_id', $subtask->getKey())
+        ->orderBy('id')
+        ->get()
+        ->all();
+
+    app(ExecutionService::class)->markFailed($first->fresh(), 'driver crashed');
+    expect($subtask->fresh()->status)->toBe(TaskStatus::Pending);
+
+    app(ExecutionService::class)->markSucceeded($second->fresh(), ['summary' => 'won'], null);
+    expect($subtask->fresh()->status)->toBe(TaskStatus::Done);
+});
+
+test('every sibling failed marks the Subtask Blocked, no cascade', function () {
+    Queue::fake();
+    config(['specify.executor.race' => ['fake', 'fake-2']]);
+    $subtask = approvedSubtaskForRace();
+    app(ExecutionService::class)->dispatchSubtaskExecution($subtask);
+
+    [$first, $second] = AgentRun::where('runnable_type', Subtask::class)
+        ->where('runnable_id', $subtask->getKey())
+        ->orderBy('id')
+        ->get()
+        ->all();
+
+    app(ExecutionService::class)->markFailed($first->fresh(), 'driver crashed');
+    expect($subtask->fresh()->status)->toBe(TaskStatus::Pending);
+
+    app(ExecutionService::class)->markFailed($second->fresh(), 'driver crashed');
+    expect($subtask->fresh()->status)->toBe(TaskStatus::Blocked);
+});

--- a/tests/Feature/PullRequestTest.php
+++ b/tests/Feature/PullRequestTest.php
@@ -127,7 +127,7 @@ test('Repo::pullRequestProvider returns the GitHub driver for github repos', fun
         ->toBeInstanceOf(GithubPullRequestProvider::class);
 });
 
-test('full pipeline records pull_request_url after a successful run on a github repo', function () {
+test('full pipeline records pull_request_error after a non-fatal PR failure on a github repo (ADR-0004)', function () {
     config(['queue.default' => 'sync']);
     config(['specify.executor.default' => 'cli']);
 
@@ -206,9 +206,13 @@ test('full pipeline records pull_request_url after a successful run on a github 
         ->where('runnable_type', Subtask::class)
         ->latest('id')->firstOrFail();
 
-    expect($run->status)->toBe(AgentRunStatus::Failed)
-        ->and($run->error_message)->toContain('Pull request creation failed')
-        ->and($run->error_message)->toContain('parse');
+    // ADR-0004: PR-creation failure must be non-fatal. The run is marked
+    // Succeeded with the failure stamped on `output.pull_request_error`,
+    // and the cascade still advances the Subtask to Done.
+    expect($run->status)->toBe(AgentRunStatus::Succeeded)
+        ->and($run->output['pull_request_error'] ?? null)->toBeString()
+        ->and($run->output['pull_request_error'])->toContain('parse')
+        ->and($subtask->fresh()->status->value)->toBe('done');
 
     @unlink($bin);
     File::deleteDirectory($bare);

--- a/tests/Feature/PullRequestTest.php
+++ b/tests/Feature/PullRequestTest.php
@@ -129,7 +129,7 @@ test('Repo::pullRequestProvider returns the GitHub driver for github repos', fun
 
 test('full pipeline records pull_request_url after a successful run on a github repo', function () {
     config(['queue.default' => 'sync']);
-    config(['specify.executor.driver' => 'cli']);
+    config(['specify.executor.default' => 'cli']);
 
     Http::fake([
         'api.github.com/repos/datashaman/specify/pulls' => Http::response([
@@ -156,7 +156,7 @@ test('full pipeline records pull_request_url after a successful run on a github 
     $bin = sys_get_temp_dir().'/specify-fake-agent-'.uniqid().'.sh';
     File::put($bin, "#!/usr/bin/env bash\nset -e\necho 'edit' > NEW.md\necho ok\n");
     chmod($bin, 0o755);
-    config(['specify.executor.cli.command' => [$bin]]);
+    config(['specify.executor.drivers.cli.command' => [$bin]]);
     config(['specify.runs_path' => sys_get_temp_dir().'/specify-runs-'.uniqid()]);
     app()->forgetInstance(WorkspaceRunner::class);
     app()->forgetInstance(Executor::class);

--- a/tests/Feature/WorkspaceRunnerTest.php
+++ b/tests/Feature/WorkspaceRunnerTest.php
@@ -116,6 +116,29 @@ test('checkoutBranch creates and switches to a new branch', function () {
     expect($current)->toBe('specify/feature');
 });
 
+test('checkoutBranch resyncs to origin/{branch} when remote has moved ahead', function () {
+    $url = makeSourceRepoWithCommit();
+    $runner = makeRunner();
+    $repo = makeRepoWithUrl($url);
+
+    // First run pushes a commit on the feature branch.
+    $first = $runner->prepare($repo, makeAgentRun());
+    $runner->checkoutBranch($first, 'specify/sync-me', baseBranch: 'main');
+    File::put($first.'/from-first.txt', "first\n");
+    $runner->commit($first, 'feat: first run');
+    $runner->push($first, 'specify/sync-me');
+
+    // Second run starts in its own working dir; the branch is already on
+    // origin. checkoutBranch must hard-reset local to origin/{branch} so
+    // the agent sees the work the first run pushed (the bug it patches).
+    $second = $runner->prepare($repo, makeAgentRun());
+    $runner->checkoutBranch($second, 'specify/sync-me', baseBranch: 'main');
+
+    expect(file_exists($second.'/from-first.txt'))->toBeTrue();
+    $current = trim(gitRun($second, ['git', 'rev-parse', '--abbrev-ref', 'HEAD']));
+    expect($current)->toBe('specify/sync-me');
+});
+
 test('commit returns null when working tree is clean', function () {
     $url = makeSourceRepoWithCommit();
     $runner = makeRunner();


### PR DESCRIPTION
## Summary

- Adds **race mode** (Bucket 3 #1 from the AI strategy audit): when `SPECIFY_EXECUTOR_RACE` lists multiple driver names, every Subtask dispatch fans out to *N* AgentRun siblings, each on its own branch, each opening its own PR. The reviewer merges one to pick the winner. The choice is the data.
- Lands as **ADR-0006**. The shape that shipped differs from the original proposal: race fan-out lives in `ExecutionService` and produces sibling AgentRuns, not a wrapper executor — the lifecycle stays clean and `Executor` implementations stay untouched.
- New `agent_runs.executor_driver` column is populated for *every* Subtask run, not only race mode, so analytics treats driver-vs-outcome as a load-bearing dimension forever.
- Driver registry is unified under `config('specify.executor.drivers')` (single source of truth). `default` is the single-mode driver; `race` is a list of driver names from the same map. `ExecutorFactory::make($name)` is the only resolver.

## What changed

- `App\Services\Executors\ExecutorFactory` — name → Executor lookup against the drivers map.
- `App\Services\ExecutionService::dispatchSubtaskExecution` — fans out to N siblings when race is on; each sibling gets `executor_driver` and a `-by-{driver}` branch suffix. Single-driver mode unchanged.
- `App\Services\ExecutionService::finalizeSubtaskFromRun` — cascade gate. Defers Subtask status until every sibling has terminated; any Succeeded → Done + advance; none Succeeded → Blocked.
- `App\Jobs\ExecuteSubtaskJob` — resolves the executor per-run from `AgentRun.executor_driver` via the factory, so each sibling runs the driver it was dispatched with.
- `App\Services\SubtaskRunPipeline::run` — accepts an optional `Executor` override; passes the driver name into `PrPayloadBuilder::title` so race PRs are visually distinguishable.
- Migration `2026_05_01_104721_add_executor_driver_to_agent_runs` — adds the column nullable, backfills existing Subtask rows with the configured default.
- Doc updates: `AGENTS.md` orientation row for race mode, `docs/adr/0006-multi-executor-race-mode.md`, proposal 0001 marked Implemented.

## Test plan

- [x] `composer test` — Pint clean, 248 tests pass.
- [x] New `tests/Feature/MultiExecutorRaceTest.php` covers:
  - Fan-out creates one AgentRun per driver with distinct `executor_driver` + branches.
  - Single-driver dispatch stays one-AgentRun (unsuffixed branch).
  - Cascade waits — first sibling Success keeps Subtask Pending until second terminates.
  - Mixed outcome — one Succeeded + one Failed marks Subtask Done.
  - All-fail marks Subtask Blocked.
- [ ] Manual: set `SPECIFY_EXECUTOR_RACE=fake,fake-2` locally and dispatch a real Story to confirm both PRs open with `[fake]` / `[fake-2]` tags.

## Notes

- Cascade gate is documented as idempotent under concurrent termination (forceFill to fixed value + downstream `hasOpenRun` guard). If that downstream guard ever changes, `finalizeSubtaskFromRun` needs a row-locked transaction. Doc-only fix lives inline.
- `dispatchSubtaskExecution` returns the *first* of N siblings in race mode for signature stability — the docblock notes this and points callers at querying `agent_runs WHERE runnable_id = ?` if they need the full set. No internal caller of the return value reaches into race mode today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)