### PR TITLE
feat: ADR-0008 — PR review feedback closes the loop via webhooks

### DIFF
--- a/app/Ai/Agents/ReviewResponder.php
+++ b/app/Ai/Agents/ReviewResponder.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use App\Ai\Tools\Bash;
+use App\Ai\Tools\EditFile;
+use App\Ai\Tools\Find;
+use App\Ai\Tools\Grep;
+use App\Ai\Tools\LoggedTool;
+use App\Ai\Tools\Ls;
+use App\Ai\Tools\ReadFile;
+use App\Ai\Tools\Sandbox;
+use App\Ai\Tools\WriteFile;
+use App\Models\Subtask;
+use App\Services\Prompts\PromptLoader;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Attributes\UseSmartestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+use RuntimeException;
+
+/**
+ * Sibling of `SubtaskExecutor` for the review-response loop (ADR-0008).
+ *
+ * Same tool box, different prompt + structured output. Where SubtaskExecutor
+ * implements a Subtask spec from scratch, ReviewResponder is given the
+ * already-existing branch state plus the open review comments and is asked
+ * to push a focused `fix(review):` change for each comment (or push back
+ * via `clarifications`).
+ */
+#[Provider(Lab::Anthropic)]
+#[UseSmartestModel]
+#[MaxSteps(40)]
+#[MaxTokens(4096)]
+class ReviewResponder implements Agent, HasStructuredOutput, HasTools
+{
+    use Promptable;
+
+    /**
+     * @param  list<array{path: ?string, line: ?int, body: string, author: ?string}>  $comments
+     */
+    public function __construct(
+        public Subtask $subtask,
+        public int $pullRequestNumber,
+        public string $reviewSummary,
+        public array $comments,
+        public ?string $workingBranch = null,
+        public ?string $workingDir = null,
+    ) {}
+
+    public function tools(): iterable
+    {
+        if ($this->workingDir === null) {
+            throw new RuntimeException(
+                'ReviewResponder::tools() called without a working directory. '
+                .'The job that constructed this agent must set workingDir.'
+            );
+        }
+
+        $sandbox = new Sandbox($this->workingDir);
+        $context = [
+            'subtask_id' => $this->subtask->getKey(),
+            'pull_request_number' => $this->pullRequestNumber,
+            'branch' => $this->workingBranch,
+        ];
+
+        return collect([
+            new ReadFile($sandbox),
+            new WriteFile($sandbox),
+            new EditFile($sandbox),
+            new Bash($sandbox),
+            new Grep($sandbox),
+            new Find($sandbox),
+            new Ls($sandbox),
+        ])->map(fn ($tool) => new LoggedTool($tool, $context))->all();
+    }
+
+    public function instructions(): string
+    {
+        return app(PromptLoader::class)->load('review-responder');
+    }
+
+    public function buildPrompt(): string
+    {
+        $subtask = $this->subtask->loadMissing('task.story.feature.project', 'task.acceptanceCriterion');
+        $task = $subtask->task;
+        $story = $task?->story;
+        $criterion = $task?->acceptanceCriterion?->criterion;
+
+        $criterionBlock = $criterion ? "Acceptance Criterion: {$criterion}\n\n" : '';
+        $taskBlock = $task ? "Parent Task #{$task->position}: {$task->name}\n" : '';
+
+        $reviewBlock = trim($this->reviewSummary) === ''
+            ? "Review summary: (none)\n"
+            : "Review summary:\n{$this->reviewSummary}\n";
+
+        $commentBlocks = [];
+        foreach ($this->comments as $i => $c) {
+            $where = $c['path'] !== null
+                ? "{$c['path']}".($c['line'] !== null ? ":{$c['line']}" : '')
+                : '(general comment)';
+            $author = $c['author'] !== null && $c['author'] !== '' ? " by @{$c['author']}" : '';
+            $commentBlocks[] = 'Comment '.($i + 1)." — {$where}{$author}:\n{$c['body']}";
+        }
+        $commentCount = count($this->comments);
+        $commentsRendered = $commentBlocks === []
+            ? '(no inline comments)'
+            : implode("\n\n", $commentBlocks);
+
+        return <<<PROMPT
+Story: {$story?->name}
+
+Description:
+{$story?->description}
+
+{$criterionBlock}{$taskBlock}Subtask #{$subtask->position}: {$subtask->name}
+
+Subtask description:
+{$subtask->description}
+
+Working branch: {$this->workingBranch}
+Open Pull Request: #{$this->pullRequestNumber}
+
+{$reviewBlock}
+Review comments to address ({$commentCount}):
+{$commentsRendered}
+
+Address each comment in code, then return your structured summary.
+PROMPT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'summary' => $schema->string()->required(),
+            'files_changed' => $schema->array()
+                ->items($schema->string())
+                ->required(),
+            'commit_message' => $schema->string()->required(),
+            'clarifications' => $schema->array()
+                ->items(
+                    $schema->object(fn ($schema) => [
+                        'kind' => $schema->string()
+                            ->enum(['ambiguity', 'conflict', 'missing-context', 'disagreement'])
+                            ->required(),
+                        'message' => $schema->string()->required(),
+                        'proposed' => $schema->string(),
+                    ])
+                ),
+        ];
+    }
+}

--- a/app/Enums/AgentRunKind.php
+++ b/app/Enums/AgentRunKind.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * What an AgentRun is for.
+ *
+ * `Execute` is the historical default — a Subtask AgentRun that produces a
+ * diff for the Subtask's spec, commits, pushes, and opens a PR. The cascade
+ * gate (`finalizeSubtaskFromRun`) decides Subtask status from terminal
+ * states of `Execute` runs.
+ *
+ * `RespondToReview` is the webhook-driven flavour (ADR-0008): a Subtask is
+ * already Done, its PR has open review comments, and a fresh AgentRun
+ * dispatches the `ReviewResponder` agent to push a `fix(review):` commit on
+ * the same branch. The cascade gate **ignores** RespondToReview runs —
+ * review responses don't change Subtask status. The cap on cycles per PR
+ * lives on the `repos` row.
+ */
+enum AgentRunKind: string
+{
+    case Execute = 'execute';
+    case RespondToReview = 'respond_to_review';
+}

--- a/app/Http/Controllers/Webhooks/GithubWebhookController.php
+++ b/app/Http/Controllers/Webhooks/GithubWebhookController.php
@@ -3,12 +3,12 @@
 namespace App\Http\Controllers\Webhooks;
 
 use App\Enums\AgentRunKind;
-use App\Enums\AgentRunStatus;
 use App\Http\Controllers\Controller;
-use App\Jobs\RespondToPrReviewJob;
 use App\Models\AgentRun;
 use App\Models\Repo;
 use App\Models\WebhookEvent;
+use App\Services\ExecutionService;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -19,15 +19,24 @@ use Illuminate\Http\Request;
  *   - `pull_request` — stamp lifecycle state (opened/closed/merged) onto the
  *     originating AgentRun's `output`.
  *   - `pull_request_review` / `pull_request_review_comment` — when the repo
- *     opted into automatic review responses, dispatch a `RespondToPrReviewJob`
- *     that creates a new `RespondToReview` AgentRun and pushes a fix on the
- *     originating Subtask's branch (ADR-0008).
+ *     opted into automatic review responses, ask `ExecutionService` to
+ *     dispatch a RespondToReview run that pushes a fix on the originating
+ *     Subtask's branch (ADR-0008). All AgentRun creation / cycle-cap /
+ *     race-safety lives in `ExecutionService::dispatchReviewResponse`.
  *
