### PR TITLE
feat: ADR-0007 — already-complete subtasks

### DIFF
--- a/app/Ai/Agents/SubtaskExecutor.php
+++ b/app/Ai/Agents/SubtaskExecutor.php
@@ -130,6 +130,8 @@ PROMPT;
                         'reason' => $schema->string()->required(),
                     ])
                 ),
+            'already_complete' => $schema->boolean(),
+            'already_complete_evidence' => $schema->array()->items($schema->string()),
         ];
     }
 }

--- a/app/Jobs/ExecuteSubtaskJob.php
+++ b/app/Jobs/ExecuteSubtaskJob.php
@@ -64,7 +64,8 @@ class ExecuteSubtaskJob implements ShouldQueue
 
         match ($outcome->state) {
             SubtaskRunOutcome::STATE_SUCCEEDED,
-            SubtaskRunOutcome::STATE_PULL_REQUEST_FAILED => $execution->markSucceeded($run, $outcome->output, $outcome->diff),
+            SubtaskRunOutcome::STATE_PULL_REQUEST_FAILED,
+            SubtaskRunOutcome::STATE_ALREADY_COMPLETE => $execution->markSucceeded($run, $outcome->output, $outcome->diff),
             SubtaskRunOutcome::STATE_NO_DIFF => $execution->markFailed($run, $outcome->error ?? 'Subtask run failed.'),
         };
 

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -61,13 +61,44 @@ class CliExecutor implements Executor
         $stdout = $process->getOutput();
         $stderr = $process->getErrorOutput();
         $files = $this->changedFiles($workingDir);
+        [$alreadyComplete, $alreadyCompleteEvidence] = $this->parseAlreadyCompleteSentinel($stdout);
 
         return new ExecutionResult(
             summary: $this->buildSummary($stdout),
             filesChanged: $files,
             commitMessage: $this->commitMessageFor($subtask),
             executorLog: $this->buildExecutorLog($stdout, $stderr),
+            alreadyComplete: $alreadyComplete,
+            alreadyCompleteEvidence: $alreadyCompleteEvidence,
         );
+    }
+
+    /**
+     * Detect an "already complete" sentinel block in the agent's stdout —
+     * `<<<SPECIFY:already_complete>>>sha1,sha2<<<END>>>` — and return the
+     * flag plus the parsed SHA list. ADR-0007.
+     *
+     * Free-text CLI agents that don't emit the sentinel keep the legacy
+     * no-diff-as-failure path — opt-in, not magic detection.
+     *
+     * @return array{0: bool, 1: list<string>}
+     */
+    private function parseAlreadyCompleteSentinel(string $stdout): array
+    {
+        if (preg_match(
+            '/<<<SPECIFY:already_complete>>>(.*?)<<<END>>>/s',
+            $stdout,
+            $m,
+        ) !== 1) {
+            return [false, []];
+        }
+
+        $shas = array_values(array_filter(
+            array_map('trim', preg_split('/[\s,]+/', $m[1]) ?: []),
+            fn ($sha) => $sha !== '',
+        ));
+
+        return [true, $shas];
     }
 
     /**

--- a/app/Services/Executors/ExecutionResult.php
+++ b/app/Services/Executors/ExecutionResult.php
@@ -20,6 +20,14 @@ class ExecutionResult
      * @param  list<ProposedSubtask>  $proposedSubtasks  Append-only follow-up Subtasks the
      *                                                   executor judges necessary; pipeline
      *                                                   attaches them to the same parent Task.
+     * @param  bool  $alreadyComplete  Agent claims the Subtask's spec is already
+     *                                 satisfied on the working branch — see ADR-0007.
+     *                                 Pipeline only honours this when paired with
+     *                                 a non-empty `alreadyCompleteEvidence` list and
+     *                                 every SHA is reachable from HEAD.
+     * @param  list<string>  $alreadyCompleteEvidence  Commit SHAs on the working branch
+     *                                                 the agent cites as already
+     *                                                 covering the spec.
      */
     public function __construct(
         public string $summary,
@@ -28,6 +36,8 @@ class ExecutionResult
         public ?string $executorLog = null,
         public array $clarifications = [],
         public array $proposedSubtasks = [],
+        public bool $alreadyComplete = false,
+        public array $alreadyCompleteEvidence = [],
     ) {}
 
     /**

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -82,6 +82,11 @@ class LaravelAiExecutor implements Executor
         $commitMessage = trim((string) ($output['commit_message'] ?? ''));
         $clarifications = $this->parseClarifications($output['clarifications'] ?? []);
         $proposedSubtasks = $this->parseProposedSubtasks($output['proposed_subtasks'] ?? []);
+        $alreadyComplete = (bool) ($output['already_complete'] ?? false);
+        $alreadyCompleteEvidence = array_values(array_filter(
+            array_map('strval', (array) ($output['already_complete_evidence'] ?? [])),
+            fn ($sha) => $sha !== '',
+        ));
 
         Log::info('specify.subtask.agent.finished', $context + [
             'duration_ms' => (int) ((microtime(true) - $start) * 1000),
@@ -106,6 +111,8 @@ class LaravelAiExecutor implements Executor
             commitMessage: $commitMessage,
             clarifications: $clarifications,
             proposedSubtasks: $proposedSubtasks,
+            alreadyComplete: $alreadyComplete,
+            alreadyCompleteEvidence: $alreadyCompleteEvidence,
         );
     }
 

--- a/app/Services/SubtaskRunOutcome.php
+++ b/app/Services/SubtaskRunOutcome.php
@@ -24,6 +24,8 @@ class SubtaskRunOutcome
 
     public const STATE_PULL_REQUEST_FAILED = 'pull_request_failed';
 
+    public const STATE_ALREADY_COMPLETE = 'already_complete';
+
     /**
      * @param  array<string, mixed>  $output
      */