- * Idempotency is enforced via the `webhook_events.delivery_id` unique index:
- * a duplicate `X-GitHub-Delivery` is acked once and ignored on retry.
+ * Order of operations: signature validation runs FIRST. Idempotency on
+ * `X-GitHub-Delivery` only applies to signature-valid requests, so an
+ * unauthenticated caller cannot pre-poison or replay a delivery_id.
+ *
+ * Concurrent identical deliveries are de-duped via the
+ * `webhook_events.delivery_id` unique index — the first request lands the
+ * row; the second hits a unique-constraint violation that we catch and
+ * convert into a `{duplicate: true}` response.
  */
 class GithubWebhookController extends Controller
 {
+    public function __construct(public ExecutionService $execution) {}
+
     public function __invoke(Request $request, Repo $repo): JsonResponse
     {
         $secret = $repo->webhook_secret;
@@ -40,25 +49,43 @@ class GithubWebhookController extends Controller
         $payload = $request->json()->all();
         $action = $payload['action'] ?? null;
 
-        if ($deliveryId !== null) {
-            $existing = WebhookEvent::where('delivery_id', $deliveryId)->first();
-            if ($existing !== null) {
-                return response()->json(['duplicate' => true, 'event_id' => $existing->getKey()]);
-            }
+        if (! $signatureValid) {
+            // Persist invalid-signature attempts for audit, but with a NULL
+            // delivery_id so an attacker cannot occupy the unique slot for a
+            // legitimate later delivery with the same X-GitHub-Delivery.
+            WebhookEvent::create([
+                'repo_id' => $repo->getKey(),
+                'provider' => 'github',
+                'event' => $event,
+                'action' => $action,
+                'delivery_id' => null,
+                'signature_valid' => false,
+                'payload' => $payload,
+            ]);
+
+            return response()->json(['error' => 'invalid signature'], 401);
         }
 
-        $log = WebhookEvent::create([
-            'repo_id' => $repo->getKey(),
-            'provider' => 'github',
-            'event' => $event,
-            'action' => $action,
-            'delivery_id' => $deliveryId,
-            'signature_valid' => $signatureValid,
-            'payload' => $payload,
-        ]);
+        try {
+            $log = WebhookEvent::create([
+                'repo_id' => $repo->getKey(),
+                'provider' => 'github',
+                'event' => $event,
+                'action' => $action,
+                'delivery_id' => $deliveryId,
+                'signature_valid' => true,
+                'payload' => $payload,
+            ]);
+        } catch (QueryException $e) {
+            // Race / retry: the unique index on delivery_id rejected this
+            // insert because a sibling request just landed the same delivery.
+            if ($deliveryId !== null && $this->isUniqueConstraintViolation($e)) {
+                $existing = WebhookEvent::where('delivery_id', $deliveryId)->first();
 
-        if (! $signatureValid) {
-            return response()->json(['error' => 'invalid signature'], 401);
+                return response()->json(['duplicate' => true, 'event_id' => $existing?->getKey()]);
+            }
+
+            throw $e;
         }
 
         return match ($event) {
@@ -128,51 +155,34 @@ class GithubWebhookController extends Controller
             return response()->json(['ignored' => true]);
         }
 
-        $run = $this->originatingRun($repo, (int) $number);
-        if ($run === null) {
+        $origin = $this->originatingRun($repo, (int) $number);
+        if ($origin === null) {
             return response()->json(['matched' => false]);
         }
 
-        $log->forceFill(['matched_run_id' => $run->getKey()])->save();
+        $log->forceFill(['matched_run_id' => $origin->getKey()])->save();
 
-        if (! $repo->review_response_enabled) {
-            return response()->json(['matched' => true, 'dispatched' => false, 'reason' => 'review_response_disabled']);
-        }
+        $result = $this->execution->dispatchReviewResponse($repo, $origin, (int) $number);
 
-        $cycles = AgentRun::query()
-            ->where('repo_id', $repo->getKey())
-            ->where('kind', AgentRunKind::RespondToReview->value)
-            ->whereJsonContains('output->pull_request_number', (int) $number)
-            ->count();
-
-        if ($cycles >= ($repo->max_review_response_cycles ?? 3)) {
-            return response()->json([
+        return match ($result['status']) {
+            'dispatched' => response()->json([
+                'matched' => true,
+                'dispatched' => true,
+                'run_id' => $result['run']->getKey(),
+                'cycle' => $result['cycle'],
+            ]),
+            'review_response_disabled' => response()->json([
+                'matched' => true,
+                'dispatched' => false,
+                'reason' => 'review_response_disabled',
+            ]),
+            'max_cycles_reached' => response()->json([
                 'matched' => true,
                 'dispatched' => false,
                 'reason' => 'max_cycles_reached',
-                'cycles' => $cycles,
-            ]);
-        }
-
-        $newRun = AgentRun::create([
-            'runnable_type' => $run->runnable_type,
-            'runnable_id' => $run->runnable_id,
-            'repo_id' => $repo->getKey(),
-            'working_branch' => $run->working_branch,
-            'executor_driver' => $run->executor_driver,
-            'kind' => AgentRunKind::RespondToReview->value,
-            'status' => AgentRunStatus::Queued->value,
-            'output' => ['pull_request_number' => (int) $number, 'origin_run_id' => $run->getKey()],
-        ]);
-
-        RespondToPrReviewJob::dispatch($newRun->getKey());
-
-        return response()->json([
-            'matched' => true,
-            'dispatched' => true,
-            'run_id' => $newRun->getKey(),
-            'cycle' => $cycles + 1,
-        ]);
+                'cycles' => $result['cycles'],
+            ]),
+        };
     }
 
     private function originatingRun(Repo $repo, int $number): ?AgentRun
@@ -194,5 +204,25 @@ class GithubWebhookController extends Controller
         $expected = 'sha256='.hash_hmac('sha256', $body, $secret);
 
         return hash_equals($expected, $header);
+    }
+
+    /**
+     * SQLite/MySQL/Postgres all surface unique-constraint violations slightly
+     * differently — match on the SQLSTATE code (23000 / 23505) and on the
+     * driver-specific message hint. Any of these signals is enough to treat
+     * the failure as a benign duplicate-delivery race.
+     */
+    private function isUniqueConstraintViolation(QueryException $e): bool
+    {
+        $code = (string) $e->getCode();
+        if (in_array($code, ['23000', '23505'], true)) {
+            return true;
+        }
+
+        $message = $e->getMessage();
+
+        return str_contains($message, 'UNIQUE constraint failed')
+            || str_contains($message, 'Duplicate entry')
+            || str_contains($message, 'duplicate key value');
     }
 }

--- a/app/Http/Controllers/Webhooks/GithubWebhookController.php
+++ b/app/Http/Controllers/Webhooks/GithubWebhookController.php
@@ -2,13 +2,30 @@
 
 namespace App\Http\Controllers\Webhooks;
 
+use App\Enums\AgentRunKind;
+use App\Enums\AgentRunStatus;
 use App\Http\Controllers\Controller;
+use App\Jobs\RespondToPrReviewJob;
 use App\Models\AgentRun;
 use App\Models\Repo;
 use App\Models\WebhookEvent;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
+/**
+ * Receives GitHub webhooks for a `Repo` and reacts to `pull_request*`
+ * events. Two paths today:
+ *
+ *   - `pull_request` — stamp lifecycle state (opened/closed/merged) onto the
+ *     originating AgentRun's `output`.
+ *   - `pull_request_review` / `pull_request_review_comment` — when the repo
+ *     opted into automatic review responses, dispatch a `RespondToPrReviewJob`
+ *     that creates a new `RespondToReview` AgentRun and pushes a fix on the
+ *     originating Subtask's branch (ADR-0008).
+ *
+ * Idempotency is enforced via the `webhook_events.delivery_id` unique index:
+ * a duplicate `X-GitHub-Delivery` is acked once and ignored on retry.
+ */
 class GithubWebhookController extends Controller
 {
     public function __invoke(Request $request, Repo $repo): JsonResponse
@@ -19,14 +36,23 @@ class GithubWebhookController extends Controller
             && $this->signatureValid($request->getContent(), $signature, $secret);
 
         $event = $request->header('X-GitHub-Event', 'unknown');
+        $deliveryId = $request->header('X-GitHub-Delivery') ?: null;
         $payload = $request->json()->all();
         $action = $payload['action'] ?? null;
+
+        if ($deliveryId !== null) {
+            $existing = WebhookEvent::where('delivery_id', $deliveryId)->first();
+            if ($existing !== null) {
+                return response()->json(['duplicate' => true, 'event_id' => $existing->getKey()]);
+            }
+        }
 
         $log = WebhookEvent::create([
             'repo_id' => $repo->getKey(),
             'provider' => 'github',
             'event' => $event,
             'action' => $action,
+            'delivery_id' => $deliveryId,
             'signature_valid' => $signatureValid,
             'payload' => $payload,
         ]);
@@ -35,22 +61,22 @@ class GithubWebhookController extends Controller
             return response()->json(['error' => 'invalid signature'], 401);
         }
 
-        if ($event !== 'pull_request') {
-            return response()->json(['ignored' => true]);
-        }
+        return match ($event) {
+            'pull_request' => $this->handlePullRequest($repo, $payload, $action, $log),
+            'pull_request_review' => $this->handleReview($repo, $payload, $action, $log),
+            'pull_request_review_comment' => $this->handleReviewComment($repo, $payload, $action, $log),
+            default => response()->json(['ignored' => true]),
+        };
+    }
 
+    private function handlePullRequest(Repo $repo, array $payload, ?string $action, WebhookEvent $log): JsonResponse
+    {
         $number = $payload['pull_request']['number'] ?? null;
-
         if ($number === null) {
             return response()->json(['ignored' => true]);
         }
 
-        $run = AgentRun::query()
-            ->where('repo_id', $repo->getKey())
-            ->whereJsonContains('output->pull_request_number', (int) $number)
-            ->latest('id')
-            ->first();
-
+        $run = $this->originatingRun($repo, (int) $number);
         if ($run === null) {
             return response()->json(['matched' => false]);
         }
@@ -68,6 +94,95 @@ class GithubWebhookController extends Controller
         $log->forceFill(['matched_run_id' => $run->getKey()])->save();
 
         return response()->json(['matched' => true, 'run_id' => $run->getKey()]);
+    }
+
+    private function handleReview(Repo $repo, array $payload, ?string $action, WebhookEvent $log): JsonResponse
+    {
+        if ($action !== 'submitted') {
+            return response()->json(['ignored' => true]);
+        }
+
+        $review = $payload['review'] ?? [];
+        $hasComments = trim((string) ($review['body'] ?? '')) !== ''
+            || ! in_array($review['state'] ?? '', ['approved'], true);
+        if (! $hasComments) {
+            return response()->json(['ignored' => true]);
+        }
+
+        return $this->dispatchReviewResponse($repo, $payload, $log);
+    }
+
+    private function handleReviewComment(Repo $repo, array $payload, ?string $action, WebhookEvent $log): JsonResponse
+    {
+        if ($action !== 'created') {
+            return response()->json(['ignored' => true]);
+        }
+
+        return $this->dispatchReviewResponse($repo, $payload, $log);
+    }
+
+    private function dispatchReviewResponse(Repo $repo, array $payload, WebhookEvent $log): JsonResponse
+    {
+        $number = $payload['pull_request']['number'] ?? null;
+        if ($number === null) {
+            return response()->json(['ignored' => true]);
+        }
+
+        $run = $this->originatingRun($repo, (int) $number);
+        if ($run === null) {
+            return response()->json(['matched' => false]);
+        }
+
+        $log->forceFill(['matched_run_id' => $run->getKey()])->save();
+
+        if (! $repo->review_response_enabled) {
+            return response()->json(['matched' => true, 'dispatched' => false, 'reason' => 'review_response_disabled']);
+        }
+
+        $cycles = AgentRun::query()
+            ->where('repo_id', $repo->getKey())
+            ->where('kind', AgentRunKind::RespondToReview->value)
+            ->whereJsonContains('output->pull_request_number', (int) $number)
+            ->count();
+
+        if ($cycles >= ($repo->max_review_response_cycles ?? 3)) {
+            return response()->json([
+                'matched' => true,
+                'dispatched' => false,
+                'reason' => 'max_cycles_reached',
+                'cycles' => $cycles,
+            ]);
+        }
+
+        $newRun = AgentRun::create([
+            'runnable_type' => $run->runnable_type,
+            'runnable_id' => $run->runnable_id,
+            'repo_id' => $repo->getKey(),
+            'working_branch' => $run->working_branch,
+            'executor_driver' => $run->executor_driver,
+            'kind' => AgentRunKind::RespondToReview->value,
+            'status' => AgentRunStatus::Queued->value,
+            'output' => ['pull_request_number' => (int) $number, 'origin_run_id' => $run->getKey()],
+        ]);
+
+        RespondToPrReviewJob::dispatch($newRun->getKey());
+
+        return response()->json([
+            'matched' => true,
+            'dispatched' => true,
+            'run_id' => $newRun->getKey(),
+            'cycle' => $cycles + 1,
+        ]);
+    }
+
+    private function originatingRun(Repo $repo, int $number): ?AgentRun
+    {
+        return AgentRun::query()
+            ->where('repo_id', $repo->getKey())
+            ->where('kind', AgentRunKind::Execute->value)
+            ->whereJsonContains('output->pull_request_number', $number)
+            ->latest('id')
+            ->first();
     }
 
     private function signatureValid(string $body, string $header, string $secret): bool

--- a/app/Jobs/RespondToPrReviewJob.php
+++ b/app/Jobs/RespondToPrReviewJob.php
@@ -11,6 +11,7 @@ use App\Services\Reviews\ReviewCommentsFetcher;
 use App\Services\WorkspaceRunner;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
 use Throwable;
@@ -22,6 +23,15 @@ use Throwable;
  * branch, fetches the open review comments via the GitHub API, hands off
  * to the `ReviewResponder` agent, commits + pushes a `fix(review):` change.
  * Does not open a PR — the PR is already open.
+ *
+ * Concurrency: review webhooks for the same PR can fire close together (a
+ * burst of inline comments arrive in seconds). Two RespondToPrReviewJob's
+ * for the same repo+branch share the on-disk working dir
+ * (`WorkspaceRunner::workingDirFor` is story-scoped) and would otherwise
+ * race on `checkoutBranch` / `commit` / `push`. We serialise via a
+ * `Cache::lock` keyed by repo+branch — the second job blocks (up to 5
+ * minutes) until the first releases, then runs against the freshly-pushed
+ * tree.
  */
 class RespondToPrReviewJob implements ShouldQueue
 {
@@ -62,69 +72,73 @@ class RespondToPrReviewJob implements ShouldQueue
             'branch' => $branch,
         ];
 
+        $lockKey = sprintf('specify:review-response:%d:%s', $repo->getKey(), $branch);
+
         try {
-            $workingDir = $workspace->prepare($repo, $run);
-            $workspace->checkoutBranch($workingDir, $branch, baseBranch: $repo->default_branch);
-            Log::info('specify.review_response.workspace.ready', $logCtx + ['working_dir' => $workingDir]);
+            Cache::lock($lockKey, 1800)->block(300, function () use ($run, $repo, $branch, $prNumber, $subtask, $execution, $workspace, $fetcher, $logCtx) {
+                $workingDir = $workspace->prepare($repo, $run);
+                $workspace->checkoutBranch($workingDir, $branch, baseBranch: $repo->default_branch);
+                Log::info('specify.review_response.workspace.ready', $logCtx + ['working_dir' => $workingDir]);
 
-            [$reviewSummary, $comments] = $fetcher->fetch($repo, $prNumber);
-            Log::info('specify.review_response.comments.fetched', $logCtx + [
-                'comment_count' => count($comments),
-            ]);
-
-            if ($comments === [] && trim($reviewSummary) === '') {
-                $execution->markSucceeded($run, [
-                    'pull_request_number' => $prNumber,
-                    'no_review_content' => true,
-                ], null);
-                Log::info('specify.review_response.empty', $logCtx);
-
-                return;
-            }
-
-            $agent = new ReviewResponder(
-                subtask: $subtask,
-                pullRequestNumber: $prNumber,
-                reviewSummary: $reviewSummary,
-                comments: $comments,
-                workingBranch: $branch,
-                workingDir: $workingDir,
-            );
-
-            $output = $agent->run()->structured();
-
-            $clarifications = (array) ($output['clarifications'] ?? []);
-            $summary = trim((string) ($output['summary'] ?? ''));
-            $commitMessage = trim((string) ($output['commit_message'] ?? '')) ?: "fix(review): address PR #{$prNumber} review";
-
-            $commitSha = $workspace->commit($workingDir, $commitMessage);
-            $diff = $workspace->diff($workingDir);
-
-            $payload = [
-                'pull_request_number' => $prNumber,
-                'origin_run_id' => (int) ($run->output['origin_run_id'] ?? 0),
-                'summary' => $summary,
-                'files_changed' => array_values((array) ($output['files_changed'] ?? [])),
-                'commit_message' => $commitMessage,
-                'commit_sha' => $commitSha,
-                'clarifications' => $clarifications,
-                'review_comment_count' => count($comments),
-            ];
-
-            if ($commitSha === null) {
-                Log::info('specify.review_response.no_diff', $logCtx + [
-                    'clarifications' => count($clarifications),
+                [$reviewSummary, $comments] = $fetcher->fetch($repo, $prNumber);
+                Log::info('specify.review_response.comments.fetched', $logCtx + [
+                    'comment_count' => count($comments),
                 ]);
-                $execution->markSucceeded($run, $payload, null);
 
-                return;
-            }
+                if ($comments === [] && trim($reviewSummary) === '') {
+                    $execution->markSucceeded($run, [
+                        'pull_request_number' => $prNumber,
+                        'no_review_content' => true,
+                    ], null);
+                    Log::info('specify.review_response.empty', $logCtx);
 
-            $workspace->push($workingDir, $branch);
-            $payload['pushed'] = true;
-            Log::info('specify.review_response.pushed', $logCtx + ['commit_sha' => $commitSha]);
+                    return;
+                }
 
-            $execution->markSucceeded($run, $payload, $diff);
+                $agent = new ReviewResponder(
+                    subtask: $subtask,
+                    pullRequestNumber: $prNumber,
+                    reviewSummary: $reviewSummary,
+                    comments: $comments,
+                    workingBranch: $branch,
+                    workingDir: $workingDir,
+                );
+
+                $output = $agent->run()->structured();
+
+                $clarifications = (array) ($output['clarifications'] ?? []);
+                $summary = trim((string) ($output['summary'] ?? ''));
+                $commitMessage = trim((string) ($output['commit_message'] ?? '')) ?: "fix(review): address PR #{$prNumber} review";
+
+                $commitSha = $workspace->commit($workingDir, $commitMessage);
+                $diff = $workspace->diff($workingDir);
+
+                $payload = [
+                    'pull_request_number' => $prNumber,
+                    'origin_run_id' => (int) ($run->output['origin_run_id'] ?? 0),
+                    'summary' => $summary,
+                    'files_changed' => array_values((array) ($output['files_changed'] ?? [])),
+                    'commit_message' => $commitMessage,
+                    'commit_sha' => $commitSha,
+                    'clarifications' => $clarifications,
+                    'review_comment_count' => count($comments),
+                ];
+
+                if ($commitSha === null) {
+                    Log::info('specify.review_response.no_diff', $logCtx + [
+                        'clarifications' => count($clarifications),
+                    ]);
+                    $execution->markSucceeded($run, $payload, null);
+
+                    return;
+                }
+
+                $workspace->push($workingDir, $branch);
+                $payload['pushed'] = true;
+                Log::info('specify.review_response.pushed', $logCtx + ['commit_sha' => $commitSha]);
+
+                $execution->markSucceeded($run, $payload, $diff);
+            });
         } catch (Throwable $e) {
             Log::error('specify.review_response.failed', $logCtx + [
                 'exception' => $e::class,

--- a/app/Jobs/RespondToPrReviewJob.php
+++ b/app/Jobs/RespondToPrReviewJob.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Ai\Agents\ReviewResponder;
+use App\Enums\AgentRunKind;
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use App\Services\ExecutionService;
+use App\Services\Reviews\ReviewCommentsFetcher;
+use App\Services\WorkspaceRunner;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Queue job for a `RespondToReview` AgentRun (ADR-0008).
+ *
+ * Loads the run, prepares the working dir and checks out the PR's head
+ * branch, fetches the open review comments via the GitHub API, hands off
+ * to the `ReviewResponder` agent, commits + pushes a `fix(review):` change.
+ * Does not open a PR — the PR is already open.
+ */
+class RespondToPrReviewJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public int $agentRunId) {}
+
+    public function handle(
+        ExecutionService $execution,
+        WorkspaceRunner $workspace,
+        ReviewCommentsFetcher $fetcher,
+    ): void {
+        $run = AgentRun::findOrFail($this->agentRunId);
+
+        if ($run->kind !== AgentRunKind::RespondToReview) {
+            $execution->markFailed($run, 'RespondToPrReviewJob dispatched for a non-review-response AgentRun.');
+
+            return;
+        }
+
+        $subtask = $run->runnable;
+        $repo = $run->repo;
+        $prNumber = (int) ($run->output['pull_request_number'] ?? 0);
+        $branch = $run->working_branch;
+
+        if (! $subtask instanceof Subtask || $repo === null || $prNumber === 0 || $branch === null || $branch === '') {
+            $execution->markFailed($run, 'RespondToPrReviewJob: incomplete run state (subtask/repo/PR number/branch missing).');
+
+            return;
+        }
+
+        $execution->markRunning($run);
+
+        $logCtx = [
+            'run_id' => $run->getKey(),
+            'subtask_id' => $subtask->getKey(),
+            'pull_request_number' => $prNumber,
+            'branch' => $branch,
+        ];
+
+        try {
+            $workingDir = $workspace->prepare($repo, $run);
+            $workspace->checkoutBranch($workingDir, $branch, baseBranch: $repo->default_branch);
+            Log::info('specify.review_response.workspace.ready', $logCtx + ['working_dir' => $workingDir]);
+
+            [$reviewSummary, $comments] = $fetcher->fetch($repo, $prNumber);
+            Log::info('specify.review_response.comments.fetched', $logCtx + [
+                'comment_count' => count($comments),
+            ]);
+
+            if ($comments === [] && trim($reviewSummary) === '') {
+                $execution->markSucceeded($run, [
+                    'pull_request_number' => $prNumber,
+                    'no_review_content' => true,
+                ], null);
+                Log::info('specify.review_response.empty', $logCtx);
+
+                return;
+            }
+
+            $agent = new ReviewResponder(
+                subtask: $subtask,
+                pullRequestNumber: $prNumber,
+                reviewSummary: $reviewSummary,
+                comments: $comments,
+                workingBranch: $branch,
+                workingDir: $workingDir,
+            );
+
+            $output = $agent->run()->structured();
+
+            $clarifications = (array) ($output['clarifications'] ?? []);
+            $summary = trim((string) ($output['summary'] ?? ''));
+            $commitMessage = trim((string) ($output['commit_message'] ?? '')) ?: "fix(review): address PR #{$prNumber} review";
+
+            $commitSha = $workspace->commit($workingDir, $commitMessage);
+            $diff = $workspace->diff($workingDir);
+
+            $payload = [
+                'pull_request_number' => $prNumber,
+                'origin_run_id' => (int) ($run->output['origin_run_id'] ?? 0),
+                'summary' => $summary,
+                'files_changed' => array_values((array) ($output['files_changed'] ?? [])),
+                'commit_message' => $commitMessage,
+                'commit_sha' => $commitSha,
+                'clarifications' => $clarifications,
+                'review_comment_count' => count($comments),
+            ];
+
+            if ($commitSha === null) {
+                Log::info('specify.review_response.no_diff', $logCtx + [
+                    'clarifications' => count($clarifications),
+                ]);
+                $execution->markSucceeded($run, $payload, null);
+
+                return;
+            }
+
+            $workspace->push($workingDir, $branch);
+            $payload['pushed'] = true;
+            Log::info('specify.review_response.pushed', $logCtx + ['commit_sha' => $commitSha]);
+
+            $execution->markSucceeded($run, $payload, $diff);
+        } catch (Throwable $e) {
+            Log::error('specify.review_response.failed', $logCtx + [
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+            $execution->markFailed($run, $e->getMessage());
+
+            throw $e instanceof RuntimeException ? $e : new RuntimeException($e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\AgentRunKind;
 use App\Enums\AgentRunStatus;
 use Database\Factories\AgentRunFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -18,10 +19,15 @@ use RuntimeException;
  * (for execution). `authorizing_approval` ties the run back to the
  * StoryApproval that authorised it. Stores the agent's input, output, diff,
  * token usage, and timing for audit and replay.
+ *
+ * `kind` distinguishes the historical `Execute` run (produces the Subtask
+ * diff and opens a PR) from `RespondToReview` (ADR-0008 — pushes a
+ * `fix(review):` commit on the originating Subtask's open PR). The cascade
+ * gate ignores RespondToReview runs.
  */
 #[Fillable([
     'runnable_type', 'runnable_id',
-    'repo_id', 'working_branch', 'executor_driver',
+    'repo_id', 'working_branch', 'executor_driver', 'kind',
     'authorizing_approval_type', 'authorizing_approval_id',
     'status', 'agent_name', 'model_id',
     'input', 'output', 'diff', 'error_message',
@@ -42,6 +48,7 @@ class AgentRun extends Model
     {
         return [
             'status' => AgentRunStatus::class,
+            'kind' => AgentRunKind::class,
             'input' => 'array',
             'output' => 'array',
             'tokens_input' => 'integer',

--- a/app/Models/Repo.php
+++ b/app/Models/Repo.php
@@ -27,7 +27,7 @@ use Illuminate\Support\Str;
  * `webhook_secret` are stored encrypted. M:N with Project via the
  * `project_repo` pivot (carrying `role` and `is_primary`).
  */
-#[Fillable(['workspace_id', 'name', 'provider', 'url', 'default_branch', 'access_token', 'webhook_secret', 'metadata'])]
+#[Fillable(['workspace_id', 'name', 'provider', 'url', 'default_branch', 'access_token', 'webhook_secret', 'review_response_enabled', 'max_review_response_cycles', 'metadata'])]
 class Repo extends Model
 {
     /** @use HasFactory<RepoFactory> */
@@ -39,6 +39,8 @@ class Repo extends Model
             'provider' => RepoProvider::class,
             'access_token' => 'encrypted',
             'webhook_secret' => 'encrypted',
+            'review_response_enabled' => 'boolean',
+            'max_review_response_cycles' => 'integer',
             'metadata' => 'array',
         ];
     }

--- a/app/Models/WebhookEvent.php
+++ b/app/Models/WebhookEvent.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * `webhook_secret`; `matched_run_id` links the event to the AgentRun whose
  * push triggered it (when one can be matched).
  */
-#[Fillable(['repo_id', 'provider', 'event', 'action', 'signature_valid', 'matched_run_id', 'payload'])]
+#[Fillable(['repo_id', 'provider', 'event', 'action', 'delivery_id', 'signature_valid', 'matched_run_id', 'payload'])]
 class WebhookEvent extends Model
 {
     protected function casts(): array

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -8,6 +8,7 @@ use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Jobs\ExecuteSubtaskJob;
 use App\Jobs\GenerateTasksJob;
+use App\Jobs\RespondToPrReviewJob;
 use App\Models\AgentRun;
 use App\Models\Repo;
 use App\Models\Story;
@@ -85,6 +86,60 @@ class ExecutionService
         }
 
         return $first;
+    }
+
+    /**
+     * Create a `RespondToReview` AgentRun for the given originating Execute
+     * run (if the repo opted in and the per-PR cycle cap isn't hit), queue
+     * the matching `RespondToPrReviewJob`, and return a result describing
+     * what happened (ADR-0008). All decisions happen inside a transaction
+     * with `lockForUpdate` on the Repo row so two webhook events arriving
+     * concurrently can't both observe under-cap and double-dispatch.
+     *
+     * Possible result `status` values:
+     *   - 'dispatched' — new run + job queued
+     *   - 'review_response_disabled' — repo flag is off
+     *   - 'max_cycles_reached' — count of existing RespondToReview runs ≥ cap
+     *
+     * @return array{status: string, run?: AgentRun, cycle?: int, cycles?: int}
+     */
+    public function dispatchReviewResponse(Repo $repo, AgentRun $originRun, int $pullRequestNumber): array
+    {
+        return DB::transaction(function () use ($repo, $originRun, $pullRequestNumber) {
+            $repo = Repo::query()->whereKey($repo->getKey())->lockForUpdate()->first() ?? $repo;
+
+            if (! $repo->review_response_enabled) {
+                return ['status' => 'review_response_disabled'];
+            }
+
+            $cycles = AgentRun::query()
+                ->where('repo_id', $repo->getKey())
+                ->where('kind', AgentRunKind::RespondToReview->value)
+                ->whereJsonContains('output->pull_request_number', $pullRequestNumber)
+                ->count();
+
+            if ($cycles >= ($repo->max_review_response_cycles ?? 3)) {
+                return ['status' => 'max_cycles_reached', 'cycles' => $cycles];
+            }
+
+            $run = AgentRun::create([
+                'runnable_type' => $originRun->runnable_type,
+                'runnable_id' => $originRun->runnable_id,
+                'repo_id' => $repo->getKey(),
+                'working_branch' => $originRun->working_branch,
+                'executor_driver' => $originRun->executor_driver,
+                'kind' => AgentRunKind::RespondToReview->value,
+                'status' => AgentRunStatus::Queued->value,
+                'output' => [
+                    'pull_request_number' => $pullRequestNumber,
+                    'origin_run_id' => $originRun->getKey(),
+                ],
+            ]);
+
+            RespondToPrReviewJob::dispatch($run->getKey());
+
+            return ['status' => 'dispatched', 'run' => $run, 'cycle' => $cycles + 1];
+        });
     }
 
     private function createAndDispatchRun(Subtask $subtask, ?StoryApproval $approval, ?Repo $repo, string $driver, ?string $branchSuffix): AgentRun

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\AgentRunKind;
 use App\Enums\AgentRunStatus;
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
@@ -253,6 +254,15 @@ class ExecutionService
      */
     private function finalizeSubtaskFromRun(AgentRun $run): void
     {
+        // ADR-0008: review-response runs do not decide cascade — the Subtask
+        // is already Done by the time review feedback arrives, and the
+        // RespondToReview run only pushes a `fix(review):` commit on its
+        // open PR. Returning here keeps the cascade gate purely about
+        // Execute-kind run terminations.
+        if ($run->kind === AgentRunKind::RespondToReview) {
+            return;
+        }
+
         DB::transaction(function () use ($run) {
             $subtask = Subtask::query()->whereKey($run->runnable_id)->lockForUpdate()->first();
             if (! $subtask) {
@@ -262,6 +272,7 @@ class ExecutionService
             $siblings = AgentRun::query()
                 ->where('runnable_type', $run->runnable_type)
                 ->where('runnable_id', $subtask->getKey())
+                ->where('kind', AgentRunKind::Execute->value)
                 ->get();
 
             $stillOpen = $siblings->contains(fn (AgentRun $r) => in_array(

--- a/app/Services/Reviews/ReviewCommentsFetcher.php
+++ b/app/Services/Reviews/ReviewCommentsFetcher.php
@@ -13,12 +13,24 @@ use RuntimeException;
  *
  * GitHub-only for now — Bitbucket / GitLab can grow their own fetcher and
  * register against a multi-provider seam if/when needed.
+ *
+ * Failure model: every API call must succeed. A non-2xx response throws a
+ * `RuntimeException` with the status + body so the dispatching job marks
+ * its AgentRun failed (and the queue can decide whether to retry).
+ * Silent fallthrough would let an auth error or rate-limit hide as
+ * "no review content" and silently no-op the response loop.
  */
 class ReviewCommentsFetcher
 {
+    /** Hard ceiling on inline-comment pages so we never loop forever. */
+    private const MAX_COMMENT_PAGES = 20;
+
     /**
      * @return array{0: string, 1: list<array{path: ?string, line: ?int, body: string, author: ?string}>}
      *                                                                                                    [reviewSummaryBody, inlineComments]
+     *
+     * @throws RuntimeException When auth is missing, the URL is unparseable,
+     *                          or any GitHub API call returns non-2xx.
      */
     public function fetch(Repo $repo, int $pullRequestNumber): array
     {
@@ -39,26 +51,45 @@ class ReviewCommentsFetcher
         $reviewsResponse = Http::withHeaders($headers)->get(
             "{$apiBase}/repos/{$owner}/{$name}/pulls/{$pullRequestNumber}/reviews"
         );
-        if ($reviewsResponse->successful()) {
-            $reviews = (array) $reviewsResponse->json();
-            // Most-recent review with a non-empty body wins.
-            usort($reviews, fn ($a, $b) => strcmp((string) ($b['submitted_at'] ?? ''), (string) ($a['submitted_at'] ?? '')));
-            foreach ($reviews as $review) {
-                $body = trim((string) ($review['body'] ?? ''));
-                if ($body !== '') {
-                    $reviewSummary = $body;
-                    break;
-                }
+        if (! $reviewsResponse->successful()) {
+            throw new RuntimeException(sprintf(
+                'GitHub reviews fetch failed (%d): %s',
+                $reviewsResponse->status(),
+                $reviewsResponse->body(),
+            ));
+        }
+        $reviews = (array) $reviewsResponse->json();
+        // Most-recent review with a non-empty body wins.
+        usort($reviews, fn ($a, $b) => strcmp((string) ($b['submitted_at'] ?? ''), (string) ($a['submitted_at'] ?? '')));
+        foreach ($reviews as $review) {
+            $body = trim((string) ($review['body'] ?? ''));
+            if ($body !== '') {
+                $reviewSummary = $body;
+                break;
             }
         }
 
         $comments = [];
-        $commentsResponse = Http::withHeaders($headers)->get(
-            "{$apiBase}/repos/{$owner}/{$name}/pulls/{$pullRequestNumber}/comments",
-            ['per_page' => 100],
-        );
-        if ($commentsResponse->successful()) {
-            foreach ((array) $commentsResponse->json() as $c) {
+        $page = 1;
+        while ($page <= self::MAX_COMMENT_PAGES) {
+            $commentsResponse = Http::withHeaders($headers)->get(
+                "{$apiBase}/repos/{$owner}/{$name}/pulls/{$pullRequestNumber}/comments",
+                ['per_page' => 100, 'page' => $page],
+            );
+            if (! $commentsResponse->successful()) {
+                throw new RuntimeException(sprintf(
+                    'GitHub review comments fetch failed (page %d, %d): %s',
+                    $page,
+                    $commentsResponse->status(),
+                    $commentsResponse->body(),
+                ));
+            }
+            $batch = (array) $commentsResponse->json();
+            if ($batch === []) {
+                break;
+            }
+
+            foreach ($batch as $c) {
                 $comments[] = [
                     'path' => isset($c['path']) ? (string) $c['path'] : null,
                     'line' => isset($c['line']) ? (int) $c['line'] : (isset($c['original_line']) ? (int) $c['original_line'] : null),
@@ -66,6 +97,11 @@ class ReviewCommentsFetcher
                     'author' => isset($c['user']['login']) ? (string) $c['user']['login'] : null,
                 ];
             }
+
+            if (count($batch) < 100) {
+                break;
+            }
+            $page++;
         }
 
         return [$reviewSummary, $comments];

--- a/app/Services/Reviews/ReviewCommentsFetcher.php
+++ b/app/Services/Reviews/ReviewCommentsFetcher.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Services\Reviews;
+
+use App\Models\Repo;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * Fetches review comments and the latest review summary for a Pull Request
+ * so the `ReviewResponder` agent has the same context a human reviewer
+ * would have when triaging the feedback (ADR-0008).
+ *
+ * GitHub-only for now — Bitbucket / GitLab can grow their own fetcher and
+ * register against a multi-provider seam if/when needed.
+ */
+class ReviewCommentsFetcher
+{
+    /**
+     * @return array{0: string, 1: list<array{path: ?string, line: ?int, body: string, author: ?string}>}
+     *                                                                                                    [reviewSummaryBody, inlineComments]
+     */
+    public function fetch(Repo $repo, int $pullRequestNumber): array
+    {
+        if ($repo->access_token === null || $repo->access_token === '') {
+            throw new RuntimeException('GitHub access_token is required to fetch review comments.');
+        }
+
+        [$owner, $name] = $this->parseOwnerRepo($repo->url);
+        $apiBase = rtrim((string) config('specify.github.api_base', 'https://api.github.com'), '/');
+
+        $headers = [
+            'Accept' => 'application/vnd.github+json',
+            'Authorization' => 'Bearer '.$repo->access_token,
+            'X-GitHub-Api-Version' => '2022-11-28',
+        ];
+
+        $reviewSummary = '';
+        $reviewsResponse = Http::withHeaders($headers)->get(
+            "{$apiBase}/repos/{$owner}/{$name}/pulls/{$pullRequestNumber}/reviews"
+        );
+        if ($reviewsResponse->successful()) {
+            $reviews = (array) $reviewsResponse->json();
+            // Most-recent review with a non-empty body wins.
+            usort($reviews, fn ($a, $b) => strcmp((string) ($b['submitted_at'] ?? ''), (string) ($a['submitted_at'] ?? '')));
+            foreach ($reviews as $review) {
+                $body = trim((string) ($review['body'] ?? ''));
+                if ($body !== '') {
+                    $reviewSummary = $body;
+                    break;
+                }
+            }
+        }
+
+        $comments = [];
+        $commentsResponse = Http::withHeaders($headers)->get(
+            "{$apiBase}/repos/{$owner}/{$name}/pulls/{$pullRequestNumber}/comments",
+            ['per_page' => 100],
+        );
+        if ($commentsResponse->successful()) {
+            foreach ((array) $commentsResponse->json() as $c) {
+                $comments[] = [
+                    'path' => isset($c['path']) ? (string) $c['path'] : null,
+                    'line' => isset($c['line']) ? (int) $c['line'] : (isset($c['original_line']) ? (int) $c['original_line'] : null),
+                    'body' => (string) ($c['body'] ?? ''),
+                    'author' => isset($c['user']['login']) ? (string) $c['user']['login'] : null,
+                ];
+            }
+        }
+
+        return [$reviewSummary, $comments];
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function parseOwnerRepo(string $url): array
+    {
+        $url = preg_replace('/\.git$/', '', $url);
+
+        if (preg_match('#^https?://[^/]+/([^/]+)/([^/]+)/?$#', $url, $m)) {
+            return [$m[1], $m[2]];
+        }
+
+        if (preg_match('#^git@[^:]+:([^/]+)/([^/]+)/?$#', $url, $m)) {
+            return [$m[1], $m[2]];
+        }
+
+        throw new RuntimeException("Unable to parse owner/repo from URL: {$url}");
+    }
+}

--- a/database/migrations/2026_05_01_174832_add_review_response_columns.php
+++ b/database/migrations/2026_05_01_174832_add_review_response_columns.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Enums\AgentRunKind;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agent_runs', function (Blueprint $table) {
+            $table->string('kind')->default(AgentRunKind::Execute->value)->after('executor_driver');
+            $table->index(['runnable_type', 'runnable_id', 'kind']);
+        });
+
+        Schema::table('repos', function (Blueprint $table) {
+            $table->boolean('review_response_enabled')->default(false)->after('webhook_secret');
+            $table->unsignedSmallInteger('max_review_response_cycles')->default(3)->after('review_response_enabled');
+        });
+
+        Schema::table('webhook_events', function (Blueprint $table) {
+            $table->string('delivery_id')->nullable()->after('action')->unique();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('webhook_events', function (Blueprint $table) {
+            $table->dropUnique(['delivery_id']);
+            $table->dropColumn('delivery_id');
+        });
+
+        Schema::table('repos', function (Blueprint $table) {
+            $table->dropColumn(['review_response_enabled', 'max_review_response_cycles']);
+        });
+
+        Schema::table('agent_runs', function (Blueprint $table) {
+            $table->dropIndex(['runnable_type', 'runnable_id', 'kind']);
+            $table->dropColumn('kind');
+        });
+    }
+};

--- a/docs/adr/0008-pr-review-feedback-via-webhooks.md
+++ b/docs/adr/0008-pr-review-feedback-via-webhooks.md
@@ -23,10 +23,16 @@ address the comments on the same branch.
 
 ## Decision
 
-**A new GitHub webhook endpoint (`POST /webhooks/github`) listens for
-`pull_request_review` and `pull_request_review_comment` events, looks up
-the AgentRun that originated the PR, and (if the repo opted in)
-dispatches a fresh AgentRun whose `kind` is `RespondToReview`.**
+**The existing GitHub webhook endpoint (`POST /webhooks/github/{repo}`)
+grows two new handlers — `pull_request_review` and
+`pull_request_review_comment` — that look up the AgentRun that
+originated the PR and ask `ExecutionService::dispatchReviewResponse` to
+queue a fresh AgentRun whose `kind` is `RespondToReview` (subject to
+opt-in and the per-PR cycle cap). Webhook payloads are stored in the
+existing `webhook_events` table; idempotency on `X-GitHub-Delivery` is
+enforced by a unique index on `webhook_events.delivery_id`. AgentRun
+creation continues to live exclusively in `ExecutionService` (the
+controller calls a service method, not `AgentRun::create` directly).**
 
 Concrete shape:
 
@@ -50,11 +56,14 @@ Concrete shape:
     many `respond_to_review` runs may be dispatched for a single
     PR. When the cap is hit the webhook is acked but no new run
     fires; reviewers fall back to humans.
-- `github_webhook_deliveries (id, delivery_id UNIQUE, repo_id, event,
-  action, received_at)` is the idempotency table. The webhook
-  controller upserts on `delivery_id` (GitHub's `X-GitHub-Delivery`
-  header) and ignores duplicates so an at-least-once webhook
-  delivery doesn't fire twice.
+- `webhook_events.delivery_id` (nullable, unique) is the idempotency
+  column on the existing webhook-events table. Signature validation
+  runs FIRST; a request that fails signature validation persists with
+  NULL `delivery_id` so an attacker cannot occupy the unique slot for
+  a legitimate later delivery. Concurrent identical (signature-valid)
+  deliveries are de-duped via the unique index — the second insert
+  hits a constraint violation that the controller catches and converts
+  into `{duplicate: true}`. No separate idempotency table is needed.
 - A new agent `App\Ai\Agents\ReviewResponder` runs the
   `respond_to_review` AgentRun. Same tool box as `SubtaskExecutor`
   (Read/Write/Edit/Bash/Grep/Find/Ls), different prompt — the prompt
@@ -62,11 +71,27 @@ Concrete shape:
   the review comments grouped by file/line, and instructs the agent
   to produce focused fixes for each comment (or a `clarification`
   if a comment requires redesign).
-- `ReviewResponseRunPipeline` reuses `WorkspaceRunner` (prepare +
-  checkoutBranch — the workspace fix from ADR-0006's stack means
-  the branch syncs to origin). Commit message convention:
+- `RespondToPrReviewJob` is the queue job that owns one
+  `RespondToReview` run end-to-end. It reuses `WorkspaceRunner`
+  (prepare + checkoutBranch — the workspace fix from ADR-0006's
+  stack means the branch syncs to origin), pulls open review
+  comments through `ReviewCommentsFetcher`, hands off to
+  `ReviewResponder`, commits, and pushes. Commit message convention:
   `fix(review): address PR #N review`. **No PR is opened** — the
   PR is already open; the new commit lands on its head branch.
+- The job serialises against itself via a `Cache::lock` keyed by
+  repo+branch. Two `RespondToPrReviewJob`s for the same PR share
+  the on-disk story-scoped working dir; the lock guarantees one runs
+  to completion (commit + push) before the next acquires the
+  workspace, so review-burst dispatches don't race on
+  `checkoutBranch` / `commit` / `push`.
+- Cycle-cap and AgentRun creation live inside
+  `ExecutionService::dispatchReviewResponse`, wrapped in a
+  transaction with `lockForUpdate` on the `Repo` row. Two webhook
+  events arriving concurrently observe the cap atomically; one
+  dispatches, the other reports `max_cycles_reached`. The controller
+  never calls `AgentRun::create` directly — the "AgentRun creation
+  lives only in `ExecutionService`" rule is preserved.
 
 ## Consequences
 

--- a/docs/adr/0008-pr-review-feedback-via-webhooks.md
+++ b/docs/adr/0008-pr-review-feedback-via-webhooks.md
@@ -1,0 +1,129 @@
+# 0008. PR review feedback closes the loop via webhooks
+
+Date: 2026-05-01
+Status: Accepted
+
+## Context
+
+Specify opens PRs at the end of every Subtask AgentRun (ADR-0004). Today
+those PRs accumulate review feedback (Copilot, human reviewers) passively
+— a human has to come back, read the comments, dispatch some kind of
+follow-up, and push a fix. We tried two off-app workarounds:
+
+- A scheduled remote agent polling open PRs every hour. Works, but is
+  external to the app's domain model, has no audit trail in
+  `agent_runs`, and lags by up to an hour.
+- Manual response loops where the human pastes the review into a chat
+  with Claude Code. Works, but defeats the point of running an
+  orchestrator.
+
+The pattern is loud enough that it should live in the app: when a review
+is posted on a PR Specify owns, dispatch an AgentRun whose job is to
+address the comments on the same branch.
+
+## Decision
+
+**A new GitHub webhook endpoint (`POST /webhooks/github`) listens for
+`pull_request_review` and `pull_request_review_comment` events, looks up
+the AgentRun that originated the PR, and (if the repo opted in)
+dispatches a fresh AgentRun whose `kind` is `RespondToReview`.**
+
+Concrete shape:
+
+- `agent_runs` gains a `kind` column (default `execute`). Two values
+  today: `execute` (the existing run that produces a Subtask's diff)
+  and `respond_to_review` (the new flavour that consumes review
+  comments and pushes a fix on the same branch).
+- The cascade gate in `ExecutionService::finalizeSubtaskFromRun`
+  ignores `respond_to_review` runs entirely. The Subtask is already
+  Done by the time review comments arrive; review responses neither
+  decide nor change the cascade.
+- `repos` gains three columns:
+  - `webhook_secret` (nullable). The shared secret used to verify
+    GitHub's `X-Hub-Signature-256` header. NULL means the repo has
+    no webhook configured and incoming events for it are rejected.
+  - `review_response_enabled` (boolean, default false). Per-repo
+    opt-in switch. The flag has to be flipped explicitly by the
+    workspace owner — automatic review-response is not the default
+    because it costs AI spend and writes to the host repo.
+  - `max_review_response_cycles` (integer, default 3). Cap on how
+    many `respond_to_review` runs may be dispatched for a single
+    PR. When the cap is hit the webhook is acked but no new run
+    fires; reviewers fall back to humans.
+- `github_webhook_deliveries (id, delivery_id UNIQUE, repo_id, event,
+  action, received_at)` is the idempotency table. The webhook
+  controller upserts on `delivery_id` (GitHub's `X-GitHub-Delivery`
+  header) and ignores duplicates so an at-least-once webhook
+  delivery doesn't fire twice.
+- A new agent `App\Ai\Agents\ReviewResponder` runs the
+  `respond_to_review` AgentRun. Same tool box as `SubtaskExecutor`
+  (Read/Write/Edit/Bash/Grep/Find/Ls), different prompt — the prompt
+  takes the originating Subtask spec, the current branch state, and
+  the review comments grouped by file/line, and instructs the agent
+  to produce focused fixes for each comment (or a `clarification`
+  if a comment requires redesign).
+- `ReviewResponseRunPipeline` reuses `WorkspaceRunner` (prepare +
+  checkoutBranch — the workspace fix from ADR-0006's stack means
+  the branch syncs to origin). Commit message convention:
+  `fix(review): address PR #N review`. **No PR is opened** — the
+  PR is already open; the new commit lands on its head branch.
+
+## Consequences
+
+### Positive
+
+- Review feedback closes the loop inside the domain model.
+  `agent_runs` carries the full audit trail (`kind`, originating
+  Subtask, commits produced, error messages) so "what happened to
+  this PR" is queryable, not lost in chat history.
+- Real-time response. Webhook → job → branch update inside seconds
+  instead of polling lag.
+- Same opt-in shape as the rest of the system — repo-level toggle,
+  bounded by a per-PR cap, no new approval surfaces.
+- The cap + the `kind` distinction make loop runaway impossible:
+  Copilot can't trigger an infinite "review the fix to the review
+  to the review" cycle, because the cap counts response runs per
+  PR.
+
+### Negative
+
+- AI spend per PR scales with how chatty the reviewer is. The cap
+  is the only governor; if `max_review_response_cycles=3` is too
+  loose, raise the bar.
+- Webhook secrets become a new piece of repo configuration.
+  Mitigation: `webhook_secret` is nullable; an unconfigured repo
+  silently rejects events and the rest of the system keeps working.
+- Public webhook endpoint requires the app to be reachable.
+  Mitigation: the endpoint is signature-gated; payloads with no
+  matching repo or invalid signature 401 immediately.
+
+### Neutral
+
+- ADR-0001 (Story is the only approval gate) is preserved.
+  `respond_to_review` runs address feedback on **already-approved**
+  work; they do not introduce new spec, do not change the Story's
+  status, and never reset approval. The PR diff-review surface
+  (the same one ADR-0001 names) is exactly where the human notices
+  if a review-response run did the wrong thing.
+- ADR-0004 (PR after push is non-fatal) is unchanged: review-response
+  runs don't open a PR, so the PR-failure path doesn't apply.
+- ADR-0005 (executor may append follow-up subtasks) does not apply
+  here — review responses don't create new Subtasks; they push
+  commits onto the originating Subtask's branch.
+- ADR-0007 (already-complete subtasks) does not apply — review-
+  response runs do not use the no-diff/already-complete machinery;
+  if the agent decides every comment is wrong, it returns a
+  clarification and the run ends Succeeded with no commit.
+
+## Open questions (future work, not blocking)
+
+- Should review-response runs themselves trigger advisory ADR-conformance
+  review? Today only `execute` runs do (gated on `pull_request_number`
+  on the run's output). Probably yes once we trust this flow, but
+  start it off.
+- Should the response agent be allowed to *close* a comment thread
+  by replying to it (GitHub API supports this), or only push code?
+  Code-only for V1.
+- Should we batch reviews — e.g. wait 60 seconds before dispatching
+  in case more comments arrive — or fire on every event? Fire-on-every
+  for V1; debouncing is an easy follow-up if it gets noisy.

--- a/prompts/review-responder.md
+++ b/prompts/review-responder.md
@@ -1,0 +1,54 @@
+You are the review-response agent for Specify. A human (or Copilot, or
+another bot reviewer) has left review comments on a Pull Request that
+Specify opened. Your job is to address each comment in code on the PR's
+head branch, then return a structured summary.
+
+The repo is already checked out for you on the PR's head branch. You have
+these tools — use them to inspect and modify the working tree:
+
+- ReadFile(path, offset?, limit?)
+- WriteFile(path, content)
+- EditFile(path, edits[]) — each edit has `old_string`, `new_string`, optional `replace_all`
+- Bash(command, timeout?) — runs in the working directory
+- Grep(pattern, path?, glob?, ignore_case?, literal?, context?, limit?)
+- Find(pattern, path?, limit?)
+- Ls(path?, limit?)
+
+Workflow:
+1. Read the originating Subtask spec and the existing diff on this branch
+   so you understand what was already done.
+2. Read each review comment carefully. Each comment names a file and a
+   line; treat that as the focal point but read enough surrounding code
+   to make a good fix.
+3. Address each comment with the smallest reasonable change. Do not
+   refactor unrelated code, do not "improve" things the comment did not
+   ask about. One comment → one focused change.
+4. If the comment is wrong on the merits — the reviewer misread, the
+   suggestion would break behaviour, the cited code is intentional —
+   record a `clarification` instead of caving. Cite the file and line
+   that supports your position.
+5. If the comment requires a redesign rather than a small fix (the
+   architecture is wrong, a different ADR contradicts the suggestion,
+   the change would touch dozens of files) — record a `clarification`
+   with `kind: disagreement`, leave the code alone, and stop. The
+   human picks it up from there.
+6. Run `composer test` (or the project's verification step) and only
+   return success once it passes. If you can't make it pass, return a
+   clarification explaining what blocked you.
+
+Constraints:
+- Make only the changes the comments require. Stay on the working branch.
+- Do not commit, push, open or close PRs, or switch branches — those are
+  handled by the orchestrator.
+- Do not disable or skip tests/lints to make verification pass — fix the
+  underlying issue or surface it as a clarification.
+- Paths in tool calls are relative to the working directory (the repo
+  root).
+
+Return a structured summary listing the files you touched and a one-line
+commit message in conventional-commit form
+(`fix(review): address PR #N review` is the convention). For each
+review comment you addressed, briefly note in `summary` what you
+changed and why. Use `clarifications` for comments you pushed back on
+or could not address — leave it empty when there is nothing real to
+report.

--- a/tests/Feature/GithubWebhookTest.php
+++ b/tests/Feature/GithubWebhookTest.php
@@ -307,6 +307,49 @@ test('approved review with no body is ignored (no spurious dispatch)', function 
     Queue::assertNothingPushed();
 });
 
+test('replayed delivery_id from an UNAUTHENTICATED caller does not poison the unique slot', function () {
+    Queue::fake();
+    $ws = Workspace::factory()->create();
+    $repo = Repo::factory()->for($ws)->create([
+        'provider' => RepoProvider::Github,
+        'webhook_secret' => 's3cret',
+        'review_response_enabled' => true,
+    ]);
+    reviewSubtaskRun($repo, 17);
+
+    // Attacker first: bad signature, but supplies a delivery_id.
+    test()->call(
+        method: 'POST',
+        uri: route('webhooks.github', $repo),
+        server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_GITHUB_EVENT' => 'pull_request_review',
+            'HTTP_X_HUB_SIGNATURE_256' => 'sha256=bogus',
+            'HTTP_X_GITHUB_DELIVERY' => 'delivery-poison-1',
+        ],
+        content: json_encode(reviewPayload(17)),
+    )->assertStatus(401);
+
+    // Legitimate webhook arrives with the same delivery_id and a valid signature.
+    $body = json_encode(reviewPayload(17));
+    $sig = 'sha256='.hash_hmac('sha256', $body, 's3cret');
+    test()->call(
+        method: 'POST',
+        uri: route('webhooks.github', $repo),
+        server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_GITHUB_EVENT' => 'pull_request_review',
+            'HTTP_X_HUB_SIGNATURE_256' => $sig,
+            'HTTP_X_GITHUB_DELIVERY' => 'delivery-poison-1',
+        ],
+        content: $body,
+    )->assertOk()->assertJson(['matched' => true, 'dispatched' => true]);
+
+    // The invalid attempt must NOT have occupied delivery_id; the valid request lands.
+    expect(WebhookEvent::where('delivery_id', 'delivery-poison-1')->where('signature_valid', true)->count())->toBe(1);
+    expect(WebhookEvent::where('delivery_id', 'delivery-poison-1')->where('signature_valid', false)->count())->toBe(0);
+});
+
 test('cascade gate ignores RespondToReview kind runs (ADR-0008)', function () {
     $ws = Workspace::factory()->create();
     $repo = Repo::factory()->for($ws)->create(['provider' => RepoProvider::Github]);

--- a/tests/Feature/GithubWebhookTest.php
+++ b/tests/Feature/GithubWebhookTest.php
@@ -1,12 +1,19 @@
 <?php
 
+use App\Enums\AgentRunKind;
+use App\Enums\AgentRunStatus;
 use App\Enums\RepoProvider;
+use App\Enums\TaskStatus;
+use App\Jobs\RespondToPrReviewJob;
 use App\Models\AgentRun;
 use App\Models\Repo;
+use App\Models\Subtask;
 use App\Models\Task;
 use App\Models\WebhookEvent;
 use App\Models\Workspace;
+use App\Services\ExecutionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 
 uses(RefreshDatabase::class);
 
@@ -145,4 +152,181 @@ test('logs every delivery as a WebhookEvent including invalid signatures', funct
         ->and($events[1]->event)->toBe('pull_request')
         ->and($events[1]->action)->toBe('closed')
         ->and($events[1]->matched_run_id)->toBe($run->id);
+});
+
+function reviewPayload(int $prNumber, string $body = 'fix this please'): array
+{
+    return [
+        'action' => 'submitted',
+        'review' => [
+            'state' => 'changes_requested',
+            'body' => $body,
+            'submitted_at' => '2026-05-01T15:00:00Z',
+        ],
+        'pull_request' => ['number' => $prNumber],
+    ];
+}
+
+function reviewSubtaskRun(Repo $repo, int $prNumber, string $branch = 'specify/feature/story'): AgentRun
+{
+    $subtask = Subtask::factory()->for(Task::factory())->create();
+
+    return AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'kind' => AgentRunKind::Execute->value,
+        'working_branch' => $branch,
+        'executor_driver' => 'fake',
+        'output' => ['pull_request_number' => $prNumber, 'pull_request_url' => 'https://github.com/o/r/pull/'.$prNumber],
+    ]);
+}
+
+test('pull_request_review dispatches a RespondToReview run when the repo opted in (ADR-0008)', function () {
+    Queue::fake();
+    $ws = Workspace::factory()->create();
+    $repo = Repo::factory()->for($ws)->create([
+        'provider' => RepoProvider::Github,
+        'webhook_secret' => 's3cret',
+        'review_response_enabled' => true,
+        'max_review_response_cycles' => 3,
+    ]);
+    $origin = reviewSubtaskRun($repo, 11);
+
+    postWebhook($repo, 's3cret', 'pull_request_review', reviewPayload(11))
+        ->assertOk()
+        ->assertJson(['matched' => true, 'dispatched' => true, 'cycle' => 1]);
+
+    $newRun = AgentRun::where('repo_id', $repo->id)
+        ->where('kind', AgentRunKind::RespondToReview->value)
+        ->latest('id')->firstOrFail();
+
+    expect($newRun->runnable_type)->toBe($origin->runnable_type)
+        ->and($newRun->runnable_id)->toBe($origin->runnable_id)
+        ->and($newRun->working_branch)->toBe($origin->working_branch)
+        ->and($newRun->status)->toBe(AgentRunStatus::Queued)
+        ->and($newRun->output['pull_request_number'])->toBe(11)
+        ->and($newRun->output['origin_run_id'])->toBe($origin->id);
+
+    Queue::assertPushed(RespondToPrReviewJob::class, fn ($job) => $job->agentRunId === $newRun->id);
+});
+
+test('pull_request_review does NOT dispatch when the repo has not opted in', function () {
+    Queue::fake();
+    $ws = Workspace::factory()->create();
+    $repo = Repo::factory()->for($ws)->create([
+        'provider' => RepoProvider::Github,
+        'webhook_secret' => 's3cret',
+        'review_response_enabled' => false,
+    ]);
+    reviewSubtaskRun($repo, 12);
+
+    postWebhook($repo, 's3cret', 'pull_request_review', reviewPayload(12))
+        ->assertOk()
+        ->assertJson(['matched' => true, 'dispatched' => false, 'reason' => 'review_response_disabled']);
+
+    expect(AgentRun::where('kind', AgentRunKind::RespondToReview->value)->count())->toBe(0);
+    Queue::assertNothingPushed();
+});
+
+test('pull_request_review respects max_review_response_cycles cap', function () {
+    Queue::fake();
+    $ws = Workspace::factory()->create();
+    $repo = Repo::factory()->for($ws)->create([
+        'provider' => RepoProvider::Github,
+        'webhook_secret' => 's3cret',
+        'review_response_enabled' => true,
+        'max_review_response_cycles' => 2,
+    ]);
+    $origin = reviewSubtaskRun($repo, 13);
+    foreach (range(1, 2) as $i) {
+        AgentRun::create([
+            'runnable_type' => $origin->runnable_type,
+            'runnable_id' => $origin->runnable_id,
+            'repo_id' => $repo->id,
+            'kind' => AgentRunKind::RespondToReview->value,
+            'status' => AgentRunStatus::Succeeded->value,
+            'output' => ['pull_request_number' => 13],
+        ]);
+    }
+
+    postWebhook($repo, 's3cret', 'pull_request_review', reviewPayload(13))
+        ->assertOk()
+        ->assertJson(['matched' => true, 'dispatched' => false, 'reason' => 'max_cycles_reached']);
+
+    Queue::assertNothingPushed();
+});
+
+test('duplicate webhook delivery is idempotent on X-GitHub-Delivery', function () {
+    Queue::fake();
+    $ws = Workspace::factory()->create();
+    $repo = Repo::factory()->for($ws)->create([
+        'provider' => RepoProvider::Github,
+        'webhook_secret' => 's3cret',
+        'review_response_enabled' => true,
+    ]);
+    reviewSubtaskRun($repo, 14);
+
+    $body = json_encode(reviewPayload(14));
+    $sig = 'sha256='.hash_hmac('sha256', $body, 's3cret');
+    $headers = [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_X_GITHUB_EVENT' => 'pull_request_review',
+        'HTTP_X_HUB_SIGNATURE_256' => $sig,
+        'HTTP_X_GITHUB_DELIVERY' => 'delivery-abc-123',
+    ];
+
+    test()->call(method: 'POST', uri: route('webhooks.github', $repo), server: $headers, content: $body)
+        ->assertOk()
+        ->assertJson(['dispatched' => true]);
+
+    test()->call(method: 'POST', uri: route('webhooks.github', $repo), server: $headers, content: $body)
+        ->assertOk()
+        ->assertJson(['duplicate' => true]);
+
+    expect(AgentRun::where('kind', AgentRunKind::RespondToReview->value)->count())->toBe(1);
+    Queue::assertPushed(RespondToPrReviewJob::class, 1);
+});
+
+test('approved review with no body is ignored (no spurious dispatch)', function () {
+    Queue::fake();
+    $ws = Workspace::factory()->create();
+    $repo = Repo::factory()->for($ws)->create([
+        'provider' => RepoProvider::Github,
+        'webhook_secret' => 's3cret',
+        'review_response_enabled' => true,
+    ]);
+    reviewSubtaskRun($repo, 15);
+
+    postWebhook($repo, 's3cret', 'pull_request_review', [
+        'action' => 'submitted',
+        'review' => ['state' => 'approved', 'body' => ''],
+        'pull_request' => ['number' => 15],
+    ])->assertOk()->assertJson(['ignored' => true]);
+
+    Queue::assertNothingPushed();
+});
+
+test('cascade gate ignores RespondToReview kind runs (ADR-0008)', function () {
+    $ws = Workspace::factory()->create();
+    $repo = Repo::factory()->for($ws)->create(['provider' => RepoProvider::Github]);
+    $origin = reviewSubtaskRun($repo, 16);
+
+    // Subtask is already Done from the original Execute run.
+    $subtask = Subtask::find($origin->runnable_id);
+    $subtask->forceFill(['status' => TaskStatus::Done->value])->save();
+
+    $reviewRun = AgentRun::create([
+        'runnable_type' => $origin->runnable_type,
+        'runnable_id' => $origin->runnable_id,
+        'repo_id' => $repo->id,
+        'kind' => AgentRunKind::RespondToReview->value,
+        'status' => AgentRunStatus::Running->value,
+    ]);
+
+    // Marking the review-response run as failed must NOT flip the Subtask
+    // back to Blocked or otherwise touch the cascade.
+    app(ExecutionService::class)->markFailed($reviewRun, 'agent crashed');
+
+    expect($subtask->fresh()->status->value)->toBe('done');
 });


### PR DESCRIPTION
## Summary

- GitHub posts a `pull_request_review` or `pull_request_review_comment` → `/webhooks/github/{repo}` → if the repo opted in and the per-PR cycle cap isn't hit, dispatch a `RespondToReview` AgentRun that pushes a `fix(review):` commit on the open PR's branch.
- Replaces the external scheduled remote agent (now disabled) with an in-app, real-time, audit-logged loop.
- New `AgentRun.kind` enum (`execute` / `respond_to_review`); cascade gate ignores response runs and filters siblings to `kind=execute`.
- Repo-level opt-in (`review_response_enabled`) + per-PR cycle cap (`max_review_response_cycles`, default 3).
- Webhook idempotency on `X-GitHub-Delivery` via `webhook_events.delivery_id` unique index.
- New `ReviewResponder` agent (sibling of `SubtaskExecutor`) + `ReviewCommentsFetcher` for GitHub.

## Test plan

- [x] `composer test` — 261/261 (6 new webhook tests cover dispatch, opt-in gating, cycle cap, idempotency, approved-no-body ignore, cascade ignores RespondToReview)
- [ ] Run a real review through the loop on a test repo (set `review_response_enabled=true`, post a Copilot review, watch the AgentRun + commit)

## ADR alignment

- ADR-0001 preserved: response runs address already-approved work; no new approval gate
- ADR-0004 N/A: no PR is opened by response runs
- ADR-0006 unchanged: cascade locks for `execute` siblings only
- ADR-0007 unchanged: response runs don't use the no-diff/already-complete machinery

🤖 Generated with [Claude Code](https://claude.com/claude-code)