@@ -60,12 +62,30 @@ class SubtaskRunOutcome
     }
 
     /**
-     * True for both clean success and the non-fatal `pullRequestFailed`
-     * outcome. The job uses this to choose markSucceeded vs markFailed; only
-     * `noDiff` returns false.
+     * The Subtask's spec was already satisfied on the working branch — agent
+     * produced no diff and cited commit SHAs the pipeline verified are
+     * reachable from HEAD. ADR-0007: Succeeded-class outcome, cascade
+     * advances. The agent's evidence and reason are stamped on `output` for
+     * post-hoc audit.
+     *
+     * @param  array<string, mixed>  $output
+     */
+    public static function alreadyComplete(array $output): self
+    {
+        return new self(self::STATE_ALREADY_COMPLETE, $output, null, null);
+    }
+
+    /**
+     * True for clean success, the non-fatal `pullRequestFailed`, and the
+     * `alreadyComplete` no-op outcome. The job uses this to choose
+     * markSucceeded vs markFailed; only `noDiff` returns false.
      */
     public function isSucceeded(): bool
     {
-        return in_array($this->state, [self::STATE_SUCCEEDED, self::STATE_PULL_REQUEST_FAILED], true);
+        return in_array(
+            $this->state,
+            [self::STATE_SUCCEEDED, self::STATE_PULL_REQUEST_FAILED, self::STATE_ALREADY_COMPLETE],
+            true,
+        );
     }
 }

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -141,6 +141,9 @@ class SubtaskRunPipeline
             }
 
             $reason = 'Agent produced no diff. The subtask was not executed.';
+            if ($result->alreadyComplete) {
+                $reason .= ' Agent claimed already_complete but the cited commit SHAs were empty or not all reachable from HEAD; rejected per ADR-0007.';
+            }
             if ($summary !== '') {
                 $reason .= ' Agent summary: '.$summary;
             }
@@ -218,24 +221,37 @@ class SubtaskRunPipeline
     }
 
     /**
-     * Filter the agent's claimed evidence SHAs down to those that actually
-     * exist on the working branch. Returns the subset reachable from HEAD;
-     * an empty result tells the pipeline to reject the alreadyComplete claim
-     * and fall through to the no_diff failure path. ADR-0007.
+     * Verify that *every* claimed evidence SHA exists on the working branch.
+     *
+     * Returns the trimmed/deduped input list only when all SHAs are
+     * reachable from HEAD; otherwise returns an empty array so the pipeline
+     * rejects the alreadyComplete claim and falls through to the no_diff
+     * failure path (ADR-0007). All-or-nothing — partial evidence (some real
+     * commits + some hallucinated SHAs) is treated the same as no evidence,
+     * because a single hallucinated SHA is enough to make the whole claim
+     * untrustworthy.
      *
      * @param  list<string>  $shas
      * @return list<string>
      */
     private function verifyAlreadyCompleteEvidence(string $workingDir, array $shas): array
     {
-        $verified = [];
-        foreach ($shas as $sha) {
-            if ($this->workspace->isCommitReachableFromHead($workingDir, $sha)) {
-                $verified[] = $sha;
+        $normalized = array_values(array_unique(array_filter(
+            array_map(static fn ($sha) => trim((string) $sha), $shas),
+            static fn ($sha) => $sha !== '',
+        )));
+
+        if ($normalized === []) {
+            return [];
+        }
+
+        foreach ($normalized as $sha) {
+            if (! $this->workspace->isCommitReachableFromHead($workingDir, $sha)) {
+                return [];
             }
         }
 
-        return array_values(array_unique($verified));
+        return $normalized;
     }
 
     /**

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -111,6 +111,35 @@ class SubtaskRunPipeline
 
         if ($commitSha === null) {
             $summary = trim($result->summary);
+
+            // ADR-0007: agent may declare the spec already satisfied on the
+            // working branch. Honour the claim only when paired with commit
+            // SHAs that exist and are reachable from HEAD.
+            if ($result->alreadyComplete) {
+                $verified = $this->verifyAlreadyCompleteEvidence(
+                    $workingDir,
+                    $result->alreadyCompleteEvidence,
+                );
+                if ($verified !== []) {
+                    $output['already_complete'] = true;
+                    $output['already_complete_evidence'] = $verified;
+                    $output['already_complete_reason'] = $summary;
+                    $output['commit_sha'] = null;
+                    $output = $this->applyProposedSubtasks($subtask, $result->proposedSubtasks, $agentRun, $output, $logCtx);
+                    Log::info('specify.subtask.already_complete', $logCtx + [
+                        'summary' => $summary,
+                        'evidence' => $verified,
+                    ]);
+
+                    return SubtaskRunOutcome::alreadyComplete($output);
+                }
+
+                Log::warning('specify.subtask.already_complete.rejected', $logCtx + [
+                    'summary' => $summary,
+                    'evidence_claimed' => $result->alreadyCompleteEvidence,
+                ]);
+            }
+
             $reason = 'Agent produced no diff. The subtask was not executed.';
             if ($summary !== '') {
                 $reason .= ' Agent summary: '.$summary;
@@ -186,6 +215,27 @@ class SubtaskRunPipeline
     private function branchFor(AgentRun $agentRun): string
     {
         return $agentRun->working_branch ?? 'specify/run-'.$agentRun->getKey();
+    }
+
+    /**
+     * Filter the agent's claimed evidence SHAs down to those that actually
+     * exist on the working branch. Returns the subset reachable from HEAD;
+     * an empty result tells the pipeline to reject the alreadyComplete claim
+     * and fall through to the no_diff failure path. ADR-0007.
+     *
+     * @param  list<string>  $shas
+     * @return list<string>
+     */
+    private function verifyAlreadyCompleteEvidence(string $workingDir, array $shas): array
+    {
+        $verified = [];
+        foreach ($shas as $sha) {
+            if ($this->workspace->isCommitReachableFromHead($workingDir, $sha)) {
+                $verified[] = $sha;
+            }
+        }
+
+        return array_values(array_unique($verified));
     }
 
     /**

--- a/app/Services/WorkspaceRunner.php
+++ b/app/Services/WorkspaceRunner.php
@@ -166,6 +166,29 @@ class WorkspaceRunner
         return $diff['stdout'];
     }
 
+    /**
+     * True when `$sha` is a commit reachable from HEAD on the working dir.
+     *
+     * Used by the pipeline to verify "already complete" evidence (ADR-0007):
+     * the agent must cite commits that actually live on the branch, not
+     * arbitrary or hallucinated SHAs.
+     */
+    public function isCommitReachableFromHead(string $workingDir, string $sha): bool
+    {
+        $sha = trim($sha);
+        if ($sha === '' || ! preg_match('/^[0-9a-f]{4,40}$/i', $sha)) {
+            return false;
+        }
+
+        $check = $this->run(
+            ['git', 'merge-base', '--is-ancestor', $sha, 'HEAD'],
+            $workingDir,
+            allowFailure: true,
+        );
+
+        return $check['exitCode'] === 0;
+    }
+
     /** Recursively delete the working directory if it exists. */
     public function cleanup(string $workingDir): void
     {

--- a/docs/adr/0007-already-complete-subtasks.md
+++ b/docs/adr/0007-already-complete-subtasks.md
@@ -1,0 +1,111 @@
+# 0007. Already-complete subtasks
+
+Date: 2026-05-01
+Status: Accepted
+
+## Context
+
+The Subtask pipeline ran an agent against a working copy and treated *no
+diff* as a hard failure: run marked Failed, Subtask flipped to Blocked,
+cascade stalled. That rule was the safety net for an agent that crashed,
+hallucinated, or simply did nothing — without it, an empty diff would
+look like success.
+
+In practice it has another, recurring failure mode: a Subtask whose work
+is *legitimately* already on the branch, bundled into an earlier Subtask's
+commit. The auth-on-mutation-endpoints case (subtask 37 of story 11) was
+the prompting example — the create/update/delete subtasks introduced
+FormRequests with `authorize()` baked in, and by the time subtask 37 ran
+"Enforce manage permission on mutation endpoints" the spec was already
+satisfied. The agent correctly inspected the branch, said "Confirmed:
+already enforces server-side manage authorization," produced no changes,
+and got marked failed. Subtask 28 hit the same pattern earlier on the
+same story.
+
+Treating no-diff as "Done, the spec is met" silently bypasses the only
+human gate (Story approval — ADR-0001) for any Subtask the agent decides
+not to act on. Treating no-diff as "Failed" stalls the cascade on every
+spec-satisfied Subtask. Neither extreme is right.
+
+## Decision
+
+**A no-diff outcome is treated as "already complete" — and so as a
+successful no-op the cascade can advance past — only when the agent
+explicitly declares it AND points at the commit SHAs that cover the
+work. Otherwise, no-diff stays a hard failure.**
+
+Concrete shape:
+
+- `ExecutionResult` gains two fields: `alreadyComplete: bool` (default
+  false) and `alreadyCompleteEvidence: list<string>` (commit SHAs the
+  agent claims cover the spec, default empty).
+- `SubtaskRunOutcome` gains a new state `STATE_ALREADY_COMPLETE` and a
+  factory `alreadyComplete($output)`. It is Succeeded-class —
+  `isSucceeded()` returns true, the queue job routes it to
+  `markSucceeded`, and the Subtask cascade advances.
+- The pipeline accepts the outcome only when **all** of the following
+  hold after the agent runs and `git commit` produces no SHA:
+  - `result->alreadyComplete === true`
+  - `result->alreadyCompleteEvidence !== []`
+  - Every SHA in the evidence list is reachable from `HEAD` on the
+    working branch (`git merge-base --is-ancestor <sha> HEAD`).
+- If any check fails (the agent didn't set the flag, gave no commits,
+  or named a commit that isn't actually on the branch), the run falls
+  through to the existing `noDiff` Failure path. That preserves the
+  safety net for hallucinated or empty agent runs.
+- The agent's evidence list and summary are persisted on
+  `agent_runs.output.already_complete` / `.already_complete_reason`
+  so post-hoc audit can ask: was the agent right?
+- Both executors are wired:
+  - `LaravelAiExecutor` reads the fields directly from the structured
+    output schema (`SubtaskExecutor` adds them).
+  - `CliExecutor` parses a sentinel block in stdout —
+    `<<<SPECIFY:already_complete>>>sha1,sha2<<<END>>>` — emitted by
+    the agent's transcript. Free-text CLI agents that don't emit the
+    sentinel keep the old behaviour (no-diff fails).
+
+## Consequences
+
+### Positive
+
+- The "spec already satisfied" pattern stops blocking the cascade
+  without hand-flipping subtasks in the database.
+- The evidence requirement makes the assertion auditable. A reviewer
+  asking "did this Subtask actually get done?" can `git show <sha>`
+  on the named commits — the agent has to point at *something real*,
+  not just say so.
+- Hallucinated "already done" claims (no commits, or named commits
+  that don't exist on the branch) still fail. The safety net stays.
+
+### Negative
+
+- The agent can still point at commits that don't *actually* cover
+  the spec — only at commits that exist. Evidence proves
+  reachability, not correctness. Mitigation: the PR diff review
+  surface (ADR-0001) is the same place a human reviews any Subtask's
+  changes; the open PR for the parent branch will include the cited
+  commits, and a reviewer reading that diff sees what the agent
+  asserted was already done.
+- CLI executors that don't emit the sentinel keep the old loop. That
+  is intentional — opt-in, not magic detection of free-text claims.
+  Agents that want this affordance must be told to emit the sentinel.
+- `ExecutionResult` grows. Existing executors and tests that
+  construct it without these fields keep working (defaults), so the
+  change is backwards-compatible.
+
+### Neutral
+
+- ADR-0001 is preserved: Story is still the only approval gate. The
+  reviewer's diff-review surface (the PR) shows the cited commits
+  alongside everything else on the branch.
+- ADR-0004 is preserved: the new state is Succeeded-class, like
+  `pullRequestFailed`. Both route to `markSucceeded`.
+
+## Open questions (future work, not blocking)
+
+- Should the evidence requirement be tightened — e.g. the agent must
+  cite at least one commit whose touched files overlap the Subtask's
+  scope? Today reachability-from-HEAD is the only check.
+- Should losing-race siblings inherit each other's "already complete"
+  evidence? (No — they ran on different branches; the evidence list
+  is branch-local.)

--- a/prompts/subtask-executor.md
+++ b/prompts/subtask-executor.md
@@ -48,6 +48,17 @@ structured output and you should use them deliberately:
   surplus is discarded. Use this when you discover required work, not as a
   backlog dumping ground.
 
+If — and only if — the Subtask's spec is **already satisfied on the working
+branch** by commits an earlier Subtask produced, set `already_complete: true`
+and populate `already_complete_evidence` with the relevant commit SHAs (use
+`git log --oneline` via Bash to find them). The orchestrator verifies every
+SHA is reachable from HEAD; if you make this claim with no commits, or with
+SHAs that are not on the branch, the run is marked Failed. Do not use this
+as a way to skip work — only when you have inspected the branch and the
+spec genuinely requires no further changes. Put the explanation in
+`summary` ("Confirmed: X is already done by commit abc1234 ...") so the
+human reviewer can audit your call.
+
 Return a structured summary of what was done. List each file you touched
 (use the same paths you passed to write/edit). Provide a one-line commit
 message in conventional-commit form (e.g. "feat: add CSV export endpoint").

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -331,6 +331,72 @@ test('alreadyComplete falls through to noDiff when evidence is empty (ADR-0007 s
     expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_NO_DIFF);
 });
 
+test('alreadyComplete falls through to noDiff when ANY cited SHA is unreachable, even if others verify (ADR-0007 all-or-nothing)', function () {
+    $task = makeApprovedTask();
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'partial-claim', 'position' => 1]);
+    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->getKey(),
+        'repo_id' => $repo->getKey(),
+        'working_branch' => 'specify/test',
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $executor = new class implements Executor
+    {
+        public function needsWorkingDirectory(): bool
+        {
+            return true;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        {
+            return new ExecutionResult(
+                summary: 'One real, one made up',
+                filesChanged: [],
+                commitMessage: 'noop',
+                alreadyComplete: true,
+                alreadyCompleteEvidence: ['abc1234', 'deadbeef'],
+            );
+        }
+    };
+
+    $workspace = new class extends WorkspaceRunner
+    {
+        public function __construct() {}
+
+        public function prepare(Repo $repo, AgentRun $run): string
+        {
+            return sys_get_temp_dir();
+        }
+
+        public function checkoutBranch(string $workingDir, string $branch, ?string $baseBranch = null): void {}
+
+        public function commit(string $workingDir, string $message): ?string
+        {
+            return null;
+        }
+
+        public function diff(string $workingDir, ?string $base = null): string
+        {
+            return '';
+        }
+
+        public function isCommitReachableFromHead(string $workingDir, string $sha): bool
+        {
+            return $sha === 'abc1234';
+        }
+    };
+
+    $pipeline = new SubtaskRunPipeline($executor, $workspace, app(PlanWriter::class), new NullContextBuilder);
+    $outcome = $pipeline->run($run);
+
+    expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_NO_DIFF)
+        ->and($outcome->error)->toContain('already_complete')
+        ->and($outcome->error)->toContain('not all reachable');
+});
+
 test('alreadyComplete falls through to noDiff when none of the cited SHAs are reachable (ADR-0007 safety net)', function () {
     $task = makeApprovedTask();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'hallucinated', 'position' => 1]);

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -11,6 +11,7 @@ use App\Models\Subtask;
 use App\Models\Task;
 use App\Services\Context\ContextBuilder;
 use App\Services\Context\NullContextBuilder;
+use App\Services\Executors\CliExecutor;
 use App\Services\Executors\ExecutionResult;
 use App\Services\Executors\Executor;
 use App\Services\Executors\ExecutorClarification;
@@ -196,6 +197,225 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
 
     expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_NO_DIFF)
         ->and($afterCount)->toBe($beforeCount);
+});
+
+test('alreadyComplete returns the Succeeded-class outcome when evidence SHAs are reachable from HEAD (ADR-0007)', function () {
+    $task = makeApprovedTask();
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'already-done', 'position' => 1]);
+    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->getKey(),
+        'repo_id' => $repo->getKey(),
+        'working_branch' => 'specify/test',
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $executor = new class implements Executor
+    {
+        public function needsWorkingDirectory(): bool
+        {
+            return true;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        {
+            return new ExecutionResult(
+                summary: 'Confirmed already done by abc1234',
+                filesChanged: [],
+                commitMessage: 'noop',
+                alreadyComplete: true,
+                alreadyCompleteEvidence: ['abc1234', 'def5678'],
+            );
+        }
+    };
+
+    $workspace = new class extends WorkspaceRunner
+    {
+        public function __construct() {}
+
+        public function prepare(Repo $repo, AgentRun $run): string
+        {
+            return sys_get_temp_dir();
+        }
+
+        public function checkoutBranch(string $workingDir, string $branch, ?string $baseBranch = null): void {}
+
+        public function commit(string $workingDir, string $message): ?string
+        {
+            return null;
+        }
+
+        public function diff(string $workingDir, ?string $base = null): string
+        {
+            return '';
+        }
+
+        public function isCommitReachableFromHead(string $workingDir, string $sha): bool
+        {
+            return in_array($sha, ['abc1234', 'def5678'], true);
+        }
+    };
+
+    $pipeline = new SubtaskRunPipeline($executor, $workspace, app(PlanWriter::class), new NullContextBuilder);
+    $outcome = $pipeline->run($run);
+
+    expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_ALREADY_COMPLETE)
+        ->and($outcome->isSucceeded())->toBeTrue()
+        ->and($outcome->output['already_complete'] ?? null)->toBeTrue()
+        ->and($outcome->output['already_complete_evidence'] ?? [])->toBe(['abc1234', 'def5678'])
+        ->and($outcome->output['already_complete_reason'] ?? null)->toContain('Confirmed');
+});
+
+test('alreadyComplete falls through to noDiff when evidence is empty (ADR-0007 safety net)', function () {
+    $task = makeApprovedTask();
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'sus-claim', 'position' => 1]);
+    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->getKey(),
+        'repo_id' => $repo->getKey(),
+        'working_branch' => 'specify/test',
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $executor = new class implements Executor
+    {
+        public function needsWorkingDirectory(): bool
+        {
+            return true;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        {
+            return new ExecutionResult(
+                summary: 'I swear it is already done',
+                filesChanged: [],
+                commitMessage: 'noop',
+                alreadyComplete: true,
+                alreadyCompleteEvidence: [],
+            );
+        }
+    };
+
+    $workspace = new class extends WorkspaceRunner
+    {
+        public function __construct() {}
+
+        public function prepare(Repo $repo, AgentRun $run): string
+        {
+            return sys_get_temp_dir();
+        }
+
+        public function checkoutBranch(string $workingDir, string $branch, ?string $baseBranch = null): void {}
+
+        public function commit(string $workingDir, string $message): ?string
+        {
+            return null;
+        }
+
+        public function diff(string $workingDir, ?string $base = null): string
+        {
+            return '';
+        }
+
+        public function isCommitReachableFromHead(string $workingDir, string $sha): bool
+        {
+            return false;
+        }
+    };
+
+    $pipeline = new SubtaskRunPipeline($executor, $workspace, app(PlanWriter::class), new NullContextBuilder);
+    $outcome = $pipeline->run($run);
+
+    expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_NO_DIFF);
+});
+
+test('alreadyComplete falls through to noDiff when none of the cited SHAs are reachable (ADR-0007 safety net)', function () {
+    $task = makeApprovedTask();
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'hallucinated', 'position' => 1]);
+    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->getKey(),
+        'repo_id' => $repo->getKey(),
+        'working_branch' => 'specify/test',
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $executor = new class implements Executor
+    {
+        public function needsWorkingDirectory(): bool
+        {
+            return true;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        {
+            return new ExecutionResult(
+                summary: 'Done in commit deadbeef',
+                filesChanged: [],
+                commitMessage: 'noop',
+                alreadyComplete: true,
+                alreadyCompleteEvidence: ['deadbeef'],
+            );
+        }
+    };
+
+    $workspace = new class extends WorkspaceRunner
+    {
+        public function __construct() {}
+
+        public function prepare(Repo $repo, AgentRun $run): string
+        {
+            return sys_get_temp_dir();
+        }
+
+        public function checkoutBranch(string $workingDir, string $branch, ?string $baseBranch = null): void {}
+
+        public function commit(string $workingDir, string $message): ?string
+        {
+            return null;
+        }
+
+        public function diff(string $workingDir, ?string $base = null): string
+        {
+            return '';
+        }
+
+        public function isCommitReachableFromHead(string $workingDir, string $sha): bool
+        {
+            return false;
+        }
+    };
+
+    $pipeline = new SubtaskRunPipeline($executor, $workspace, app(PlanWriter::class), new NullContextBuilder);
+    $outcome = $pipeline->run($run);
+
+    expect($outcome->state)->toBe(SubtaskRunOutcome::STATE_NO_DIFF);
+});
+
+test('CliExecutor parses the already_complete sentinel out of stdout', function () {
+    $stdout = "doing some work\nlooks fine\n<<<SPECIFY:already_complete>>>abc1234, def5678\n9012345<<<END>>>\nbye\n";
+    $reflection = new ReflectionMethod(CliExecutor::class, 'parseAlreadyCompleteSentinel');
+    $reflection->setAccessible(true);
+
+    $exec = new CliExecutor(['true']);
+    [$flag, $shas] = $reflection->invoke($exec, $stdout);
+
+    expect($flag)->toBeTrue()
+        ->and($shas)->toBe(['abc1234', 'def5678', '9012345']);
+});
+
+test('CliExecutor returns false/empty when the sentinel is absent', function () {
+    $reflection = new ReflectionMethod(CliExecutor::class, 'parseAlreadyCompleteSentinel');
+    $reflection->setAccessible(true);
+
+    $exec = new CliExecutor(['true']);
+    [$flag, $shas] = $reflection->invoke($exec, "ordinary agent output\nno sentinel here\n");
+
+    expect($flag)->toBeFalse()
+        ->and($shas)->toBe([]);
 });
 
 test('context_brief is persisted on AgentRun.output even when the run ends in noDiff', function () {


### PR DESCRIPTION
## Summary

- Spec-satisfied Subtasks (work bundled into an earlier Subtask's commit) were silently stalling the cascade — agent says "already implemented", no diff, run marked Failed, Subtask flipped Blocked. Hit twice in a row on story 11.
- Add an explicit, evidence-backed signal: `alreadyComplete: true` + `alreadyCompleteEvidence: list<sha>`. Pipeline accepts only when every cited SHA is reachable from HEAD; otherwise falls through to existing no_diff failure (safety net intact).
- New Succeeded-class outcome state `STATE_ALREADY_COMPLETE`. Cascade advances. `output.already_complete*` persisted for audit.
- LaravelAiExecutor reads from the structured schema. CliExecutor parses a `<<<SPECIFY:already_complete>>>sha,sha<<<END>>>` sentinel — opt-in.
- ADR-0007 documents the design + the open question on whether evidence should also prove file overlap with the Subtask scope.

## Test plan

- [x] `composer test` — 254/254 (5 new tests cover happy path, empty evidence, unreachable SHA, sentinel parsed, sentinel absent)
- [ ] Run a real Subtask through `cli` driver where the agent emits the sentinel and verify the run lands Succeeded with evidence persisted on `agent_runs.output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)