### PR TITLE
ADR-0012: project-first IA + Story document redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-error.log
 /.zed
 .gstack/
 *.swp
+.playwright-mcp/
+*.png

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,94 @@
+# Specify — Domain glossary
+
+Living document. Terms are added as they're sharpened during design discussions. Implementation detail belongs in code or ADRs, not here.
+
+## Core hierarchy
+
+`Workspace → Project → Feature → Story → Task → Subtask`
+
+- **Workspace** — tenant boundary, owned by a User. Hosts Projects, Repos, Teams, and ApprovalPolicies. In the UI, workspace is **ambient chrome** (top-left switcher), not a breadcrumb segment. Cross-workspace navigation is a route change; within a workspace, the breadcrumb starts at Project.
+- **Project** — a body of work inside a Workspace. Holds Features and is linked M:N to workspace-scoped Repos via `project_repo` (with `role`, `is_primary`).
+- **Feature** — product-owner framing of a capability. Holds Stories.
+- **Story** — product-owner unit of value. Carries an integer `revision` (auto-bumps on edit), a description, notes, and AcceptanceCriteria. **The only approval gate** (ADR-0001).
+- **AcceptanceCriterion** — observable behaviour the Story must satisfy. 1:1 with Task (ADR-0002). In the UI, AC and Task are not two separate lists: the Story's plan section is the AC list, with each row leading on the AC text (product-owner voice) and the Task description + Subtasks (engineering voice) folded beneath. The Plan toggle (Grooming / Run) drives default collapse — Grooming collapses everything below the AC; Run expands Task + Subtasks for live watching.
+- **Task** — engineering contract for one AcceptanceCriterion. Owns 1+ Subtasks.
+- **Subtask** — the unit an Executor runs (one Subtask per `ExecuteSubtaskJob`).
+
+## Adjacent
+
+- **Team** — workspace-scoped, M:N with User via `team_user`.
+- **Repo** — workspace-scoped, attached to Projects via `project_repo`. Carries `provider`, encrypted `access_token`, and `webhook_secret`.
+- **ApprovalPolicy** — cascade `workspace → project → story` with a `required_approvals` threshold. Resolved policy decides how many Approve decisions a Story needs. The threshold is surfaced in the UI as a tally pill in the Story breadcrumb (`Approved · 2/2`, `Pending · 1/2`, `Changes requested`). The Story right rail shows the immutable **decision log** (Approve / ChangesRequested / Reject / Revoke, approver, time) rather than a flat approver list. ChangesRequested resets the tally — the editor must surface this consequence before the click. Reject is terminal and lives in a "more" menu with a hard confirm. **Story authors cannot approve their own Stories** — the Approve button is hidden for the author. When threshold > 1, the rail lists eligible approvers.
+
+## Runs and race mode
+
+- **AgentRun** — one execution attempt. In single-driver mode, a Subtask has one AgentRun. In race mode (ADR-0006), a Subtask has N sibling AgentRuns — one per driver — each on its own branch and opening its own PR. The "winner" is the PR a human merges on the host VCS, not a flag in the app.
+- **Run console** — scoped to one AgentRun. URL: `/stories/:story/subtasks/:subtask/runs/:agent_run_id`. Nested route preserves breadcrumb continuity.
+- **Story revision** — integer on `Story.revision`, auto-bumps on any edit. Surfaces in the UI as `v7`. There is no snapshot table today; the run header simply shows the integer revision the run was dispatched against. Drift between current Story and run-time Story is *not* visualised in V1 — adding a `story_snapshots` table is a future ADR.
+- **Subtask drawer** — opened from the Story plan or live band. Hosts the per-Subtask **leaderboard** (one row per sibling AgentRun). In single-driver mode the drawer shows one row; in race mode N rows. Click a row to enter that AgentRun's run console.
+- **Live run band** — Story-level ambient strip. Grouped by Task (one block per Task), with a sub-bar over Subtasks inside each block. Mid-run plan growth (ADR-0005) only reflows the inside of the affected Task's block — the outer Story-level structure stays still. A racing Subtask's sub-segment is subdivided into N driver stripes. The band is *not* scoped to a single AgentRun. Per-Subtask state includes a distinct "review-response running" visual (comment-dot glyph, sky rail) for when a `respond_to_review` run is active on an already-merged-or-pending PR.
+
+## Subtask outcomes
+
+- **Already-complete** (ADR-0007) — a Succeeded-class outcome where the agent declares the spec already met and cites commit SHAs reachable from `HEAD`. Renders **prominently** in the spine and plan: green check + chain-link glyph, tooltip "Already complete · N commits cited", expanding to show the SHA list (each linkable to the host VCS) and the agent's `already_complete_reason`. Not muted — the declination is one of the most reviewer-relevant decisions the agent makes.
+- **Clarifications** (ADR-0005) — structured signals from the executor (`kind`: ambiguity / conflict / missing-context / disagreement, plus message and optional `proposed`). Surfaced in three scopes:
+  1. **Run console right ambient panel** — live cards as the run produces them, kind-chipped.
+  2. **Subtask drawer** — clarifications strip above the leaderboard so a reviewer sees them before entering a specific AgentRun.
+  3. **Story right rail** — aggregate `Clarifications (N)` link across all runs of the Story.
+  A `!` badge marks Subtask segments in the live band when active clarifications exist — an orthogonal ambient signal, distinct from running/failed state.
+
+## Plan growth and provenance
+
+- Mid-run append-only growth (ADR-0005) is bounded at +3 Subtasks per run, scoped to the parent Task.
+- **Subtask drawer / run console spine** renders original Subtasks as fixed segments; appended Subtasks land in an "Appended this run (+N of 3 cap)" tray beneath the spine — never reflowing the original list.
+- Every Subtask row in the spine, plan, and drawer shows a small `+` glyph when `subtasks.proposed_by_run_id` is set, with a tooltip naming the originating AgentRun.
+
+## Run console anatomy by driver
+
+The Logs tab has two distinct anatomies, selected by `agent_runs.executor_driver`:
+
+- **Structured-output drivers** (e.g. `LaravelAiExecutor`) — foldable per-tool-call blocks, kind filter chips (tool / edit / shell / thinking / errors), dimmed thinking lines. Timeline tab (flame chart) is available.
+- **CLI drivers** (`CliExecutor`) — raw ANSI stdout + stderr in a terminal-style scrollback, ANSI colour rendering, no kind filters (full-text search instead). Sentinel blocks (`<<<SPECIFY:...>>>` — see ADR-0007 for `already_complete`; future: `clarifications`) are detected and rendered **inline as structured callouts** within the stdout stream. Timeline tab is **hidden**, not placeheld.
+
+The Logs tab header carries a small driver badge so watchers know which anatomy they're seeing. In race mode, sibling AgentRuns on the same Subtask may have different anatomies — the drawer's leaderboard is uniform; clicking into each opens its driver-appropriate console.
+
+**Open follow-up:** some CLIs (e.g. Claude Code's `--output-format stream-json`) emit structured events that could promote a CLI run to the structured anatomy. Out of scope for V1; revisit when the CLI sentinel parser is generalised.
+
+## Cancel and retry
+
+Neither cancel nor retry is in V1.
+
+- **Cancel** — `Executor::execute` returns one `ExecutionResult` at the end and has no in-process kill switch; `LaravelAiExecutor` runs synchronously inside `ExecuteSubtaskJob`; `CliExecutor` has a configurable timeout but no cooperative cancel plumbing. Race-mode cancellation is also semantically ambiguous (one sibling vs. all). The button is **hidden** until a cancel ADR lands; it's not stubbed.
+- **Retry** — manual Subtask retry has no domain affordance today. Failed Subtasks surface their failure (state + error) but offer no one-click retry. Re-running is an ADR-worthy capability, not a UI feature.
+
+## Realtime transport
+
+Reverb is reserved for low-frequency state events where push beats poll meaningfully. Anything per-line or per-tool-call goes via HTTP poll.
+
+| Channel / transport | Slice | Frequency | Purpose |
+|---|---|---|---|
+| `stories.{id}` (Reverb) | 1 | on state change | approval transitions, run lifecycle milestones, revision bumps |
+| `runs.{agent_run_id}` (Reverb) | 2 | on subtask transition | current subtask index, state, elapsed |
+| `runs/{id}/logs?after={cursor}` (HTTP poll, 1–2s) | 2 | poll | log entries; driver-shaped (structured blocks for laravel-ai, ANSI scrollback for cli) |
+| `runs/{id}/diff` (HTTP, on tab focus) | 2 | one-shot | cumulative working-tree diff |
+| `runs.{agent_run_id}.review` (Reverb) | future | on webhook delivery | review-response dispatch |
+| presence / multiplayer cursors | (dropped) | — | not building Figma; "X is viewing" is not a feature |
+
+Reverb log streaming is deferred to a future slice with its own ADR — `Executor::execute` returns one `ExecutionResult` at the end (no streaming hook), and `CliExecutor`'s process model has no line-buffered broadcast plumbing today. Per-tool-call / per-line streaming requires executor instrumentation that isn't a UI design decision.
+
+## UI stack and existing surface
+
+- **Stack**: Livewire Volt single-file components mounted as Laravel Folio pages (file convention `⚡name.blade.php`). Classed Livewire components are not the working pattern (`app/Livewire/` holds only Actions). New pages and shells in the brief should follow Volt-in-Folio, not Livewire classes.
+- **Triage**, not Inbox. The page that holds Stories awaiting approval is named **Triage** (Linear's term — implies a queue you process). Existing `pages/⚡inbox.blade.php` is renamed.
+- **Story document** is extended in place (`pages/stories/⚡show.blade.php`) — it already wires `AcceptanceCriterion`, `Task`, `Subtask`, `AgentRun`, `ApprovalService`, `ExecutionService`. The redesign is layout + visual system on top of existing data wiring, not a rewrite.
+
+## AgentRun kinds
+
+- `execute` — the original Subtask run that produces a diff and opens a PR (ADR-0004). Has a subtask spine in its run console.
+- `respond_to_review` — dispatched by webhook when review comments arrive on a PR Specify owns (ADR-0008). Pushes commits to the existing PR's branch; does **not** open a new PR, change cascade, or reset Story approval. Capped by `max_review_response_cycles` per PR.
+
+Both kinds share the same run-console shell, parameterised by kind:
+- `execute`: spine + tabs (Logs / Timeline / Diff / PR).
+- `respond_to_review`: no spine; tabs become Logs / Timeline / Diff / **Comments being addressed** (file/line groups). Header shows cycle counter (`2 of 3`) and a link back to the parent `execute` run.
+
+The **Subtask drawer** renders all AgentRuns for a Subtask as a tree: top-level rows are `execute` runs (1 in single-driver mode, N in race), each expandable to show its `respond_to_review` children chronologically with a per-PR cycle indicator.

--- a/docs/adr/0009-story-snapshots-for-run-authorisation.md
+++ b/docs/adr/0009-story-snapshots-for-run-authorisation.md
@@ -1,0 +1,71 @@
+# 0009. Story snapshots for run authorisation
+
+Date: 2026-05-02
+Status: Proposed
+
+## Context
+
+`Story` carries an integer `revision` that auto-bumps on edit (ADR-0001/0002), and `AgentRun.authorizing_approval` points at the immutable `StoryApproval` row that sanctioned the run. Together they tell us *that* a run was authorised — but not *what was authorised*. The Story body, acceptance criteria, Tasks, and Subtasks are mutated in place. Once a Story moves from v7 to v8, there is no way to render "what v7 looked like."
+
+This is fine for the cascade and the executor — they read the current state when dispatched. It is not fine for two consumers we now want to support:
+
+- **The UI design brief (2026-05-02 draft)** specifies a "Story has changed since this run started — view diff" affordance on the Run console header. With no snapshot, the UI cannot honestly show the v7-at-dispatch-time state alongside the v8 current state.
+- **Audit and post-hoc review.** A reviewer asking "what did I actually approve at 14:02 on 2026-05-01?" today has to read commit history, git branches, and the diff on the open PR. The structured story body and plan as approved are not recoverable.
+
+We considered three paths during the design grill:
+
+1. **Display only the integer revision.** Cheap; loses the audit trail; the UI cannot honestly visualise drift. (Chosen for V1 of the UI brief.)
+2. **Synthesise from `StoryApproval`.** Re-derive a snapshot when revisions match; show "approval record only" otherwise. Lossy and inconsistent.
+3. **Add a real snapshot table.** Hard-to-reverse schema change; full audit trail; UI can render any historical revision verbatim.
+
+V1 ships path 1. This ADR is the schema change that unblocks the drift indicator and a richer audit surface in a later slice.
+
+## Decision
+
+**On every successful approval transition (`PendingApproval → Approved`), `ApprovalService` writes a `story_snapshot` row capturing the Story body, AcceptanceCriteria, Tasks, and Subtasks at that revision. Every Subtask `AgentRun` of `kind=execute` gains a `story_snapshot_id` FK pointing at the snapshot it was authorised against.**
+
+Concrete shape:
+
+- New table `story_snapshots`:
+  - `id`, `story_id`, `revision` (integer; unique with `story_id`), `created_at`.
+  - `body` (JSON; serialised Story description + notes).
+  - `acceptance_criteria` (JSON; ordered list of AC text + position).
+  - `plan` (JSON; ordered list of Tasks each with description, AC link, and ordered Subtasks).
+  - Snapshots are **append-only**; rows are never updated.
+- `agent_runs.story_snapshot_id` (nullable FK on `story_snapshots`). Backfilled to NULL for existing rows; populated for every newly-dispatched `execute` run via `ExecutionService::dispatchSubtaskExecution`.
+- Snapshots are taken **at approval time**, not at dispatch time. `ApprovalService::recompute()` writes the snapshot the moment `required_approvals` is met, before any cascade kicks off. This guarantees the snapshot reflects the human-approved state rather than a state the executor's append-only growth (ADR-0005) might have already drifted past.
+- Append-only growth (ADR-0005) does **not** create a new snapshot. The growth is part of the run's output, not part of the approved spec; the snapshot is the spec-as-approved.
+- Edits that reset approval (ADR-0001) bump `Story.revision` and clear no snapshots — old snapshots stay forever as audit records. The next approval writes the next snapshot at the new revision.
+- `respond_to_review` runs (ADR-0008) do **not** carry a `story_snapshot_id` — they don't change spec; their authorising context is the parent `execute` run.
+
+UI consequences (not part of this ADR's schema, but the reason it's being proposed):
+
+- Run console header gains a `View story at v7` link → read-only render of the snapshot JSON.
+- "Story has changed since this run started" drift indicator appears when `Story.revision > AgentRun.story_snapshot.revision`.
+- Story document right rail can list "approved revisions" (snapshot count + most recent approval timestamps).
+
+## Consequences
+
+### Positive
+
+- The "what was approved" question becomes queryable: `agent_runs.story_snapshot_id → story_snapshots.*` reads exactly the spec the human authorised, regardless of what the live Story looks like now.
+- ADR-0001's invariant ("approval is the only gate") gains a concrete artefact in the data model — the snapshot is the proof.
+- The UI can honestly render drift between "what was approved" and "what is current" without lying about capabilities (UI brief Principle 4).
+
+### Negative
+
+- **Storage growth.** Every approval writes a snapshot; large Stories (50+ Subtasks) will produce non-trivial JSON blobs. Mitigation: at scale, prune snapshots older than N revisions per Story (with a config knob); not in V1.
+- **Backfill ambiguity.** Existing `execute` runs have `story_snapshot_id = NULL`. Either accept the gap (old runs simply have no snapshot, UI shows "snapshot unavailable") or run a one-shot best-effort backfill from current Story state for runs where revisions still match. Lean: accept the gap.
+- **Snapshot drift from running runs.** If a snapshot is written at approval time but the executor's append-only growth (ADR-0005) extends the plan during the run, the snapshot will not reflect the appended Subtasks. This is intentional — the snapshot is "what was approved," not "what was executed" — but it must be documented so reviewers don't read it as a contradiction.
+
+### Neutral
+
+- ADR-0001 is preserved: Story is still the only approval gate; snapshots are an audit artefact, not a new gate.
+- ADR-0005 is preserved: append-only growth still does not reset approval and still does not produce a new snapshot.
+- ADR-0008 is preserved: `respond_to_review` runs don't snapshot because they don't change spec.
+
+## Open questions
+
+- Snapshot pruning policy at scale — flag knob, retention horizon, or both?
+- Should the snapshot include a hash of its own JSON for tamper detection? Probably yes; small column, big audit value.
+- Should snapshots be written **before** the cascade dispatches the first Subtask, or **after**? Lean: before — the cascade should never run against an unwritten snapshot.

--- a/docs/adr/0010-cancel-and-retry-for-agent-runs.md
+++ b/docs/adr/0010-cancel-and-retry-for-agent-runs.md
@@ -1,0 +1,78 @@
+# 0010. Cancel and retry semantics for AgentRuns
+
+Date: 2026-05-02
+Status: Proposed
+
+## Context
+
+Two affordances the UI design brief (2026-05-02 draft) explicitly defers because no domain plumbing exists for them today:
+
+- **Cancel a running AgentRun.** `Executor::execute` (ADR-0003) returns one `ExecutionResult` at the end and has no in-process kill switch. `LaravelAiExecutor` runs synchronously inside `ExecuteSubtaskJob` with no cooperative cancel point. `CliExecutor` has a configurable timeout but no cancel plumbing — operators currently kill the queue worker or wait for the timeout.
+- **Retry a Failed Subtask.** `ExecuteSubtaskJob` is dispatched per Subtask; once a run terminates Failed and the Subtask is Blocked, there's no domain affordance to dispatch another attempt without manual database surgery.
+
+Race mode (ADR-0006) makes both questions ambiguous in a way single-driver mode does not: cancelling "the run for this Subtask" could mean one sibling or all N. Retrying could mean re-running just the failed sibling or the whole race fan-out.
+
+A third related affordance — **retrying just the PR-creation step** for a Succeeded run that has `pull_request_error` set — is named in ADR-0004's follow-ups. It is the same family of operation (act on an existing AgentRun's artefacts) without being either cancel or retry of the run itself.
+
+Two implementation shapes were considered for cancel:
+
+- **Hard cancel via SIGTERM.** Works for `CliExecutor`; doesn't work for `LaravelAiExecutor` (synchronous in-process model call). Requires per-driver branching in the cancel controller. Honest about its asymmetry; partial.
+- **Cooperative cancel via flag.** `agent_runs.cancel_requested` column; the pipeline polls between phases (and, where the executor cooperates, between tool calls). Doesn't kill long-running tool calls mid-flight. Honest about its partiality; works uniformly across drivers.
+
+We chose cooperative + per-driver augmentation: the flag is the universal contract; drivers that can react more quickly do so.
+
+## Decision
+
+**Cancel is cooperative, retry creates a new AgentRun, and the PR-retry case becomes a third domain operation with its own job. All three are surfaced through `ExecutionService` and live alongside the existing dispatch path; none mutates an existing AgentRun's terminal state.**
+
+Concrete shape:
+
+### Cancel
+
+- New column `agent_runs.cancel_requested` (boolean, default false). Set by `ExecutionService::cancelRun(AgentRun)`; cleared on terminal state.
+- `SubtaskRunPipeline` polls the flag between phases (prepare / checkout / execute / commit / diff / push / open PR). When set, it transitions to a new terminal state `Cancelled` (Failure-class — the cascade treats it as Blocked).
+- `Executor` interface gains an optional `supportsCooperativeCancel(): bool` capability (default false). Drivers that opt in receive a `CancelToken` argument on `execute()` and may check it between tool calls. `LaravelAiExecutor` opts in (the agent loop is ours); `CliExecutor` does not (CLI process is opaque). Cancel for non-cooperating drivers waits for the next pipeline-phase boundary or the configured timeout.
+- New state `AgentRunStatus::Cancelled`. `SubtaskRunOutcome::cancelled()` factory; `isFailure()` true.
+- **Race semantics**: `cancelRun` cancels exactly the targeted AgentRun. A `cancelSubtask(Subtask)` convenience method cancels all sibling AgentRuns for that Subtask. The UI offers both; the API is explicit.
+
+### Retry
+
+- Retry is **not** a state transition on the existing run; it is a **new AgentRun**. `agent_runs` is append-only (CLAUDE.md).
+- New column `agent_runs.retry_of_id` (nullable FK on `agent_runs`). Populated when `ExecutionService::retrySubtaskExecution(Subtask, ?fromRun)` dispatches a fresh run for a Subtask whose previous run terminated Failed / Cancelled / Blocked.
+- The new run authorises against the **same `StoryApproval`** as the retried-from run, *only if* the Story is still at the same revision. If the Story has been edited since (revision bumped → approval reset → re-approved at a new revision), the retry binds to the **current** approving `StoryApproval`. Retrying a run authorised by an approval that has been revoked or superseded by ChangesRequested fails with a clear error.
+- Race mode: `retrySubtaskExecution` retries **only the targeted sibling driver** by default; an explicit `retryRace(Subtask)` retries every driver in the configured race list.
+- `respond_to_review` runs (ADR-0008) are not retryable through this mechanism — they re-fire automatically when new review events arrive (subject to cycle cap).
+
+### PR retry
+
+- New job `OpenPullRequestJob` and corresponding `ExecutionService::retryPullRequestOpen(AgentRun)` for runs in state Succeeded with `pull_request_error` set and `pull_request_url` empty.
+- Re-invokes `PullRequestManager::for($repo)?->open(...)` against the AgentRun's recorded branch and commit. On success: clears `pull_request_error`, stamps `pull_request_url` on the AgentRun's output. On failure: overwrites `pull_request_error` with the new message; AgentRun remains Succeeded (ADR-0004 preserved).
+- Idempotent: if a PR already exists for the branch (returned by `PullRequestProvider::find($branch)`), adopt its URL rather than open a duplicate.
+- Race siblings: each AgentRun is a separate row with its own `pull_request_error`; PR retry operates per-run.
+
+## Consequences
+
+### Positive
+
+- The "kill this run" question gets an honest answer: cooperative cancel works uniformly, drivers that can react faster do, drivers that can't fall back to phase-boundary checks.
+- Retry becomes a queryable history (`retry_of_id` chain) rather than a hidden re-dispatch — a reviewer can ask "how many attempts did Subtask 37 take?" and get an answer.
+- ADR-0004's named follow-up (retry the PR open for a successful run) lands without any change to the run's terminal-state semantics.
+- ADR-0001's invariant (approval is the only gate) stays intact: retry re-resolves authorisation through the current `StoryApproval`, never bypasses it.
+
+### Negative
+
+- `CliExecutor` cancel latency is bounded only by the next phase boundary (typically the executor's full timeout). Mitigation: the timeout is the failsafe; truly stuck CLI runs require operator intervention. A future driver-specific cancel (signal the process group) is a follow-up, not blocking.
+- `cancel_requested` and `retry_of_id` are two new columns on `agent_runs`. Schema growth is cheap but adds to the surface area of the append-only invariant — both columns are write-once at dispatch / cancel-request time, never mutated thereafter.
+- PR retry can re-introduce ordering races if invoked while the original `open()` call is still in flight on a slow API. Mitigation: a `Cache::lock` keyed by `agent_run_id` serialises the retry against any concurrent PR open attempt.
+
+### Neutral
+
+- ADR-0003 is amended in place to note the optional `supportsCooperativeCancel()` capability. Existing executors continue to work without it.
+- ADR-0006 (race mode) is preserved: cancel and retry both operate per-AgentRun; sibling cancel/retry are explicit conveniences, not hidden cascades.
+- ADR-0008 (respond-to-review) is preserved: review-response runs are not subject to manual retry.
+
+## Open questions
+
+- Should `Cancelled` runs count toward the race-mode cascade gate (`finalizeSubtaskFromRun`)? Lean: yes — Cancelled is a Failure-class terminal state; the cascade treats it the same as Failed for the "no sibling Succeeded → Blocked" rule.
+- Should retry be exposed as an MCP tool, or only as a UI button? Probably both, but the MCP tool wants its own surface (input validation, audit log entry).
+- A "retry from phase N" affordance (skip prepare/checkout if branch already exists, resume from commit) would speed retries but couples the retry semantics to the pipeline's internals. Defer; for V1, retry replays the whole pipeline.

--- a/docs/adr/0011-streaming-progress-events-from-executors.md
+++ b/docs/adr/0011-streaming-progress-events-from-executors.md
@@ -1,0 +1,79 @@
+# 0011. Streaming progress events from executors
+
+Date: 2026-05-02
+Status: Proposed
+
+## Context
+
+The UI design brief (2026-05-02 draft) ships log streaming via HTTP polling on `runs/{id}/logs?after={cursor}` at 1–2s intervals. That works because it requires no executor changes, but it has two known limits:
+
+- **Latency floor.** The fastest a watcher sees a tool call is "next poll cycle." For runs that produce 10+ tool calls per second (large refactors), the user sees jumpy bursts of work, not a live console.
+- **Cost.** Every connected watcher polls; a Story page with N watchers and a long-running run is N requests per second against the runs endpoint, even when nothing has happened.
+
+The honest fix is to push events from the executor as they happen. ADR-0003's follow-ups list capability flags exactly for this case ("supports streaming, supports interactive clarification") — the design grill confirmed they're load-bearing for a real-time console.
+
+Two implementation shapes were considered:
+
+- **Tail the agent_run row.** Executor writes log lines to a `agent_run_events` table; the controller exposes a Reverb-bridged stream. Decouples the executor from broadcasting but doubles writes (DB + broadcast); growing event log inflates run row size.
+- **Broadcast directly from the executor.** Executor calls `broadcast()` per event; transport layer is Reverb private channels. No extra storage; events are ephemeral (a watcher who joins late sees no history beyond what's in the polling endpoint).
+
+We chose **broadcast-direct with HTTP-poll fallback** for late joiners. The poll endpoint stays as the source of truth for "what happened in this run"; the broadcast is the low-latency optimisation for connected watchers.
+
+## Decision
+
+**The `Executor` interface gains an optional `ProgressEmitter` argument and a `supportsProgressEvents(): bool` capability. Drivers that opt in emit structured events as they make tool calls; the pipeline persists each event to `agent_run_events` and broadcasts it on `runs.{agent_run_id}.log`. The HTTP-poll endpoint reads from `agent_run_events`; Reverb watchers receive the events live.**
+
+Concrete shape:
+
+- New table `agent_run_events`:
+  - `id`, `agent_run_id` FK, `seq` (per-run monotonic), `ts`, `type` (`tool_call|edit|shell|thinking|stdout|stderr|error|sentinel`), `payload` (JSON).
+  - Unique index on `(agent_run_id, seq)`.
+  - **Append-only**; never updated.
+- `Executor::execute()` signature extends to accept an optional `ProgressEmitter $emitter`:
+  ```php
+  public function execute(
+      Subtask $subtask,
+      ?string $workingDir,
+      ?Repo $repo,
+      ?string $workingBranch,
+      ?ProgressEmitter $emitter = null,
+  ): ExecutionResult;
+  ```
+  Drivers that don't implement progress events ignore the argument; existing executors compile unchanged.
+- `ProgressEmitter` is a thin wrapper around the run's id and a sequence counter. Calls to `emit($type, $payload)` write a row to `agent_run_events` and broadcast on `runs.{id}.log`. Writes are batched per pipeline phase (typed buffer, flushed every 250ms or on phase boundary) to keep DB churn bounded.
+- New capability flag `Executor::supportsProgressEvents(): bool` (default false). The pipeline reads it once at run start and only constructs an emitter for cooperating drivers.
+- **`LaravelAiExecutor`** opts in. Tool-call lifecycle hooks emit `tool_call`, `edit`, `shell`, and `thinking` events; the agent loop already has the introspection points.
+- **`CliExecutor`** opts in for stdout/stderr only. The process pipe is read line-buffered and emitted as `stdout` / `stderr` events; sentinel-block parsing (ADR-0007 `<<<SPECIFY:already_complete>>>`; future: `clarifications`) is detected at emit time and tagged as `sentinel`. Tool-call introspection is not available for opaque CLIs.
+- **`FakeExecutor`** opts in with synthetic events for tests.
+- HTTP-poll endpoint `runs/{id}/logs?after={cursor}` reads from `agent_run_events` (`WHERE seq > cursor ORDER BY seq`). Polling and Reverb both read the same table; the broadcast is the live optimisation.
+- The runs page's existing log rendering (Slice 2 of the UI brief) is unchanged: it already consumes the polling endpoint. Reverb support is layered on; on disconnect, the Volt component falls back to polling.
+
+The interface change to `Executor::execute` is the only ADR-0003 amendment this ADR introduces. Capability flag preserves backwards compatibility — non-cooperating drivers do nothing differently and have no rows in `agent_run_events`.
+
+## Consequences
+
+### Positive
+
+- Latency floor drops from "next poll" to "next broadcast" — typically <100ms for connected watchers.
+- The HTTP-poll endpoint remains authoritative; late joiners and disconnected watchers reconstruct full history from `agent_run_events`. No "you missed it" gaps.
+- The flame-chart Timeline tab (UI brief Slice 3, structured drivers only) gains its data source for free — `agent_run_events` rows of type `tool_call` already encode the start/end timestamps it needs.
+- Sentinel parsing for CLI runs becomes a first-class typed event rather than a UI-side string match.
+
+### Negative
+
+- **Database write amplification.** A run that previously produced 1 row in `agent_runs` now produces N rows in `agent_run_events`. Mitigation: 250ms emitter batching; partition or prune `agent_run_events` older than M days (config knob) once the table grows.
+- **Reverb fanout cost** scales with watchers per run. Mitigation: events are private-channel; only authorised watchers join. For pathologically chatty runs, the batching window absorbs most of the cost.
+- **Broadcast/persist ordering**: events must persist before broadcast (otherwise a Reverb-only watcher could see an event that's not in the poll endpoint). Mitigation: emitter writes the row, then broadcasts; on broadcast failure, the row stays — eventual consistency holds via polling.
+
+### Neutral
+
+- ADR-0001 / ADR-0008: unchanged. Streaming is a transport concern; approval and review-response semantics don't move.
+- ADR-0003: amended in place to record the optional `ProgressEmitter` argument and the `supportsProgressEvents` capability. Existing drivers compile unchanged.
+- ADR-0007: the `<<<SPECIFY:already_complete>>>` sentinel becomes a typed `sentinel` event in addition to its end-of-run parse. Both paths converge on the same evidence list.
+
+## Open questions
+
+- Should `agent_run_events` carry a `phase` column (prepare / execute / commit / push / etc.) for filtering, or is `type` enough? Lean: yes, add `phase`; cheap, useful for the Timeline view.
+- Retention: how long do we keep events for terminated runs? Lean: 30 days default, configurable; long enough for review-response cycles to matter.
+- Should the broadcast carry the full payload or just `(seq, type)` with a refetch from the endpoint? Lean: full payload — Reverb message size limits are generous and refetch defeats the latency win.
+- Future drivers that emit token-level events (e.g. streaming model output as it generates) need a per-token `thinking` rate that may overwhelm the 250ms batch window. Cap or sample at emit time? Defer until a driver actually does this.

--- a/docs/adr/0012-project-first-information-architecture.md
+++ b/docs/adr/0012-project-first-information-architecture.md
@@ -1,7 +1,7 @@
 # 0012. Project-first information architecture
 
 Date: 2026-05-02
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/0012-project-first-information-architecture.md
+++ b/docs/adr/0012-project-first-information-architecture.md
@@ -1,0 +1,173 @@
+# 0012. Project-first information architecture
+
+Date: 2026-05-02
+Status: Proposed
+
+## Context
+
+The shell that grew alongside the early features is flat: every record-type — Features, Stories, Runs, Repos, Events, Inbox — sits at the workspace level in the sidebar, and the URLs that back them are unscoped (`/stories/{id}`, `/runs/{id}`, `/features`). That worked while the system carried one project; it does not work now.
+
+Concrete failures observed in the live shell (2026-05-02 visual smoke):
+
+- **No project context is ever visible**. Switching projects in the workspace switcher updates a session value but the rest of the UI doesn't reflect it — the Stories list is workspace-wide, the Runs list is workspace-wide, breadcrumbs lead back to "Approval inbox" rather than the parent Feature / Project.
+- **`/stories/{id}` cannot be parsed at a glance**. The URL gives no hint of which Project or Feature the Story belongs to, so notification deep-links and PR descriptions force the reader to open the page to orient.
+- **Repos sit at the wrong level** — they're attached to Projects (per ADR-0006's project-repo wiring), but the sidebar lists them as a workspace concern.
+- **The triage role and the project role share one nav surface** — a reviewer clearing the cross-project queue and an engineer working a single project are looking at the same flat list and the same flat URLs.
+- **Feature has no document of its own**. The route `features.show` exists but renders a thin list; Stories' rail/pill/decision chrome doesn't roll up to the Feature.
+
+The grilling that produced the UI design brief (2026-05-02) settled five branches:
+
+1. Workspace is **ambient chrome** — switcher only, never a navigation target. (Q1.)
+2. The **project** is the persistent context. The active project drives every project-scoped page.
+3. **Triage** is **workspace-wide** — a cross-project reviewer queue. (renamed from "Approval inbox".)
+4. **Activity** replaces "Events" as the cross-project event stream.
+5. **Run console URL** is nested: `/projects/{p}/stories/{s}/subtasks/{st}/runs/{r}`. The brief recorded this but the routes never landed.
+
+This ADR records the IA decision so the slice-by-slice migration that follows has a single load-bearing reference.
+
+## Decision
+
+**The shell uses two-section sidebar navigation: a workspace-scoped section (Triage, Activity) and a project-scoped section bound to a session-persisted active project. All record-type listings, the Story document, and the run console live under `/projects/{p}/...`. The legacy flat URLs 301 to their nested equivalents.**
+
+Concrete shape:
+
+### Sidebar
+
+```
+Sidebar
+─────────────────────────────────
+[Workspace ▾]                    ← ambient: switcher only
+─────────────────────────────────
+Triage          ← cross-project approval queue (renamed from Inbox)
+Activity        ← cross-project event stream (renamed from Events)
+─────────────────────────────────
+[Project ▾]                      ← own dropdown; persistent active project
+  Overview
+  Features
+  Stories
+  Runs
+  Repos
+─────────────────────────────────
+[User ▾]
+```
+
+The workspace switcher and the project switcher are **separate dropdowns**. They are not nested — switching workspace clears the active project and shows a project picker; switching project preserves the workspace.
+
+### Active-project state
+
+A single new column carries the persistence:
+
+```php
+Schema::table('users', function (Blueprint $t) {
+    $t->foreignId('active_project_id')->nullable()->constrained('projects')->nullOnDelete();
+});
+```
+
+- **Read path**: `session('active_project_id')`. Cheap, request-local; no DB hit per request.
+- **Write path**: switching project writes both `session()` and `users.active_project_id`. The DB column is the cross-device fallback hydrated on login.
+- **First login**: pick the first project the user can access. If they have zero, render a project picker (no project menu shown).
+- **Stale session**: if the session id no longer matches a project the user can access, fall back to the column; if that's also stale, fall back to "first accessible".
+- **Authorisation**: every project-scoped route must `abort_unless($user->canAccessProject($project), 404)`. Active-project state is a UI affordance, not a permission grant.
+
+### Routes
+
+| Workspace-scoped | Purpose |
+|---|---|
+| `/triage` | cross-project approval queue (renamed from `/inbox`) |
+| `/activity` | cross-project event stream (renamed from `/events`) |
+
+| Project-scoped | Purpose |
+|---|---|
+| `/projects/{project}` | project overview (in-flight stories, recent runs, blockers) |
+| `/projects/{project}/features` | feature list |
+| `/projects/{project}/features/{feature}` | feature page (status pill rolls up child stories) |
+| `/projects/{project}/stories` | cross-feature story list for the project |
+| `/projects/{project}/stories/{story}` | Story document (canonical) |
+| `/projects/{project}/stories/{story}/subtasks/{subtask}` | subtask drawer |
+| `/projects/{project}/stories/{story}/subtasks/{subtask}/runs/{run}` | run console |
+| `/projects/{project}/runs` | recent runs for this project |
+| `/projects/{project}/repos` | repos connected to this project |
+
+### Legacy URL handling
+
+| Legacy | Behaviour |
+|---|---|
+| `/inbox` | 301 → `/triage` |
+| `/events` | 301 → `/activity` |
+| `/stories/{id}` | 301 → `/projects/{p}/stories/{s}` (resolve `p` from `story.feature.project_id`) |
+| `/runs/{id}` | 301 → `/projects/{p}/stories/{s}/subtasks/{st}/runs/{r}` (resolve via `agent_run.runnable`); for plan-generation runs (Story-runnable) → `/projects/{p}/stories/{s}` |
+| `/features`, `/features/{p}/{f}` | 301 → project-scoped equivalent if active project resolves; 404 otherwise |
+| `/dashboard` | retired; 301 → `/projects/{p}` |
+
+The redirect map lives in **one place** — a single `RedirectController` (or `routes/web.php` block). PR descriptions, Slack links, and outbound notification emails written against legacy URLs continue to resolve.
+
+### Folio file layout
+
+The Folio convention (`resources/views/pages/`) maps URL segments to file paths via `[param]` directories. The new layout:
+
+```
+pages/
+├── triage.blade.php
+├── activity.blade.php
+├── projects/
+│   └── [project]/
+│       ├── index.blade.php              # project overview
+│       ├── features/
+│       │   ├── index.blade.php
+│       │   └── [feature].blade.php
+│       ├── stories/
+│       │   ├── index.blade.php
+│       │   └── [story]/
+│       │       ├── index.blade.php       # story document (canonical)
+│       │       └── subtasks/
+│       │           └── [subtask]/
+│       │               ├── index.blade.php  # drawer/page
+│       │               └── runs/
+│       │                   └── [run].blade.php  # run console
+│       ├── runs/
+│       │   └── index.blade.php
+│       └── repos/
+│           └── index.blade.php
+```
+
+The current `pages/stories/⚡show.blade.php` moves verbatim to `pages/projects/[project]/stories/[story]/index.blade.php`. The component logic does not change — only the URL by which it's reached.
+
+### Slice plan
+
+Migration ships in four slices behind individual PRs, each independently mergeable:
+
+- **Slice 1** — sidebar shell + workspace renames. New sidebar layout, `/inbox` → `/triage`, `/events` → `/activity`, `users.active_project_id` migration, project switcher dropdown, no page-content changes. Existing 278 tests stay green.
+- **Slice 2** — project-scoped listings. `/projects/{p}` overview + `/projects/{p}/{features,stories,runs,repos}`; legacy 301 redirects; breadcrumbs `{Project} › {Section}`. Cross-project firehose lists removed.
+- **Slice 3** — nested Story / Subtask / Run console URLs. Story document moves to `/projects/{p}/stories/{s}`; subtask drawer and run console land. Notification emails / webhooks updated to canonical URLs.
+- **Slice 4** — Feature page chrome. Rail/pill rolling up child story states; child story list with shared row chrome.
+
+## Consequences
+
+### Positive
+
+- **Project context is visible everywhere** — the URL, the breadcrumb, and the sidebar all carry the active project. Switching project moves the whole UI atomically.
+- **Triage role is separated from project role**. A reviewer working the cross-project queue and an engineer working a single project see distinct nav and distinct URLs.
+- **Deep-links are self-describing** — `/projects/specify/stories/manage-context-items` orients the reader without opening the page.
+- **Repos and Runs are scoped correctly** — they live under the project that owns them, not the workspace.
+- **The Feature finally has its own document**, with the same rail/pill chrome the Story uses; rolling tallies make Feature-level state visible at a glance.
+- **The brief's Slice 2 run-console URL contract can finally land** — the routes exist for the brief's nested run-console anatomy to attach to.
+
+### Negative
+
+- **Volume of file moves** — every existing page under `pages/` either moves under `pages/projects/[project]/...` or gets a redirect. Four slices and an explicit redirect map keep the blast radius bounded; tests cover every old → new mapping.
+- **Active-project hydration is a new failure mode** — a stale session id pointing at a deleted project or a project the user no longer accesses must fall back gracefully. ADR specifies the fallback chain (column → first-accessible → picker); tests cover each branch.
+- **Breadcrumbs become page chrome** — every page renders `{Project} › {Section} [› {Subsection}]`, so the breadcrumb component must be a first-class layout primitive rather than a per-page snippet.
+
+### Neutral
+
+- **ADR-0001 unchanged** — Story is still the only approval gate; the IA change is shell-level.
+- **ADR-0006 unchanged** — multi-executor race mode is per-Subtask; the run console URL nests it under Subtask cleanly.
+- **MCP tools unchanged** — the MCP tool surface (`get-story`, `list-runs`, etc.) returns IDs, not URLs; the client stitches URLs from the active context. The IA change ripples through the web shell only.
+
+## Open questions
+
+- **`/dashboard`** — kill outright (301 to `/projects/{p}`) or keep as a thin "all your projects" landing for users with multiple? Lean: kill; the project overview is the home; users who span projects use Triage as their cross-project surface.
+- **Project picker on first login** — show only when the user has zero accessible projects, or also when they have many and no clear default? Lean: show only on zero; pick first accessible otherwise.
+- **Breadcrumb for Triage / Activity** — render as just `Triage` / `Activity` (no chain), or as `Workspace › Triage`? Lean: just `Triage` / `Activity` — the workspace is ambient.
+- **Triage filter chip "current project only"** — Slice 1 or Slice 2? Lean: Slice 2; Slice 1 ships cross-project only and adds the chip alongside the project-scoped routes.
+- **MCP `current-context` tool** — should it return the active project, the workspace, or both? Lean: both; the agent already needs project context to scope MCP queries; the workspace is informational.

--- a/docs/adr/0012-project-first-information-architecture.md
+++ b/docs/adr/0012-project-first-information-architecture.md
@@ -55,19 +55,19 @@ The workspace switcher and the project switcher are **separate dropdowns**. They
 
 ### Active-project state
 
-A single new column carries the persistence:
+The active project is persisted in the existing `users.current_project_id`
+column. The session-first read path described in earlier drafts of this ADR
+was not adopted — the column is read directly per request (the existing
+`User` model already exposes it). What shipped:
 
-```php
-Schema::table('users', function (Blueprint $t) {
-    $t->foreignId('active_project_id')->nullable()->constrained('projects')->nullOnDelete();
-});
-```
+- **Read path**: `auth()->user()->current_project_id` — direct column read.
+- **Write path**: every project-scoped page's `mount(int $project)` validates the URL param against `accessibleProjectIds()` and pins the column to match (see `pages/stories/⚡show.blade.php`, `pages/stories/⚡index.blade.php`, `pages/runs/⚡index.blade.php`, `pages/repos/⚡index.blade.php`, `pages/subtasks/⚡show.blade.php`, `pages/runs/⚡show.blade.php`). The URL is the source of truth; the column mirrors the URL so the sidebar and other workspace-scoped pages stay in sync.
+- **Switcher**: `livewire/app-switcher` writes the column via `User::switchProject()` and navigates back to the referer.
+- **Stale-pin fallback (legacy redirects)**: when `/stories`, `/runs`, `/repos`, or `/stories/create` are hit, the redirect helper checks `current_project_id` against `accessibleProjectIds()` before composing the project-scoped URL; if the pin is stale (project deleted or membership revoked), it falls back to `/projects` rather than emitting a broken link. See `routes/web.php`.
+- **First login**: no special handling — the column is null until the user picks a project. The sidebar's Project section collapses to a single "Pick a project" link in that state.
+- **Authorisation**: every project-scoped page mount aborts 404 when the URL param isn't in `accessibleProjectIds()`. Active-project state is a UI affordance, not a permission grant.
 
-- **Read path**: `session('active_project_id')`. Cheap, request-local; no DB hit per request.
-- **Write path**: switching project writes both `session()` and `users.active_project_id`. The DB column is the cross-device fallback hydrated on login.
-- **First login**: pick the first project the user can access. If they have zero, render a project picker (no project menu shown).
-- **Stale session**: if the session id no longer matches a project the user can access, fall back to the column; if that's also stale, fall back to "first accessible".
-- **Authorisation**: every project-scoped route must `abort_unless($user->canAccessProject($project), 404)`. Active-project state is a UI affordance, not a permission grant.
+**Why no session-first?** The original draft proposed `session('active_project_id')` as the read path with the column as a cross-device fallback. In practice the column is cheap (already loaded with the User row each request), the URL is canonical for project-scoped pages anyway, and adding a session layer would have introduced a stale-state class without a corresponding cost saving. If a future need arises (multi-tab, cross-device sync), the session layer can be re-introduced as a non-breaking addition.
 
 ### Routes
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,6 +18,6 @@ except to mark them Superseded.
 | [0009](0009-story-snapshots-for-run-authorisation.md) | Story snapshots for run authorisation | Proposed |
 | [0010](0010-cancel-and-retry-for-agent-runs.md) | Cancel and retry semantics for AgentRuns | Proposed |
 | [0011](0011-streaming-progress-events-from-executors.md) | Streaming progress events from executors | Proposed |
-| [0012](0012-project-first-information-architecture.md) | Project-first information architecture | Proposed |
+| [0012](0012-project-first-information-architecture.md) | Project-first information architecture | Accepted |
 
 Use [`0000-template.md`](0000-template.md) when adding a new ADR. Number sequentially and update this index.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,5 +18,6 @@ except to mark them Superseded.
 | [0009](0009-story-snapshots-for-run-authorisation.md) | Story snapshots for run authorisation | Proposed |
 | [0010](0010-cancel-and-retry-for-agent-runs.md) | Cancel and retry semantics for AgentRuns | Proposed |
 | [0011](0011-streaming-progress-events-from-executors.md) | Streaming progress events from executors | Proposed |
+| [0012](0012-project-first-information-architecture.md) | Project-first information architecture | Proposed |
 
 Use [`0000-template.md`](0000-template.md) when adding a new ADR. Number sequentially and update this index.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,5 +11,12 @@ except to mark them Superseded.
 | [0002](0002-story-task-subtask-hierarchy.md) | Story → Task → Subtask hierarchy (Plan retired) | Accepted |
 | [0003](0003-pluggable-executor-interface.md) | Pluggable Executor interface | Accepted |
 | [0004](0004-pr-after-push-is-non-fatal.md) | Opening the pull request after push is a non-fatal step | Accepted |
+| [0005](0005-plans-grow-append-only-mid-run.md) | Plans grow append-only mid-run | Accepted |
+| [0006](0006-multi-executor-race-mode.md) | Multi-executor race mode | Accepted |
+| [0007](0007-already-complete-subtasks.md) | Already-complete subtasks | Accepted |
+| [0008](0008-pr-review-feedback-via-webhooks.md) | PR review feedback closes the loop via webhooks | Accepted |
+| [0009](0009-story-snapshots-for-run-authorisation.md) | Story snapshots for run authorisation | Proposed |
+| [0010](0010-cancel-and-retry-for-agent-runs.md) | Cancel and retry semantics for AgentRuns | Proposed |
+| [0011](0011-streaming-progress-events-from-executors.md) | Streaming progress events from executors | Proposed |
 
 Use [`0000-template.md`](0000-template.md) when adding a new ADR. Number sequentially and update this index.

--- a/docs/proposals/ui-design-brief.md
+++ b/docs/proposals/ui-design-brief.md
@@ -22,19 +22,27 @@ This brief is opinionated. Decisions taken during the grill are recorded in `CON
 
 ## 2. Information architecture
 
+This brief was drafted before the IA was finalised; the routes that
+shipped match ADR-0012 — see that ADR for the load-bearing reference.
+Summary of the canonical routes:
+
 ```
-/                                       Workspace landing for the active workspace
-/projects                               Projects index
-/projects/:project                      Project landing
-/features/:feature                      Feature document
-/stories/:story                         Story document — the centerpiece
-/stories/:story/subtasks/:subtask       Subtask drawer (slide-over off the Story plan)
-/stories/:story/subtasks/:subtask/runs/:agent_run_id   Run console
-/triage                                 Stories awaiting approval (renamed from /inbox)
-/runs                                   Runs across all projects
-/repos                                  Workspace-scoped repo registry
-/events                                 Event log
+/triage                                            Cross-project approval queue (renamed from /inbox)
+/activity                                          Cross-project event stream (renamed from /events)
+/projects                                          Projects index
+/projects/:project                                 Project landing (currently the features list; real Overview deferred)
+/projects/:project/features/:feature               Feature document
+/projects/:project/stories                         Stories index for the project
+/projects/:project/stories/:story                  Story document — the centerpiece
+/projects/:project/stories/:story/subtasks/:subtask                 Subtask drawer / page
+/projects/:project/stories/:story/subtasks/:subtask/runs/:run       Run console
+/projects/:project/runs                            Runs for the project
+/projects/:project/repos                           Repos for the project
 ```
+
+Legacy URLs (`/inbox`, `/events`, `/stories/:id`, `/runs/:id`, flat
+`/stories`, `/runs`, `/repos`, `/features`) all 301-redirect to the
+canonical project-scoped equivalents — see `routes/web.php`.
 
 **Workspace is ambient chrome, not a breadcrumb segment.** A switcher sits in the top-left of the global nav (Linear-style); cross-workspace navigation is a hard route change. Inside a workspace, the breadcrumb starts at Project: `Project › Feature › Story › Subtask › Run`.
 

--- a/docs/proposals/ui-design-brief.md
+++ b/docs/proposals/ui-design-brief.md
@@ -1,0 +1,507 @@
+# Specify — UI/UX Design Brief
+
+**Status:** Draft for review (rewritten 2026-05-02 after `/grill-with-docs` against ADRs 0001–0008)
+**Audience:** Implementer (senior eng, comfortable with Livewire Volt / Folio / Flux UI / Tailwind 4 / Reverb)
+**Scope:** End-to-end interface for a hybrid spec + execution system. `Workspace → Project → Feature → Story → Task → Subtask`, with autonomous executor runs, PR review-response runs, and race mode.
+
+This brief is opinionated. Decisions taken during the grill are recorded in `CONTEXT.md` at the repo root — read that for the canonical glossary; this document is the implementation-shaped expansion.
+
+---
+
+## 1. Principles
+
+1. **Approval is the loudest signal.** Story approval gates everything (ADR-0001). Its visual state must be unmistakable from any list, document, or run view — not one chip among many.
+2. **Differentiate levels visually.** Same chrome at every level is Jira-fatigue. Project/Feature feel architectural; Story feels like a contract document; Task/Subtask feel like execution rows.
+3. **One live band, then hard navigate.** Stories show a single ambient band when work is in flight. The deep-dive console is its own page. Nothing in between.
+4. **Don't lie about capabilities the system doesn't have.** No fake SHAs (Story revision is an integer). No snapshot links (no snapshot table). No retry buttons (no retry job). No cancel buttons (no cooperative cancel). When the schema doesn't support it, the UI doesn't pretend it does.
+5. **Motion budget: one moving thing per pane.** Logs may scroll; leaderboards may not also reorder. Quiet enough to leave on a second monitor.
+6. **Never spinner-as-status.** Always render: current subtask, current tool call, elapsed time. Opacity is the agent-UX antipattern.
+7. **Reverb is for low-frequency state events; HTTP-poll for everything else.** Push beats poll only when the event is rare. Per-line streaming is HTTP-poll until executor instrumentation is its own ADR.
+
+---
+
+## 2. Information architecture
+
+```
+/                                       Workspace landing for the active workspace
+/projects                               Projects index
+/projects/:project                      Project landing
+/features/:feature                      Feature document
+/stories/:story                         Story document — the centerpiece
+/stories/:story/subtasks/:subtask       Subtask drawer (slide-over off the Story plan)
+/stories/:story/subtasks/:subtask/runs/:agent_run_id   Run console
+/triage                                 Stories awaiting approval (renamed from /inbox)
+/runs                                   Runs across all projects
+/repos                                  Workspace-scoped repo registry
+/events                                 Event log
+```
+
+**Workspace is ambient chrome, not a breadcrumb segment.** A switcher sits in the top-left of the global nav (Linear-style); cross-workspace navigation is a hard route change. Inside a workspace, the breadcrumb starts at Project: `Project › Feature › Story › Subtask › Run`.
+
+Slide-overs are used **within** a level — opening a Story from a Feature, or opening a Subtask drawer from a Story plan. Cross-level navigation is a real route change.
+
+---
+
+## 3. Visual system
+
+### 3.1 Approval state — the color rail
+
+A 3-px left border rail carries Story approval state on every Story-bearing surface (Triage rows, Feature lists, Story document, Run console header). Approval state is **never** a chip among other chips.
+
+| State              | Rail                                 | Pill text                  |
+|--------------------|--------------------------------------|----------------------------|
+| Draft              | `slate-300`                          | Draft                      |
+| Pending approval   | `amber-500`                          | Pending · `n/N`            |
+| Approved           | `emerald-500`                        | Approved · `N/N`           |
+| Changes requested  | `rose-500`                           | Changes requested          |
+| Rejected           | `slate-500`                          | Rejected                   |
+| Running            | `sky-500` (animated 1.5s pulse)      | (run-state pill, see 3.2)  |
+| Run complete       | `emerald-600`                        | Run complete · PR #N       |
+| Run failed         | `rose-600`                           | Run failed                 |
+
+The approval pill always carries the **threshold tally** (`Pending · 1/2`, `Approved · 2/2`) so a single approver knows whether their click is the last word.
+
+### 3.2 Subtask state vocabulary
+
+State is shown as a dot in the spine, plan, and drawer.
+
+| State                    | Glyph         | Meaning                                                                                       |
+|--------------------------|---------------|------------------------------------------------------------------------------------------------|
+| Queued                   | `○`           | dispatched, not yet started                                                                   |
+| Running                  | `◐` pulse     | active                                                                                        |
+| Done                     | `✓`           | succeeded with a diff and PR                                                                  |
+| Already complete         | `✓⛓`          | declared `alreadyComplete` with cited SHAs (ADR-0007). Clicking expands the SHA list + reason. |
+| Failed                   | `✗`           | terminal failure                                                                              |
+| Blocked                  | `⊘`           | waiting on something (race siblings, etc.)                                                    |
+| Review-response running  | `◐💬`         | a `respond_to_review` run is active on this Subtask's PR                                      |
+
+**Provenance glyph**: a small `+` appears next to any Subtask row whose `proposed_by_run_id` is non-null (ADR-0005), with a tooltip naming the originating AgentRun. Visible everywhere a Subtask row renders.
+
+**Clarifications badge**: a `!` badge appears on the Subtask segment in the live band when active clarifications exist (ADR-0005). Orthogonal to running/failed state.
+
+### 3.3 Level differentiation
+
+| Level    | Surface                          | Chrome cues                                                            |
+|----------|----------------------------------|------------------------------------------------------------------------|
+| Workspace | Top-left switcher (ambient)     | Org icon + name; never in breadcrumb                                   |
+| Project  | Card grid / landing              | Large heading, hero blurb, repo chips                                  |
+| Feature  | Document landing                 | Prose-led, stories appear as a structured list                         |
+| Story    | Document with right rail         | Editor-grade typography, color rail, decision log on right             |
+| Task     | Folded under AC inside Story plan | Compact, secondary; expanded only in Run-mode toggle                  |
+| Subtask  | Row inside Task or run console spine | Terse, monospace identifier, state dot, provenance glyph if appended |
+
+### 3.4 Plan view modes
+
+The Story plan section has a **Plan toggle** (Notion-style):
+- **Grooming** (default when no run is active): Tasks collapsed under their AC. AC text leads.
+- **Run** (default during/after a run): Tasks expanded, Subtasks visible inline with state dots.
+
+Per-user sticky.
+
+---
+
+## 4. Page-by-page
+
+### 4.1 Workspace chrome (global)
+
+- Top-left **workspace switcher** with org icon + name. Click opens a popover listing the user's workspaces. Switching is a hard route change.
+- A workspace-scoped left nav sits below: Triage / Projects / Runs / Repos / Events.
+- Workspace landing (`/`) is the post-switch home: card grid of Projects + recent activity strip + workspace member count + active approval policy summary. Replaces the previous `⚡dashboard.blade.php`.
+
+### 4.2 Triage (`/triage`)
+
+Renamed from `/inbox`. Stories awaiting approval, color-railed.
+
+**Row anatomy** (left → right):
+- Color rail (amber for Pending, rose if Changes requested)
+- Story title (bold) + Feature name (muted)
+- Plan summary: `5 ACs · 13 subtasks` + delta from prior revision when re-submitted
+- Author avatar + relative time
+- Threshold tally on the right (`1/2`, `0/1`)
+- Action buttons:
+  - **Approve** — hidden if the viewer is the Story author (authors cannot approve their own Stories)
+  - **Request changes** — always visible
+  - **Reject** lives in a "more" menu with a hard confirm — terminal, distinct from Request changes
+- Keyboard: `A` Approve, `C` Request changes, `R` Reject (with confirm)
+
+**Empty state**: "No stories pending approval. Nothing's blocking the agents." No illustration.
+
+**Filters at top**: project chip, author chip, age. No saved views in V1.
+
+### 4.3 Projects index (`/projects`)
+
+Existing `pages/projects/⚡index.blade.php`, extended. Card per project; each card shows story counts by state (color-rail summary), open-runs count, primary repo chip.
+
+### 4.4 Project landing (`/projects/:project`)
+
+Existing `pages/projects/⚡show.blade.php`, extended.
+
+- Hero: project name, blurb, primary repo (set via `set-primary-repo`), executor config summary (`single-driver: claude-code` or `race: [claude-code, codex, gemini]`).
+- **Features grid**: cards. Each card = feature title + story counts by state + open-runs count.
+- **Live activity strip**: last N events (run started, story approved, PR opened, review-response dispatched). Truncates; "View all" → `/events`.
+
+### 4.5 Feature document (`/features/:feature`)
+
+Existing `pages/features/⚡show.blade.php`, extended.
+
+- Document layout (max-width prose). Title, owner, description.
+- **Stories list** as cards in vertical stack — color-railed, one-line title + plan summary + state pill (with tally).
+- New Story button (top-right). Clicking a Story opens a **slide-over** (preserves Feature context); ⌘-click → hard route to Story document.
+
+### 4.6 Story document (`/stories/:story`) — the centerpiece
+
+Extended in place at `pages/stories/⚡show.blade.php` (already wires `AcceptanceCriterion`, `Task`, `Subtask`, `AgentRun`, `ApprovalService`, `ExecutionService`). Layout and visual changes only — data wiring stays.
+
+#### Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ ← Feature › Story  [Approved · 2/2]  v7  ⌥E to edit  ⌘K palette    │ breadcrumb + actions
+├──────────────────────────────────────────────────────────────────────┤
+│ ▌ Story title                                                        │
+│ ▌ As a {role}, I want {thing}, so that {outcome}.                    │
+│ ▌                                                                    │
+│ ▌ ── Plan  [Grooming | Run]  · 5 ACs · 13 subtasks · v7              │
+│ ▌ ▸ AC1 — User can submit a story via the MCP tool                   │
+│ ▌ ▸ AC2 — Submitting persists an ApprovalEvent                       │
+│ ▌ ▾ AC3 — Wire MCP submit-story tool                                 │
+│ ▌    Task: Implement submit-story handler             [running 2/4]  │
+│ ▌    ✓ Subtask 3.1                                                   │
+│ ▌    ◐ Subtask 3.2 (current)                                         │
+│ ▌    ○ Subtask 3.3                                                   │
+│ ▌    ○ Subtask 3.4                                                   │
+│ ▌    + Subtask 3.5  (appended by Run #41)                            │
+│ ▌ ▸ AC4 — ...                                                        │
+│ ▌                                                                    │
+│ ▌ ── Live run band (Slice 2; only when work is in flight) ─────      │
+│ ▌ Task1[▮▮▮▮] Task2[▮▮◐▯] Task3[▯▯▯] Task4[▯▯] Task5[▯▯▯]            │
+│ ▌ Run #41 · subtask 3.2 · claude-code · 6m12s  → Watch               │
+└──────────────────────────────────────────────────────────────────────┘
+                              right rail (collapsible) →
+                              ┌──────────────────────────┐
+                              │ State                    │
+                              │ ▌ Approved · 2/2 · v7    │
+                              │                          │
+                              │ Decision log             │
+                              │   ✓ alice  approved      │
+                              │     2026-05-01 14:02     │
+                              │   ✓ bob    approved      │
+                              │     2026-05-01 14:09     │
+                              │                          │
+                              │ Eligible approvers       │
+                              │   alice, bob, carol      │
+                              │                          │
+                              │ Linked PRs               │
+                              │   #123 · open            │
+                              │   #119 · merged          │
+                              │                          │
+                              │ Recent runs              │
+                              │   #41 v7 · running       │
+                              │   #38 v6 · failed        │
+                              │   #34 v5 · complete      │
+                              │                          │
+                              │ Clarifications (4) →     │
+                              └──────────────────────────┘
+```
+
+#### Plan section (AC-led, Task-folded)
+
+- The plan section *is* the AC list. Each row leads with the AC text (product-owner voice, prominent).
+- Below each AC — collapsed by default in **Grooming**, expanded by default in **Run** — sits the Task description (engineering voice, secondary) and the Subtask list with state dots.
+- Subtask rows show the provenance `+` glyph when appended mid-run; clicking opens the Subtask drawer.
+- Reordering is on the AC row; Task and Subtasks move with it. Subtasks within a Task can be reordered independently.
+
+#### Editing
+
+- Inline edit on click for AC text and Story body. No modal.
+- **Plan editing** (adding/editing/removing ACs, Tasks, or Subtasks) opens an in-page editor with a persistent banner:
+  > **Saving will reset this Story to Pending Approval.** Current state: Approved · 2/2 · v7.
+  >
+  > Plan delta: +2 subtasks, ~1 edited, −0 removed. [View diff]
+- Save button label flips to **"Save & request re-approval"** when the change resets approval. Cancel discards.
+- A `respond_to_review` run does *not* count as the kind of edit that resets approval (ADR-0008).
+- While a run is executing the previous revision, edits queue as the next revision: banner says "Run #41 still executing against v7. Saving creates v8 and queues for re-approval."
+
+#### Decision log right rail
+
+- **Immutable** chronological list of `StoryApproval` rows: Approve / ChangesRequested / Reject / Revoke, with approver and time.
+- A user can **revoke** their own prior decision via a small `…` menu on their row. Revoking when threshold was met rolls state back to Pending.
+- ChangesRequested resets the tally; the editor's persistent banner makes that consequence visible *before* the click.
+
+#### Live run band (Slice 2)
+
+When any AgentRun for the Story is non-terminal:
+- Single horizontal band at the bottom of the document, full-width.
+- **Grouped by Task** — one block per Task — with a sub-bar over Subtasks inside each block. Mid-run plan growth (ADR-0005) only reflows inside one Task block; the outer structure stays still.
+- Racing Subtasks have their sub-segment subdivided into N driver stripes.
+- A `!` badge marks Subtasks with active clarifications.
+- A comment-dot glyph + sky rail marks Subtasks with an active `respond_to_review` run on their PR.
+- "Watch" button hard-navigates to the Subtask drawer (or, when only one Subtask is in flight, directly to its run console).
+
+### 4.7 Subtask drawer (`/stories/:story/subtasks/:subtask` slide-over)
+
+The home for the **leaderboard**. Opens as a slide-over from the Story plan (preserving Story context).
+
+#### Anatomy
+
+- Header: AC text (parent), Task description, Subtask name, state dot.
+- **Clarifications strip** (when present) — kind-chipped cards above the leaderboard so reviewers see them before drilling into a specific run.
+- **Leaderboard** — a tree of AgentRuns:
+  - Top-level rows are `execute` runs (1 in single-driver mode, N in race). Each row shows: driver, started, duration, current step, branch, PR link with merge state, run-state badge.
+  - Each row expands to show its `respond_to_review` children chronologically, with a per-PR cycle counter (`2 of 3 used`).
+- Click a row → enter that AgentRun's run console (nested route).
+- Hard-navigate to full-page if drawer feels cramped (race with N>3 siblings).
+
+### 4.8 Run console (`/stories/:story/subtasks/:subtask/runs/:agent_run_id`)
+
+Scoped to **one** AgentRun. Same shell for both `kind`s, parameterised.
+
+#### Header
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ ← Subtask  [Run #41 · v7 · running · 6m 12s]                           │
+│ kind: execute · driver: claude-code · branch: specify/story-11-v7-task-3 │
+│ Started 12:04 · subtask step 2/4                                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+For `respond_to_review`:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ ← Subtask  [Run #43 · responding to PR #123 · cycle 2 of 3]             │
+│ kind: respond_to_review · driver: claude-code · branch: specify/...     │
+│ Parent run: #41 → │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+No "Cancel" button in V1 (no cooperative cancel exists in the executors today — ADR-worthy follow-up).
+
+#### Left spine (`execute` only)
+
+Vertical list of Subtask **steps** (the current Subtask's plan position is fixed; this spine shows step progression within the run).
+
+Wait — clarify: the "spine" in the `execute` console is **the parent Task's Subtasks** (the run is for one Subtask, but the agent's progress through that Subtask isn't itself segmented). Reconsider: the spine is the run's progression within its single Subtask, expressed as **completed phases** (prepare workdir → checkout → execute → commit → diff → push → open PR — the SubtaskRunPipeline phases). State dots track which phase is active.
+
+**Appended-this-run tray** sits beneath the spine when the executor has emitted `proposed_subtasks` (ADR-0005): "+N of 3 cap" header, list of appended subtask names. Original phases above never reflow.
+
+For `respond_to_review`: **no spine** — there's no plan being walked. The space is occupied by the **Comments-being-addressed** pane (file/line groups, status: addressing / done).
+
+#### Center — tabs
+
+| Tab           | `execute`                                         | `respond_to_review`                                  |
+|---------------|---------------------------------------------------|------------------------------------------------------|
+| Logs          | Driver-shaped (see 4.9)                           | Driver-shaped                                        |
+| Timeline      | Flame-chart (laravel-ai only; **hidden** for cli) | Same rule                                            |
+| Diff          | Cumulative working-tree diff (HTTP, on tab focus) | Same                                                 |
+| PR            | PR header + body + advisory review feedback       | (no separate tab — addressed via Comments pane)      |
+| Comments      | (n/a)                                             | File/line groups of review comments being addressed  |
+
+**PR tab error states**:
+- Run completed but `pull_request_error` is set: shows the error, the pushed branch name (`specify/story-...-task-N`), and a host-VCS "compare branches" link so the operator can open the PR manually. **No retry button** in V1; ADR-0004's follow-up retry tool is a future ADR.
+
+#### Right ambient (collapsible)
+
+Always-on summary panel.
+- **Currently doing**: one-line "Editing src/Services/PlanWriter.php" — updates inline, no log scroll required.
+- **Last tool call**: header only (structured drivers); last stdout line (CLI drivers).
+- **Live clarifications cards**: kind-chipped, one card per clarification, as the run produces them.
+
+### 4.9 Logs anatomy by driver (Slice 2)
+
+Two distinct anatomies, picked by `agent_runs.executor_driver`. Driver badge in the Logs tab header.
+
+#### Structured-output drivers (`LaravelAiExecutor`, `FakeExecutor`)
+
+- Foldable per-tool-call blocks: header always visible (`Edit src/foo.ts +12 −3`); body collapsible (args, result).
+- Filter chips: tool / edit / shell / thinking / errors. Multi-select.
+- Thinking renders dimmer (`text-slate-500 italic`).
+- Autoscroll-with-pause; "Jump to live ▼ (N new)" pill on scroll-up.
+- ⌘F in-pane search.
+
+#### CLI drivers (`CliExecutor`)
+
+- Raw ANSI stdout + stderr in terminal-style scrollback. ANSI colour rendering.
+- No kind filters — full-text search instead.
+- **Sentinel blocks** (`<<<SPECIFY:already_complete>>>...<<<END>>>` per ADR-0007; future: clarifications) are detected and rendered **inline as structured callouts** within the stdout stream.
+- Same autoscroll-with-pause behaviour.
+
+**Open follow-up** (not in V1): some CLIs (e.g. Claude Code's `--output-format stream-json`) emit structured events that could promote a CLI run to the structured anatomy. Out of scope; revisit when the CLI sentinel parser is generalised.
+
+#### Transport
+
+- HTTP polling on `runs/{id}/logs?after={cursor}` every 1–2s in V1. No Reverb log streaming.
+- Reverb log streaming is deferred to a future slice with its own ADR — `Executor::execute` returns one `ExecutionResult` at the end and has no streaming hook; `CliExecutor`'s process model has no line-buffered broadcast plumbing today.
+
+### 4.10 `respond_to_review` run console
+
+Same shell as `execute`, parameterised:
+- Header carries cycle counter and parent-run link.
+- No left spine; **Comments being addressed** pane in its place — file/line groups, each comment with status (addressing / done / clarification-only).
+- Tabs: Logs / (Timeline if structured driver) / Diff / Comments.
+- **No PR opens** — commits push to the existing PR's branch.
+
+A `respond_to_review` run does not change cascade, does not reset approval, does not produce new Subtasks (ADR-0008).
+
+---
+
+## 5. Reverb channels and HTTP transport
+
+| Channel / endpoint | Slice | Frequency | Purpose |
+|---|---|---|---|
+| `stories.{id}` (Reverb) | 1 | on state change | approval transitions, run lifecycle milestones, revision bumps |
+| `runs.{agent_run_id}` (Reverb) | 2 | on subtask transition / phase change | current step, state, elapsed |
+| `GET runs/{id}/logs?after={cursor}` (HTTP poll) | 2 | 1–2s | log entries; driver-shaped |
+| `GET runs/{id}/diff` (HTTP) | 2 | one-shot, on tab focus | cumulative working-tree diff |
+| `runs.{agent_run_id}.review` (Reverb) | 3 | on webhook delivery | review-response dispatch |
+| presence / cursors | (dropped) | — | not building Figma |
+
+Each Reverb event payload follows `{type, ts, data}`.
+
+---
+
+## 6. Component / page inventory
+
+Stack: **Livewire Volt SFCs in Folio pages** (file convention `⚡name.blade.php`). Classed Livewire components are not the working pattern (`app/Livewire/` holds only Actions). The brief uses Volt SFCs for composition; Flux UI primitives for chrome; Tailwind 4 for layout.
+
+### 6.1 Primitives (Flux UI + Tailwind components)
+
+| Component | Purpose |
+|---|---|
+| `<x-rail>` | Left color rail (props: `state`). Story rows, document, run header. |
+| `<x-state-pill>` | Text pill with threshold tally where applicable. |
+| `<x-state-dot>` | `○ ◐ ✓ ✓⛓ ✗ ⊘ ◐💬` with motion respect for `prefers-reduced-motion`. |
+| `<x-task-band>` | One block per Task with a sub-progress bar over Subtasks. Used in the live run band. |
+| `<x-driver-stripe>` | Subdivision of a Subtask sub-segment into N driver stripes for race mode. |
+| `<x-tool-call-block>` | Foldable header/body block (structured drivers). |
+| `<x-stdout-pane>` | ANSI-rendered scrollback with sentinel-callout detection (CLI drivers). |
+| `<x-clarification-card>` | Kind-chipped card for a clarification. |
+| `<x-decision-row>` | One immutable row in the decision log. |
+| `<x-provenance-glyph>` | `+` glyph + tooltip for appended Subtasks. |
+
+### 6.2 Volt SFC pages (Folio)
+
+Existing — extended in place:
+- `pages/⚡dashboard.blade.php` → becomes the workspace landing (route `/`).
+- `pages/⚡inbox.blade.php` → **renamed** to `pages/⚡triage.blade.php`.
+- `pages/projects/⚡index.blade.php`, `⚡show.blade.php` — extended with workspace chrome and cards.
+- `pages/features/⚡show.blade.php` — slide-over story navigation.
+- `pages/stories/⚡show.blade.php` — **layout + visual rewrite**, data wiring retained. AC-led plan, decision log rail, live run band (Slice 2).
+- `pages/runs/⚡index.blade.php` — already renders `pull_request_error`; aligned to new state vocabulary.
+- `pages/repos/⚡index.blade.php` — moved under workspace routing.
+- `pages/events/⚡index.blade.php` — feeds the Project landing's live activity strip.
+
+New in this brief:
+- `pages/stories/subtasks/⚡show.blade.php` — Subtask drawer / page with leaderboard.
+- `pages/stories/subtasks/runs/⚡show.blade.php` — Run console (parameterised by `kind`).
+
+### 6.3 Volt fragments / partials
+
+- `live-run-band.blade.php` — listens on `stories.{id}`, renders Task blocks; only mounts when a non-terminal run exists.
+- `run-console-shell.blade.php` — shared shell for both `kind`s; switches spine vs Comments pane on `kind`.
+- `logs-pane.{structured,cli}.blade.php` — driver-shaped variants.
+
+---
+
+## 7. Interactions & keyboard
+
+- **⌘K** global command palette (Linear shape).
+- **⌥E** edit current document (Story body or plan).
+- **A / C / R** in Triage row → Approve / Request changes / Reject (R confirms first).
+- **J / K** down/up in any list.
+- **G then T** → triage. **G then R** → all runs. **G then P** → projects.
+- **⌘F** in-pane search in logs.
+
+All keybindings registered through the Flux command surface; no custom global key handler.
+
+---
+
+## 8. Empty / loading / error states
+
+- **Loading**: skeletons matching populated structure (no centered spinners).
+- **No runs yet**: Story document just has no live band. No nag.
+- **Run failed**: rail goes rose; failed phase shown in spine with error block in Logs. **No retry button in V1.**
+- **PR creation failed (ADR-0004)**: Run rail stays emerald (run succeeded). PR tab shows the error + pushed branch name + host-VCS compare-branches link. **No retry button in V1**; manual PR open on the host VCS.
+- **`respond_to_review` cycle cap reached**: Subtask drawer shows "Cycle cap reached (3/3)" on the parent `execute` row; the leaderboard hides the Add-cycle affordance (there isn't one — webhooks dispatch automatically until the cap).
+- **Reverb disconnected**: amber banner "Live updates paused — reconnecting…". Components fall back to polling for state-only data.
+
+---
+
+## 9. Accessibility
+
+- All color-rail semantics duplicated in text (state pill is the readable label).
+- Timeline flame chart has a tabular fallback (toggle in tab header) — only present on structured-driver runs anyway.
+- All keybindings discoverable via `?` overlay.
+- Live regions (`aria-live="polite"`) for run state changes.
+- Motion respects `prefers-reduced-motion`: pulse becomes static; segmented bar transitions instant.
+
+---
+
+## 10. Slice plan
+
+Three independently-shippable slices.
+
+### Slice 1 — Spec surface (no realtime run viz)
+
+- Workspace switcher chrome + workspace landing.
+- Triage page (renamed from inbox).
+- AC-led Story document with Plan toggle (Grooming / Run).
+- Decision-log right rail with Approve / Request changes / Reject / Revoke. Author cannot approve own Story.
+- Plan-edit reset-approval banner with delta preview.
+- Threshold tally pill (`Pending · 1/2`).
+- `stories.{id}` Reverb channel — state events only (approval transitions, run lifecycle milestones, revision bumps).
+- Existing Folio pages reconciled: `⚡inbox` → `⚡triage`, projects/features/stories/runs/repos pages extended with workspace chrome.
+
+**Not in slice**: live run band, Subtask drawer, Run console, race UI, Timeline, log streaming.
+
+### Slice 2 — Run console & Subtask drawer
+
+- Subtask drawer with leaderboard (1 row single-driver, N rows race; `respond_to_review` children expandable).
+- Nested Run console at `/stories/:story/subtasks/:subtask/runs/:agent_run_id`.
+- Driver-aware Logs anatomy (structured blocks for laravel-ai; ANSI scrollback + inline sentinel callouts for cli).
+- Diff & PR tabs (HTTP, on tab focus).
+- `runs.{agent_run_id}` Reverb channel for state.
+- HTTP-polled logs at `runs/{id}/logs?after={cursor}` (1–2s).
+- Live run band on Story (Task-grouped, sub-bar by Subtask, race driver stripes, clarification `!` badge).
+- Already-complete (`✓⛓`) Subtask state with cited SHA expansion.
+- Clarifications surfaces: run-console ambient panel, Subtask drawer strip, Story right rail digest.
+- Provenance `+` glyph for appended Subtasks; appended-this-run tray in the run console.
+
+**Not in slice**: `respond_to_review` console, Timeline tab, race "diff-of-diffs" tooling.
+
+### Slice 3 — Review-response console + cycle UX + Timeline
+
+- `respond_to_review` console variant (no spine; Comments-being-addressed pane).
+- `runs.{agent_run_id}.review` channel for review-response dispatch.
+- Review-response state on the live band (comment-dot glyph).
+- Timeline tab (flame chart) for structured-driver runs; hidden on CLI runs.
+
+### Out of V1 entirely (each its own ADR)
+
+- Retry-PR button (ADR-0004 follow-up).
+- Run cancel / Subtask retry.
+- `story_snapshots` table + drift indicator + snapshot link.
+- Reverb log streaming + executor instrumentation.
+- Multiplayer presence / cursors.
+- Race "diff-of-diffs" comparison tooling.
+- Stream-JSON CLI promotion to structured anatomy.
+
+---
+
+## 11. Open questions
+
+1. **PR review feedback location** — single right-rail thread, or PR tab section, or both? Brief assumes **both** (mid-run shows in run-console ambient; full thread on PR tab). Validate after Slice 2.
+2. **Plan diff preview format** — git-style hunks vs. structured "added/edited/removed" cards. Brief assumes structured cards; revisit once we see real plan diffs.
+3. **Race-mode resource cost** — running 3 executors per Subtask is expensive. Per-Story toggle? Likely yes; out of scope for this brief but flagged for ADR.
+4. **Workspace landing vs Projects index** — workspace landing (`/`) and `/projects` overlap. Brief makes `/` show projects + recent activity + members, and `/projects` a denser project-only grid. Could collapse to one if the projects grid is the only useful surface.
+5. **Mobile** — out of scope. Story document and Triage are read-only mobile-ok; Run console is desktop-only.
+
+---
+
+## 12. Decisions deferred to implementation
+
+- Specific Tailwind tokens for rail colors (current draft uses default palette; harmonize with brand later).
+- Whether Plan toggle persists per-user or per-Story-state (likely per-user, sticky).
+- Pagination strategy for `/runs` and `/events`.
+- Whether sentinel callouts in CLI logs link out to the structured representation when available (e.g. `already_complete` SHAs as clickable host-VCS links — likely yes, low-cost).

--- a/resources/views/components/decision-row.blade.php
+++ b/resources/views/components/decision-row.blade.php
@@ -16,6 +16,13 @@
         'revoke' => 'text-zinc-500 dark:text-zinc-400',
         default => 'text-zinc-500',
     };
+    $decisionLabel = match ($decision->value) {
+        'approve' => __('Approved'),
+        'changes_requested' => __('Changes requested'),
+        'reject' => __('Rejected'),
+        'revoke' => __('Revoked'),
+        default => \Illuminate\Support\Str::headline($decision->value),
+    };
 @endphp
 
 <div data-decision="{{ $decision->value }}" class="flex items-start gap-2 text-sm">
@@ -23,7 +30,7 @@
     <div class="min-w-0 flex-1">
         <div class="flex flex-wrap items-baseline gap-x-2">
             <span class="font-medium">{{ $approval->approver?->name ?? __('unknown') }}</span>
-            <span class="text-xs text-zinc-500">{{ $decision->value }}</span>
+            <span class="text-xs text-zinc-500">{{ $decisionLabel }}</span>
             @if ($approval->story_revision)
                 <span class="text-xs text-zinc-500">rev {{ $approval->story_revision }}</span>
             @endif

--- a/resources/views/components/decision-row.blade.php
+++ b/resources/views/components/decision-row.blade.php
@@ -1,0 +1,36 @@
+@props(['approval'])
+
+@php
+    $decision = $approval->decision;
+    $glyph = match ($decision->value) {
+        'approve' => '✓',
+        'changes_requested' => '↻',
+        'reject' => '✗',
+        'revoke' => '↶',
+        default => '·',
+    };
+    $tone = match ($decision->value) {
+        'approve' => 'text-emerald-600 dark:text-emerald-400',
+        'changes_requested' => 'text-amber-600 dark:text-amber-400',
+        'reject' => 'text-rose-600 dark:text-rose-400',
+        'revoke' => 'text-zinc-500 dark:text-zinc-400',
+        default => 'text-zinc-500',
+    };
+@endphp
+
+<div data-decision="{{ $decision->value }}" class="flex items-start gap-2 text-sm">
+    <span class="mt-0.5 font-mono {{ $tone }}" aria-hidden="true">{{ $glyph }}</span>
+    <div class="min-w-0 flex-1">
+        <div class="flex flex-wrap items-baseline gap-x-2">
+            <span class="font-medium">{{ $approval->approver?->name ?? __('unknown') }}</span>
+            <span class="text-xs text-zinc-500">{{ $decision->value }}</span>
+            @if ($approval->story_revision)
+                <span class="text-xs text-zinc-500">rev {{ $approval->story_revision }}</span>
+            @endif
+            <span class="ml-auto text-xs text-zinc-400">{{ $approval->created_at?->diffForHumans() }}</span>
+        </div>
+        @if ($approval->notes)
+            <div class="mt-0.5 whitespace-pre-wrap text-xs text-zinc-600 dark:text-zinc-300">{{ $approval->notes }}</div>
+        @endif
+    </div>
+</div>

--- a/resources/views/components/rail.blade.php
+++ b/resources/views/components/rail.blade.php
@@ -1,0 +1,17 @@
+@props(['state' => 'draft'])
+
+@php
+    $colors = [
+        'draft' => 'bg-zinc-300 dark:bg-zinc-700',
+        'pending' => 'bg-amber-500',
+        'approved' => 'bg-emerald-500',
+        'changes_requested' => 'bg-rose-500',
+        'rejected' => 'bg-zinc-500',
+        'running' => 'bg-sky-500 animate-pulse motion-reduce:animate-none',
+        'run_complete' => 'bg-emerald-600',
+        'run_failed' => 'bg-rose-600',
+    ];
+    $cls = $colors[$state] ?? $colors['draft'];
+@endphp
+
+<div data-rail="{{ $state }}" {{ $attributes->merge(['class' => "w-1 self-stretch rounded-full $cls"]) }}></div>

--- a/resources/views/components/state-pill.blade.php
+++ b/resources/views/components/state-pill.blade.php
@@ -1,0 +1,30 @@
+@props(['state' => 'draft', 'tally' => null, 'label' => null])
+
+@php
+    $palette = [
+        'draft' => 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300',
+        'pending' => 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+        'approved' => 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+        'changes_requested' => 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200',
+        'rejected' => 'bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300',
+        'running' => 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',
+        'run_complete' => 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+        'run_failed' => 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200',
+    ];
+    $defaults = [
+        'draft' => __('Draft'),
+        'pending' => __('Pending'),
+        'approved' => __('Approved'),
+        'changes_requested' => __('Changes requested'),
+        'rejected' => __('Rejected'),
+        'running' => __('Running'),
+        'run_complete' => __('Run complete'),
+        'run_failed' => __('Run failed'),
+    ];
+    $text = $label ?? ($defaults[$state] ?? __('Draft'));
+    $cls = $palette[$state] ?? $palette['draft'];
+@endphp
+
+<span data-pill="{{ $state }}" {{ $attributes->merge(['class' => "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium $cls"]) }}>
+    {{ $text }}@if ($tally !== null) <span class="opacity-70">·</span> <span class="tabular-nums">{{ $tally }}</span>@endif
+</span>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -27,10 +27,7 @@
 
                     @if ($currentProjectId)
                         <flux:sidebar.group :heading="__('Project')" class="grid">
-                            <flux:sidebar.item icon="home" :href="route('projects.show', $currentProjectId)" :current="request()->routeIs('projects.show') && (string) request()->route('project') === (string) $currentProjectId" wire:navigate>
-                                {{ __('Overview') }}
-                            </flux:sidebar.item>
-                            <flux:sidebar.item icon="rectangle-stack" :href="route('projects.show', $currentProjectId)" :current="request()->routeIs('features.show')" wire:navigate>
+                            <flux:sidebar.item icon="rectangle-stack" :href="route('projects.show', $currentProjectId)" :current="request()->routeIs('projects.show') || request()->routeIs('features.show')" wire:navigate>
                                 {{ __('Features') }}
                             </flux:sidebar.item>
                             <flux:sidebar.item icon="bookmark" :href="route('stories.index', ['project' => $currentProjectId])" :current="request()->routeIs('stories.*')" wire:navigate>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -33,13 +33,13 @@
                             <flux:sidebar.item icon="rectangle-stack" :href="route('projects.show', $currentProjectId)" :current="request()->routeIs('features.show')" wire:navigate>
                                 {{ __('Features') }}
                             </flux:sidebar.item>
-                            <flux:sidebar.item icon="bookmark" :href="route('stories.index')" :current="request()->routeIs('stories.*')" wire:navigate>
+                            <flux:sidebar.item icon="bookmark" :href="route('stories.index', ['project' => $currentProjectId])" :current="request()->routeIs('stories.*')" wire:navigate>
                                 {{ __('Stories') }}
                             </flux:sidebar.item>
-                            <flux:sidebar.item icon="clipboard-document-list" :href="route('runs.index')" :current="request()->routeIs('runs.*')" wire:navigate>
+                            <flux:sidebar.item icon="clipboard-document-list" :href="route('runs.index', ['project' => $currentProjectId])" :current="request()->routeIs('runs.*')" wire:navigate>
                                 {{ __('Runs') }}
                             </flux:sidebar.item>
-                            <flux:sidebar.item icon="folder-open" :href="route('repos.index')" :current="request()->routeIs('repos.*')" wire:navigate>
+                            <flux:sidebar.item icon="folder-open" :href="route('repos.index', ['project' => $currentProjectId])" :current="request()->routeIs('repos.*')" wire:navigate>
                                 {{ __('Repos') }}
                             </flux:sidebar.item>
                         </flux:sidebar.group>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -12,39 +12,45 @@
 
             <flux:sidebar.nav class="!pt-0 !mt-0">
                 @auth
-                    <livewire:app-switcher />
-                @endauth
+                    @php $currentProjectId = auth()->user()->current_project_id; @endphp
 
-                <flux:sidebar.group :heading="__('Platform')" class="grid">
-                    <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
-                        {{ __('Dashboard') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="inbox" :href="route('inbox')" :current="request()->routeIs('inbox')" wire:navigate>
-                        {{ __('Inbox') }}
-                    </flux:sidebar.item>
-                    @auth
-                        @if (auth()->user()->current_project_id)
-                            <flux:sidebar.item icon="rectangle-stack" :href="route('projects.show', auth()->user()->current_project_id)" :current="request()->routeIs('projects.show') || request()->routeIs('features.show')" wire:navigate>
+                    <livewire:app-switcher />
+
+                    <flux:sidebar.group :heading="__('Workspace')" class="grid">
+                        <flux:sidebar.item icon="inbox" :href="route('triage')" :current="request()->routeIs('triage')" wire:navigate>
+                            {{ __('Triage') }}
+                        </flux:sidebar.item>
+                        <flux:sidebar.item icon="signal" :href="route('activity.index')" :current="request()->routeIs('activity.*')" wire:navigate>
+                            {{ __('Activity') }}
+                        </flux:sidebar.item>
+                    </flux:sidebar.group>
+
+                    @if ($currentProjectId)
+                        <flux:sidebar.group :heading="__('Project')" class="grid">
+                            <flux:sidebar.item icon="home" :href="route('projects.show', $currentProjectId)" :current="request()->routeIs('projects.show') && (string) request()->route('project') === (string) $currentProjectId" wire:navigate>
+                                {{ __('Overview') }}
+                            </flux:sidebar.item>
+                            <flux:sidebar.item icon="rectangle-stack" :href="route('projects.show', $currentProjectId)" :current="request()->routeIs('features.show')" wire:navigate>
                                 {{ __('Features') }}
                             </flux:sidebar.item>
-                            <flux:sidebar.item icon="bookmark" :href="route('stories.index')" :current="request()->routeIs('stories.index')" wire:navigate>
+                            <flux:sidebar.item icon="bookmark" :href="route('stories.index')" :current="request()->routeIs('stories.*')" wire:navigate>
                                 {{ __('Stories') }}
                             </flux:sidebar.item>
-                            <flux:sidebar.item icon="plus" :href="route('stories.create')" :current="request()->routeIs('stories.create')" wire:navigate>
-                                {{ __('New story') }}
+                            <flux:sidebar.item icon="clipboard-document-list" :href="route('runs.index')" :current="request()->routeIs('runs.*')" wire:navigate>
+                                {{ __('Runs') }}
                             </flux:sidebar.item>
-                        @endif
-                    @endauth
-                    <flux:sidebar.item icon="folder-open" :href="route('repos.index')" :current="request()->routeIs('repos.*')" wire:navigate>
-                        {{ __('Repos') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="clipboard-document-list" :href="route('runs.index')" :current="request()->routeIs('runs.*')" wire:navigate>
-                        {{ __('Runs') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="signal" :href="route('events.index')" :current="request()->routeIs('events.*')" wire:navigate>
-                        {{ __('Events') }}
-                    </flux:sidebar.item>
-                </flux:sidebar.group>
+                            <flux:sidebar.item icon="folder-open" :href="route('repos.index')" :current="request()->routeIs('repos.*')" wire:navigate>
+                                {{ __('Repos') }}
+                            </flux:sidebar.item>
+                        </flux:sidebar.group>
+                    @else
+                        <flux:sidebar.group :heading="__('Project')" class="grid">
+                            <flux:sidebar.item icon="folder-plus" :href="route('projects.index')" :current="request()->routeIs('projects.index')" wire:navigate>
+                                {{ __('Pick a project') }}
+                            </flux:sidebar.item>
+                        </flux:sidebar.group>
+                    @endif
+                @endauth
             </flux:sidebar.nav>
 
             <flux:spacer />

--- a/resources/views/pages/activity/⚡index.blade.php
+++ b/resources/views/pages/activity/⚡index.blade.php
@@ -8,7 +8,7 @@ use Livewire\Attributes\Title;
 use Livewire\Component;
 use Livewire\WithPagination;
 
-new #[Title('Events')] class extends Component {
+new #[Title('Activity')] class extends Component {
     use WithPagination;
 
     public ?string $event = null;
@@ -41,7 +41,7 @@ new #[Title('Events')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6 p-6">
-    <flux:heading size="xl">{{ __('Events') }}</flux:heading>
+    <flux:heading size="xl">{{ __('Activity') }}</flux:heading>
 
     <div class="flex flex-wrap gap-2">
         <flux:select wire:model.live="repo_id" :placeholder="__('All repos')">

--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Enums\StoryStatus;
+use App\Enums\TaskStatus;
 use App\Models\Feature;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
@@ -93,80 +95,190 @@ new #[Title('Feature')] class extends Component {
             ? $this->feature->stories()->with('creator', 'tasks:id,story_id,status')->latest('updated_at')->get()
             : collect();
     }
+
+    /**
+     * Tally child stories by status. Drives both the rail-state roll-up
+     * and the chip strip in the header. Keys are StoryStatus->value.
+     *
+     * @return array<string, int>
+     */
+    #[Computed]
+    public function storyTally(): array
+    {
+        $tally = [];
+        foreach ($this->stories as $story) {
+            $key = $story->status->value;
+            $tally[$key] = ($tally[$key] ?? 0) + 1;
+        }
+
+        return $tally;
+    }
+
+    /**
+     * Roll-up rail state. "running" wins if any story has an active
+     * subtask run; otherwise we walk the priority ladder. Empty feature
+     * is "draft".
+     */
+    #[Computed]
+    public function railState(): string
+    {
+        if ($this->stories->isEmpty()) {
+            return 'draft';
+        }
+
+        $hasActiveRun = $this->stories->contains(function ($story) {
+            return $story->tasks->isNotEmpty()
+                && $story->status === StoryStatus::Approved
+                && $story->tasks->contains(fn ($t) => $t->status === TaskStatus::InProgress || $t->status === TaskStatus::Pending);
+        });
+        if ($hasActiveRun) {
+            return 'running';
+        }
+
+        $statuses = $this->stories->pluck('status')->map(fn ($s) => $s->value);
+
+        if ($statuses->every(fn ($s) => $s === StoryStatus::Done->value)) {
+            return 'run_complete';
+        }
+        if ($statuses->contains(StoryStatus::ChangesRequested->value)) {
+            return 'changes_requested';
+        }
+        if ($statuses->contains(StoryStatus::PendingApproval->value)) {
+            return 'pending';
+        }
+        if ($statuses->contains(StoryStatus::Approved->value)) {
+            return 'approved';
+        }
+
+        return 'draft';
+    }
 }; ?>
 
-<div class="flex flex-col gap-6 p-6">
+<div class="flex p-6">
     @if (! $this->feature)
         <flux:text class="text-zinc-500">{{ __('Feature not found.') }}</flux:text>
     @else
-        <div>
-            <a href="{{ route('projects.show', $this->feature->project) }}" wire:navigate class="text-sm text-zinc-500 underline">
-                &larr; {{ $this->feature->project->name }}
-            </a>
-            @if ($editing)
-                <div class="mt-3 flex flex-col gap-3">
-                    <flux:input wire:model="editName" :label="__('Name')" />
-                    <flux:textarea wire:model="editDescription" :label="__('Description (markdown supported)')" rows="6" />
-                    <flux:textarea wire:model="editNotes" :label="__('Notes (markdown supported)')" rows="4" />
-                    <div class="flex items-center gap-2">
-                        <flux:button wire:click="saveEdit" wire:target="saveEdit" wire:loading.attr="disabled" variant="primary">
-                            <span wire:loading.remove wire:target="saveEdit">{{ __('Save') }}</span>
-                            <span wire:loading wire:target="saveEdit">{{ __('Saving…') }}</span>
-                        </flux:button>
-                        <flux:button wire:click="cancelEdit" variant="ghost">{{ __('Cancel') }}</flux:button>
-                    </div>
-                </div>
-            @else
-                <div class="mt-2 flex items-center justify-between gap-3">
-                    <flux:heading size="xl">{{ $this->feature->name }}</flux:heading>
-                    <div class="flex items-center gap-2">
-                        @if ($this->canEditFeature())
-                            <flux:button wire:click="startEdit" size="sm" variant="ghost">{{ __('Edit') }}</flux:button>
-                        @endif
-                        <a href="{{ route('stories.create', ['project' => $this->feature->project_id, 'feature_id' => $this->feature->id]) }}" wire:navigate>
-                            <flux:button variant="primary">{{ __('+ New story for this feature') }}</flux:button>
-                        </a>
-                    </div>
-                </div>
-                @if ($this->feature->description)
-                    <x-markdown :content="$this->feature->description" class="mt-1" />
-                @endif
-                @if ($this->feature->notes)
-                    <details class="mt-2">
-                        <summary class="cursor-pointer text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Notes') }}</summary>
-                        <x-markdown :content="$this->feature->notes" class="mt-2" />
-                    </details>
-                @endif
-            @endif
-        </div>
+        @php
+            $feature = $this->feature;
+            $tally = $this->storyTally;
+            $totalStories = array_sum($tally);
+        @endphp
 
-        <section class="flex flex-col gap-3">
-            <flux:heading size="lg">{{ __('Stories') }}</flux:heading>
-            @forelse ($this->stories as $story)
-                <flux:card>
-                    <a href="{{ route('stories.show', ['project' => $this->feature->project_id, 'story' => $story->id]) }}" wire:navigate>
-                        <div class="flex flex-wrap items-center gap-2">
-                            <flux:badge>{{ $story->status->value }}</flux:badge>
-                            <flux:badge>rev {{ $story->revision }}</flux:badge>
-                            @if ($story->creator)
-                                <flux:badge>{{ __('by') }} {{ $story->creator->name }}</flux:badge>
-                            @endif
-                            @php
-                                $tasksTotal = $story->tasks->count();
-                                $tasksDone = $story->tasks->filter(fn ($t) => $t->status === \App\Enums\TaskStatus::Done)->count();
-                            @endphp
-                            @if ($tasksTotal > 0)
-                                <flux:badge>{{ $tasksDone }}/{{ $tasksTotal }} {{ __('tasks') }}</flux:badge>
-                            @endif
-                            <flux:text class="ml-auto text-xs text-zinc-500">{{ $story->updated_at?->diffForHumans() }}</flux:text>
+        <x-rail :state="$this->railState" class="mr-4" />
+
+        <div class="flex min-w-0 max-w-4xl flex-1 flex-col gap-6">
+            <div>
+                <nav aria-label="Breadcrumb" class="flex flex-wrap items-center gap-1 text-sm text-zinc-500" data-section="breadcrumb">
+                    <a href="{{ route('projects.show', $feature->project) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $feature->project->name }}</a>
+                    <span aria-hidden="true">›</span>
+                    <span class="text-zinc-700 dark:text-zinc-300" aria-current="page">{{ $feature->name }}</span>
+                </nav>
+
+                @if ($editing)
+                    <div class="mt-3 flex flex-col gap-3">
+                        <flux:input wire:model="editName" :label="__('Name')" />
+                        <flux:textarea wire:model="editDescription" :label="__('Description (markdown supported)')" rows="6" />
+                        <flux:textarea wire:model="editNotes" :label="__('Notes (markdown supported)')" rows="4" />
+                        <div class="flex items-center gap-2">
+                            <flux:button wire:click="saveEdit" wire:target="saveEdit" wire:loading.attr="disabled" variant="primary">
+                                <span wire:loading.remove wire:target="saveEdit">{{ __('Save') }}</span>
+                                <span wire:loading wire:target="saveEdit">{{ __('Saving…') }}</span>
+                            </flux:button>
+                            <flux:button wire:click="cancelEdit" variant="ghost">{{ __('Cancel') }}</flux:button>
                         </div>
-                        <flux:heading class="mt-2">{{ $story->name }}</flux:heading>
-                        <x-markdown :content="$story->description" class="mt-1" />
+                    </div>
+                @else
+                    <div class="mt-2 flex items-start justify-between gap-3">
+                        <flux:heading size="xl">{{ $feature->name }}</flux:heading>
+                        <div class="flex items-center gap-2">
+                            @if ($this->canEditFeature())
+                                <flux:button wire:click="startEdit" size="sm" icon="pencil-square">{{ __('Edit') }}</flux:button>
+                            @endif
+                            <a href="{{ route('stories.create', ['project' => $feature->project_id, 'feature_id' => $feature->id]) }}" wire:navigate>
+                                <flux:button variant="primary">{{ __('+ New story') }}</flux:button>
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="mt-2 flex flex-wrap items-center gap-2" data-section="story-tally">
+                        <x-state-pill
+                            :state="$this->railState"
+                            :tally="$totalStories > 0 ? (string) $totalStories : null"
+                            :label="__($totalStories === 1 ? ':n story' : ':n stories', ['n' => $totalStories])"
+                        />
+                        @foreach ($tally as $statusValue => $count)
+                            @php
+                                $pillState = match ($statusValue) {
+                                    StoryStatus::Draft->value, StoryStatus::ProposedByAI->value => 'draft',
+                                    StoryStatus::PendingApproval->value => 'pending',
+                                    StoryStatus::Approved->value => 'approved',
+                                    StoryStatus::ChangesRequested->value => 'changes_requested',
+                                    StoryStatus::Rejected->value, StoryStatus::Cancelled->value => 'rejected',
+                                    StoryStatus::Done->value => 'run_complete',
+                                    default => 'draft',
+                                };
+                            @endphp
+                            <x-state-pill
+                                :state="$pillState"
+                                :tally="(string) $count"
+                                :label="$statusValue"
+                                data-tally-status="{{ $statusValue }}"
+                            />
+                        @endforeach
+                    </div>
+
+                    @if ($feature->description)
+                        <x-markdown :content="$feature->description" class="mt-3" />
+                    @endif
+                    @if ($feature->notes)
+                        <details class="mt-2">
+                            <summary class="cursor-pointer text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Notes') }}</summary>
+                            <x-markdown :content="$feature->notes" class="mt-2" />
+                        </details>
+                    @endif
+                @endif
+            </div>
+
+            <section class="flex flex-col gap-3" data-section="stories">
+                <flux:heading size="lg">{{ __('Stories') }}</flux:heading>
+                @forelse ($this->stories as $story)
+                    @php
+                        $rowState = match ($story->status->value) {
+                            StoryStatus::Draft->value, StoryStatus::ProposedByAI->value => 'draft',
+                            StoryStatus::PendingApproval->value => 'pending',
+                            StoryStatus::Approved->value => 'approved',
+                            StoryStatus::ChangesRequested->value => 'changes_requested',
+                            StoryStatus::Rejected->value, StoryStatus::Cancelled->value => 'rejected',
+                            StoryStatus::Done->value => 'run_complete',
+                            default => 'draft',
+                        };
+                        $tasksTotal = $story->tasks->count();
+                        $tasksDone = $story->tasks->filter(fn ($t) => $t->status === TaskStatus::Done)->count();
+                    @endphp
+                    <a href="{{ route('stories.show', ['project' => $feature->project_id, 'story' => $story->id]) }}" wire:navigate class="flex items-stretch gap-3 rounded-lg border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50" data-story-row="{{ $story->id }}">
+                        <x-rail :state="$rowState" class="!w-0.5" />
+                        <div class="min-w-0 flex-1">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <x-state-pill :state="$rowState" :label="$story->status->value" />
+                                <flux:badge size="sm">rev {{ $story->revision }}</flux:badge>
+                                @if ($story->creator)
+                                    <flux:badge size="sm">{{ __('by') }} {{ $story->creator->name }}</flux:badge>
+                                @endif
+                                @if ($tasksTotal > 0)
+                                    <flux:badge size="sm">{{ $tasksDone }}/{{ $tasksTotal }} {{ __('tasks') }}</flux:badge>
+                                @endif
+                                <flux:text class="ml-auto text-xs text-zinc-500">{{ $story->updated_at?->diffForHumans() }}</flux:text>
+                            </div>
+                            <flux:heading class="mt-2">{{ $story->name }}</flux:heading>
+                            @if ($story->description)
+                                <x-markdown :content="$story->description" class="mt-1 text-sm text-zinc-600 dark:text-zinc-400" />
+                            @endif
+                        </div>
                     </a>
-                </flux:card>
-            @empty
-                <flux:text class="text-zinc-500">{{ __('No stories yet for this feature.') }}</flux:text>
-            @endforelse
-        </section>
+                @empty
+                    <flux:text class="text-zinc-500">{{ __('No stories yet for this feature.') }}</flux:text>
+                @endforelse
+            </section>
+        </div>
     @endif
 </div>

--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -144,7 +144,7 @@ new #[Title('Feature')] class extends Component {
             <flux:heading size="lg">{{ __('Stories') }}</flux:heading>
             @forelse ($this->stories as $story)
                 <flux:card>
-                    <a href="{{ route('stories.show', $story) }}" wire:navigate>
+                    <a href="{{ route('stories.show', ['project' => $this->feature->project_id, 'story' => $story->id]) }}" wire:navigate>
                         <div class="flex flex-wrap items-center gap-2">
                             <flux:badge>{{ $story->status->value }}</flux:badge>
                             <flux:badge>rev {{ $story->revision }}</flux:badge>

--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -203,8 +203,8 @@ new #[Title('Feature')] class extends Component {
                     <div class="mt-2 flex flex-wrap items-center gap-2" data-section="story-tally">
                         <x-state-pill
                             :state="$this->railState"
-                            :tally="$totalStories > 0 ? (string) $totalStories : null"
-                            :label="__($totalStories === 1 ? ':n story' : ':n stories', ['n' => $totalStories])"
+                            :tally="(string) $totalStories"
+                            :label="__('stories')"
                         />
                         @foreach ($tally as $statusValue => $count)
                             @php

--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -123,7 +123,7 @@ new #[Title('Feature')] class extends Component {
                         @if ($this->canEditFeature())
                             <flux:button wire:click="startEdit" size="sm" variant="ghost">{{ __('Edit') }}</flux:button>
                         @endif
-                        <a href="{{ route('stories.create', ['feature_id' => $this->feature->id]) }}" wire:navigate>
+                        <a href="{{ route('stories.create', ['project' => $this->feature->project_id, 'feature_id' => $this->feature->id]) }}" wire:navigate>
                             <flux:button variant="primary">{{ __('+ New story for this feature') }}</flux:button>
                         </a>
                     </div>

--- a/resources/views/pages/repos/⚡index.blade.php
+++ b/resources/views/pages/repos/⚡index.blade.php
@@ -12,16 +12,27 @@ use Livewire\Attributes\Title;
 use Livewire\Component;
 
 new #[Title('Repositories')] class extends Component {
+    public int $project_id;
+
     public string $githubRepoSearch = '';
+
+    public function mount(int $project): void
+    {
+        $user = Auth::user();
+        abort_unless(in_array((int) $project, $user->accessibleProjectIds(), true), 404);
+        $this->project_id = (int) $project;
+        if ((int) $user->current_project_id !== $this->project_id) {
+            $user->forceFill(['current_project_id' => $this->project_id])->save();
+        }
+    }
 
     #[Computed]
     public function project(): ?Project
     {
-        $id = Auth::user()->current_project_id;
-
-        return $id
-            ? Project::query()->whereIn('id', Auth::user()->accessibleProjectIds())->with('team')->find($id)
-            : null;
+        return Project::query()
+            ->whereIn('id', Auth::user()->accessibleProjectIds())
+            ->with('team')
+            ->find($this->project_id);
     }
 
     #[Computed]

--- a/resources/views/pages/runs/⚡index.blade.php
+++ b/resources/views/pages/runs/⚡index.blade.php
@@ -13,7 +13,19 @@ use Livewire\WithPagination;
 new #[Title('Run history')] class extends Component {
     use WithPagination;
 
+    public int $project_id;
+
     public ?string $status = null;
+
+    public function mount(int $project): void
+    {
+        $user = Auth::user();
+        abort_unless(in_array((int) $project, $user->accessibleProjectIds(), true), 404);
+        $this->project_id = (int) $project;
+        if ((int) $user->current_project_id !== $this->project_id) {
+            $user->forceFill(['current_project_id' => $this->project_id])->save();
+        }
+    }
 
     #[Computed]
     public function runs()

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -1,0 +1,218 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+new #[Title('Run')] class extends Component {
+    public int $project_id;
+
+    public int $story_id;
+
+    public int $subtask_id;
+
+    public int $run_id;
+
+    public string $tab = 'logs';
+
+    public function mount(int $project, int $story, int $subtask, int $run): void
+    {
+        $this->project_id = (int) $project;
+        $this->story_id = (int) $story;
+        $this->subtask_id = (int) $subtask;
+        $this->run_id = (int) $run;
+
+        abort_unless($this->run, 404);
+
+        $user = Auth::user();
+        if ((int) $user->current_project_id !== $this->project_id) {
+            $user->forceFill(['current_project_id' => $this->project_id])->save();
+        }
+    }
+
+    #[Computed]
+    public function run(): ?AgentRun
+    {
+        $accessible = Auth::user()->accessibleProjectIds();
+
+        return AgentRun::query()
+            ->where('id', $this->run_id)
+            ->where('runnable_type', Subtask::class)
+            ->where('runnable_id', $this->subtask_id)
+            ->whereHasMorph('runnable', [Subtask::class], fn ($q) => $q
+                ->whereHas('task.story', fn ($qq) => $qq->where('id', $this->story_id))
+                ->whereHas('task.story.feature', fn ($qq) => $qq
+                    ->where('project_id', $this->project_id)
+                    ->whereIn('project_id', $accessible)
+                )
+            )
+            ->with(['runnable.task.story.feature.project', 'repo'])
+            ->first();
+    }
+
+    public function setTab(string $tab): void
+    {
+        $this->tab = in_array($tab, ['logs', 'diff', 'pr'], true) ? $tab : 'logs';
+    }
+}; ?>
+
+<div class="flex p-6">
+    @if (! $this->run)
+        <flux:text class="text-zinc-500">{{ __('Run not found.') }}</flux:text>
+    @else
+        @php
+            $run = $this->run;
+            $subtask = $run->runnable;
+            $task = $subtask->task;
+            $story = $task->story;
+            $feature = $story->feature;
+            $project = $feature->project;
+            $rail = match ($run->status) {
+                AgentRunStatus::Succeeded => 'run_complete',
+                AgentRunStatus::Running, AgentRunStatus::Queued => 'running',
+                AgentRunStatus::Failed, AgentRunStatus::Aborted => 'run_failed',
+                default => 'draft',
+            };
+            $duration = $run->started_at && $run->finished_at
+                ? $run->started_at->diffInSeconds($run->finished_at)
+                : null;
+            $prUrl = $run->output['pull_request_url'] ?? null;
+            $prError = $run->output['pull_request_error'] ?? null;
+            $diff = $run->diff;
+        @endphp
+
+        <x-rail :state="$rail" class="mr-4" />
+
+        <div class="flex min-w-0 max-w-5xl flex-1 flex-col gap-6">
+            <nav aria-label="Breadcrumb" class="flex flex-wrap items-center gap-1 text-sm text-zinc-500" data-section="breadcrumb">
+                <a href="{{ route('projects.show', $project) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $project->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('features.show', ['project' => $project, 'feature' => $feature]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $feature->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('stories.show', ['project' => $project, 'story' => $story]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $story->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('subtasks.show', ['project' => $project, 'story' => $story, 'subtask' => $subtask]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $subtask->name }}</a>
+                <span aria-hidden="true">›</span>
+                <span class="text-zinc-700 dark:text-zinc-300" aria-current="page">run #{{ $run->id }}</span>
+            </nav>
+
+            <div>
+                <div class="flex flex-wrap items-center gap-2">
+                    <flux:heading size="xl">{{ __('Run') }} #{{ $run->id }}</flux:heading>
+                    <x-state-pill :state="$rail" :label="$run->status->value" />
+                    @if ($run->kind && $run->kind->value !== 'execute')
+                        <flux:badge color="purple">{{ $run->kind->value }}</flux:badge>
+                    @endif
+                </div>
+                <div class="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                    @if ($run->executor_driver)
+                        <flux:badge size="sm" icon="cpu-chip">{{ $run->executor_driver }}</flux:badge>
+                    @endif
+                    @if ($run->repo)
+                        <flux:badge size="sm" icon="folder">{{ $run->repo->name }}</flux:badge>
+                    @endif
+                    @if ($run->working_branch)
+                        <flux:badge size="sm" icon="code-bracket">{{ $run->working_branch }}</flux:badge>
+                    @endif
+                    @if ($duration !== null)
+                        <flux:badge size="sm" icon="clock">{{ $duration }}s</flux:badge>
+                    @endif
+                    @if ($run->started_at)
+                        <flux:text class="text-xs text-zinc-500">{{ __('started') }} {{ $run->started_at->diffForHumans() }}</flux:text>
+                    @endif
+                    @if ($run->finished_at)
+                        <flux:text class="text-xs text-zinc-500">· {{ __('finished') }} {{ $run->finished_at->diffForHumans() }}</flux:text>
+                    @endif
+                </div>
+                @if ($run->tokens_input || $run->tokens_output)
+                    <div class="mt-1 text-xs text-zinc-500">
+                        {{ __('Tokens:') }} {{ number_format($run->tokens_input ?? 0) }} {{ __('in') }} · {{ number_format($run->tokens_output ?? 0) }} {{ __('out') }}
+                    </div>
+                @endif
+            </div>
+
+            @if ($run->error_message)
+                <details class="rounded-md border border-rose-200 bg-rose-50 dark:border-rose-900/40 dark:bg-rose-950/30" open>
+                    <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-rose-800 dark:text-rose-300">
+                        {{ __('Error output') }}
+                    </summary>
+                    <pre class="max-h-80 overflow-auto px-3 pb-3 font-mono text-xs leading-snug text-rose-900 dark:text-rose-200">{{ $run->error_message }}</pre>
+                </details>
+            @endif
+
+            @if ($prError)
+                <flux:callout icon="exclamation-triangle" color="amber">
+                    <flux:callout.heading>{{ __('PR creation failed') }}</flux:callout.heading>
+                    <flux:callout.text>{{ $prError }}</flux:callout.text>
+                    <flux:callout.text class="text-xs">{{ __('Per ADR-0004, PR-after-push is non-fatal: the run still succeeded; the PR can be opened manually.') }}</flux:callout.text>
+                </flux:callout>
+            @endif
+
+            <div class="flex flex-col gap-3" data-section="run-tabs">
+                <div class="inline-flex rounded-md border border-zinc-200 p-0.5 text-xs dark:border-zinc-700" role="tablist">
+                    @foreach (['logs' => __('Logs'), 'diff' => __('Diff'), 'pr' => __('Pull request')] as $key => $label)
+                        <button
+                            type="button"
+                            role="tab"
+                            wire:click="setTab('{{ $key }}')"
+                            aria-selected="{{ $tab === $key ? 'true' : 'false' }}"
+                            class="rounded px-3 py-1 {{ $tab === $key ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900' : 'text-zinc-600 dark:text-zinc-300' }}"
+                        >{{ $label }}</button>
+                    @endforeach
+                </div>
+
+                @if ($tab === 'logs')
+                    @php
+                        $stdout = $run->output['stdout'] ?? null;
+                        $stderr = $run->output['stderr'] ?? null;
+                    @endphp
+                    @if ($stdout || $stderr)
+                        @if ($stdout)
+                            <div>
+                                <div class="mb-1 text-xs uppercase tracking-wide text-zinc-500">{{ __('stdout') }}</div>
+                                <pre class="max-h-[32rem] overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 font-mono text-xs leading-snug dark:border-zinc-700 dark:bg-zinc-900">{{ $stdout }}</pre>
+                            </div>
+                        @endif
+                        @if ($stderr)
+                            <div>
+                                <div class="mb-1 text-xs uppercase tracking-wide text-zinc-500">{{ __('stderr') }}</div>
+                                <pre class="max-h-[32rem] overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 font-mono text-xs leading-snug dark:border-zinc-700 dark:bg-zinc-900">{{ $stderr }}</pre>
+                            </div>
+                        @endif
+                    @else
+                        <flux:text class="text-zinc-500">{{ __('No log output captured for this run. (ADR-0011 streaming events land here once implemented.)') }}</flux:text>
+                    @endif
+                @elseif ($tab === 'diff')
+                    @if ($diff)
+                        <pre class="max-h-[40rem] overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 font-mono text-xs leading-snug dark:border-zinc-700 dark:bg-zinc-900">{{ $diff }}</pre>
+                    @else
+                        <flux:text class="text-zinc-500">{{ __('No diff captured for this run.') }}</flux:text>
+                    @endif
+                @elseif ($tab === 'pr')
+                    @if ($prUrl)
+                        <flux:card>
+                            <div class="flex flex-wrap items-center gap-2">
+                                <flux:badge size="sm">{{ __('PR') }}</flux:badge>
+                                <a href="{{ $prUrl }}" target="_blank" rel="noopener" class="text-sm underline">{{ $prUrl }}</a>
+                                @if (($action = $run->output['pull_request_action'] ?? null))
+                                    <flux:badge size="sm">{{ $action }}</flux:badge>
+                                @endif
+                                @if (! is_null($run->output['pull_request_merged'] ?? null))
+                                    <flux:badge size="sm" color="{{ $run->output['pull_request_merged'] ? 'emerald' : 'zinc' }}">
+                                        {{ $run->output['pull_request_merged'] ? __('merged') : __('open') }}
+                                    </flux:badge>
+                                @endif
+                            </div>
+                        </flux:card>
+                    @else
+                        <flux:text class="text-zinc-500">{{ __('No pull request opened for this run.') }}</flux:text>
+                    @endif
+                @endif
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/pages/stories/⚡create.blade.php
+++ b/resources/views/pages/stories/⚡create.blade.php
@@ -25,12 +25,17 @@ new #[Title('New story')] class extends Component {
     /** @var array<int,string> */
     public array $criteria = [''];
 
-    public function mount(): void
+    public function mount(int $project): void
     {
         $user = Auth::user();
+        abort_unless(in_array((int) $project, $user->accessibleProjectIds(), true), 404);
+        if ((int) $user->current_project_id !== (int) $project) {
+            $user->forceFill(['current_project_id' => (int) $project])->save();
+        }
+
         if ($this->feature_id) {
             $feature = Feature::query()
-                ->whereHas('project', fn ($q) => $q->whereIn('id', $user->accessibleProjectIds()))
+                ->where('project_id', (int) $project)
                 ->find($this->feature_id);
             if ($feature) {
                 return;
@@ -38,13 +43,10 @@ new #[Title('New story')] class extends Component {
             $this->feature_id = null;
         }
 
-        $projectId = $user->current_project_id;
-        if ($projectId) {
-            $this->feature_id = Feature::query()
-                ->where('project_id', $projectId)
-                ->orderBy('id')
-                ->first()?->id;
-        }
+        $this->feature_id = Feature::query()
+            ->where('project_id', (int) $project)
+            ->orderBy('id')
+            ->first()?->id;
     }
 
     #[Computed]

--- a/resources/views/pages/stories/⚡index.blade.php
+++ b/resources/views/pages/stories/⚡index.blade.php
@@ -60,7 +60,7 @@ new #[Title('Stories')] class extends Component {
 
     <div class="flex flex-col gap-3">
         @forelse ($this->stories as $story)
-            <a href="{{ route('stories.show', $story) }}" wire:navigate>
+            <a href="{{ route('stories.show', ['project' => $story->feature->project_id, 'story' => $story->id]) }}" wire:navigate>
                 <flux:card class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
                     <div class="flex flex-wrap items-center gap-2">
                         <flux:badge variant="solid">{{ $story->feature->project->name }}</flux:badge>

--- a/resources/views/pages/stories/⚡index.blade.php
+++ b/resources/views/pages/stories/⚡index.blade.php
@@ -12,8 +12,20 @@ use Livewire\WithPagination;
 new #[Title('Stories')] class extends Component {
     use WithPagination;
 
+    public int $project_id;
+
     #[Url(as: 'status')]
     public ?string $status = null;
+
+    public function mount(int $project): void
+    {
+        $user = Auth::user();
+        abort_unless(in_array((int) $project, $user->accessibleProjectIds(), true), 404);
+        $this->project_id = (int) $project;
+        if ((int) $user->current_project_id !== $this->project_id) {
+            $user->forceFill(['current_project_id' => $this->project_id])->save();
+        }
+    }
 
     #[Computed]
     public function stories()
@@ -32,7 +44,7 @@ new #[Title('Stories')] class extends Component {
 <div class="flex flex-col gap-6 p-6">
     <div class="flex items-center justify-between">
         <flux:heading size="xl">{{ __('Stories') }}</flux:heading>
-        <a href="{{ route('stories.create') }}" wire:navigate>
+        <a href="{{ route('stories.create', ['project' => $this->project_id]) }}" wire:navigate>
             <flux:button variant="primary">{{ __('+ New story') }}</flux:button>
         </a>
     </div>

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -41,10 +41,19 @@ new #[Title('Story')] class extends Component {
      */
     public bool $planRunMode = false;
 
-    public function mount(int $story): void
+    public function mount(int $story, ?int $project = null): void
     {
         $this->story_id = $story;
-        abort_unless($this->story, 404);
+        $loaded = $this->story;
+        abort_unless($loaded, 404);
+
+        if ($project !== null) {
+            abort_unless((int) $loaded->feature->project_id === (int) $project, 404);
+            $user = Auth::user();
+            if ((int) $user->current_project_id !== (int) $project) {
+                $user->forceFill(['current_project_id' => (int) $project])->save();
+            }
+        }
     }
 
     public function startEdit(): void
@@ -591,9 +600,13 @@ new #[Title('Story')] class extends Component {
 
         {{-- ── Header ──────────────────────────────────────────── --}}
         <div>
-            <a href="{{ route('features.show', ['project' => $project->id, 'feature' => $story->feature_id]) }}" wire:navigate class="text-sm text-zinc-500 underline">
-                &larr; {{ $project->name }} / {{ $story->feature->name }}
-            </a>
+            <nav aria-label="Breadcrumb" class="flex flex-wrap items-center gap-1 text-sm text-zinc-500" data-section="breadcrumb">
+                <a href="{{ route('projects.show', $project->id) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $project->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('features.show', ['project' => $project->id, 'feature' => $story->feature_id]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $story->feature->name }}</a>
+                <span aria-hidden="true">›</span>
+                <span class="text-zinc-700 dark:text-zinc-300" aria-current="page">{{ $story->name }}</span>
+            </nav>
 
             @if ($editing)
                 <div class="mt-3 flex flex-col gap-3">

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -11,8 +11,8 @@ use App\Models\Subtask;
 use App\Models\Task;
 use App\Services\ApprovalService;
 use App\Services\ExecutionService;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Attributes\Validate;
@@ -33,6 +33,13 @@ new #[Title('Story')] class extends Component {
 
     /** @var array<int, array{id: ?int, criterion: string}> */
     public array $editCriteria = [];
+
+    /**
+     * Plan view mode: false = Grooming (Tasks collapsed), true = Run (Tasks expanded).
+     * Persisted client-side per user via localStorage; server-side default below
+     * is overridden when an active run exists.
+     */
+    public bool $planRunMode = false;
 
     public function mount(int $story): void
     {
@@ -264,6 +271,161 @@ new #[Title('Story')] class extends Component {
         unset($this->story);
     }
 
+    /**
+     * Visual rail state derived from the Story status. Does not double as the
+     * pill text — the pill carries the tally, the rail is the invariant carrier.
+     */
+    #[Computed]
+    public function railState(): string
+    {
+        $story = $this->story;
+        if (! $story) {
+            return 'draft';
+        }
+        if ($this->hasActiveSubtaskRun) {
+            return 'running';
+        }
+
+        return match ($story->status) {
+            StoryStatus::Draft, StoryStatus::ProposedByAI => 'draft',
+            StoryStatus::PendingApproval => 'pending',
+            StoryStatus::Approved => 'approved',
+            StoryStatus::ChangesRequested => 'changes_requested',
+            StoryStatus::Rejected, StoryStatus::Cancelled => 'rejected',
+            StoryStatus::Done => 'run_complete',
+        };
+    }
+
+    /**
+     * Pill state + tally + label for the breadcrumb. Returns the data shape
+     * the x-state-pill component consumes.
+     *
+     * @return array{state: string, tally: ?string, label: ?string}
+     */
+    #[Computed]
+    public function pill(): array
+    {
+        $story = $this->story;
+        if (! $story) {
+            return ['state' => 'draft', 'tally' => null, 'label' => null];
+        }
+        $policy = $this->effectivePolicy;
+        $required = $policy?->required_approvals ?? 0;
+        $count = count($this->effectiveApprovals);
+
+        return match ($story->status) {
+            StoryStatus::Draft => ['state' => 'draft', 'tally' => null, 'label' => __('Draft')],
+            StoryStatus::ProposedByAI => ['state' => 'draft', 'tally' => null, 'label' => __('Proposed by AI')],
+            StoryStatus::PendingApproval => [
+                'state' => 'pending',
+                'tally' => $required > 0 ? sprintf('%d/%d', $count, $required) : null,
+                'label' => __('Pending'),
+            ],
+            StoryStatus::Approved => [
+                'state' => 'approved',
+                'tally' => $required > 0 ? sprintf('%d/%d', $required, $required) : null,
+                'label' => __('Approved'),
+            ],
+            StoryStatus::ChangesRequested => ['state' => 'changes_requested', 'tally' => null, 'label' => __('Changes requested')],
+            StoryStatus::Rejected => ['state' => 'rejected', 'tally' => null, 'label' => __('Rejected')],
+            StoryStatus::Cancelled => ['state' => 'rejected', 'tally' => null, 'label' => __('Cancelled')],
+            StoryStatus::Done => ['state' => 'run_complete', 'tally' => null, 'label' => __('Done')],
+        };
+    }
+
+    #[Computed]
+    public function hasActiveSubtaskRun(): bool
+    {
+        $story = $this->story;
+        if (! $story) {
+            return false;
+        }
+
+        return $story->tasks->flatMap->subtasks->flatMap->agentRuns
+            ->contains(fn (AgentRun $run) => in_array(
+                $run->status,
+                [AgentRunStatus::Queued, AgentRunStatus::Running],
+                true,
+            ));
+    }
+
+    /**
+     * AC counts/edits/removes between the live edit form and the persisted ACs.
+     * Returns counts only when status is in [Approved, ChangesRequested] AND
+     * something has actually changed; otherwise null. Drives the reset-approval
+     * banner and the Save button label.
+     *
+     * @return array{added: int, edited: int, removed: int}|null
+     */
+    #[Computed]
+    public function acDelta(): ?array
+    {
+        $story = $this->story;
+        if (! $story || ! $this->editing) {
+            return null;
+        }
+        if (! in_array($story->status, [StoryStatus::Approved, StoryStatus::ChangesRequested], true)) {
+            return null;
+        }
+
+        $existing = $story->acceptanceCriteria->keyBy('id');
+        $added = 0;
+        $edited = 0;
+        $kept = [];
+        foreach ($this->editCriteria as $row) {
+            $id = $row['id'] ?? null;
+            $text = trim((string) ($row['criterion'] ?? ''));
+            if ($id === null) {
+                if ($text !== '') {
+                    $added++;
+                }
+                continue;
+            }
+            if (! $existing->has($id)) {
+                continue;
+            }
+            $kept[] = $id;
+            if (trim((string) $existing[$id]->criterion) !== $text) {
+                $edited++;
+            }
+        }
+        $removed = $existing->keys()->diff($kept)->count();
+
+        if ($added === 0 && $edited === 0 && $removed === 0) {
+            return null;
+        }
+
+        return ['added' => $added, 'edited' => $edited, 'removed' => $removed];
+    }
+
+    /**
+     * Eligible approvers for the current Story; lazy so the page doesn't pay
+     * the cost when the policy threshold is 1. When the policy disallows
+     * self-approval, the author is filtered out — they cannot count toward
+     * the threshold so listing them as "eligible" is misleading.
+     *
+     * @return \Illuminate\Support\Collection<int, \App\Models\User>
+     */
+    #[Computed]
+    public function eligibleApprovers()
+    {
+        $story = $this->story;
+        $policy = $this->effectivePolicy;
+        if (! $story || ! $policy || ($policy->required_approvals ?? 0) <= 1) {
+            return collect();
+        }
+
+        $excludeAuthor = ! ($policy->allow_self_approval ?? false);
+
+        return \App\Models\User::query()
+            ->whereHas('teams.workspace', fn ($q) => $q->where('workspaces.id', $story->feature->project->team->workspace_id))
+            ->orderBy('name')
+            ->get()
+            ->filter(fn (\App\Models\User $u) => $u->canApproveInProject($story->feature->project))
+            ->reject(fn (\App\Models\User $u) => $excludeAuthor && $u->id === $story->created_by_id)
+            ->values();
+    }
+
     #[Computed]
     public function pendingPlanRun(): ?AgentRun
     {
@@ -286,52 +448,148 @@ new #[Title('Story')] class extends Component {
                 'acceptanceCriteria',
                 'tasks.acceptanceCriterion',
                 'tasks.dependencies',
-                'tasks.subtasks',
+                'tasks.subtasks.agentRuns.repo',
                 'approvals.approver',
             ])
             ->find($this->story_id);
     }
 
     #[Computed]
-    public function runs()
+    public function effectivePolicy()
+    {
+        return $this->story?->effectivePolicy();
+    }
+
+    /**
+     * Live approvals for the current revision: replay approve/revoke per approver.
+     *
+     * @return array<int, \App\Models\StoryApproval>
+     */
+    #[Computed]
+    public function effectiveApprovals(): array
+    {
+        $story = $this->story;
+        if (! $story) {
+            return [];
+        }
+        $effective = [];
+        foreach ($story->approvals->where('story_revision', $story->revision ?? 1)->sortBy('created_at') as $a) {
+            $key = (int) $a->approver_id;
+            if ($a->decision === ApprovalDecision::Approve) {
+                $effective[$key] = $a;
+            } elseif ($a->decision === ApprovalDecision::Revoke) {
+                unset($effective[$key]);
+            }
+        }
+
+        return $effective;
+    }
+
+    #[Computed]
+    public function userApproved(): bool
+    {
+        return isset($this->effectiveApprovals[Auth::id()]);
+    }
+
+    #[Computed]
+    public function canApproveStory(): bool
+    {
+        $story = $this->story;
+
+        return $story !== null && Auth::user()->canApproveInProject($story->feature->project);
+    }
+
+    #[Computed]
+    public function isAuthor(): bool
+    {
+        return $this->story?->created_by_id === Auth::id();
+    }
+
+    #[Computed]
+    public function blockedBySelfApproval(): bool
+    {
+        $policy = $this->effectivePolicy;
+
+        return $this->isAuthor && $policy && ! $policy->allow_self_approval;
+    }
+
+    #[Computed]
+    public function autoPromotes(): bool
+    {
+        $policy = $this->effectivePolicy;
+
+        return $policy !== null && ($policy->auto_approve || $policy->required_approvals === 0);
+    }
+
+    #[Computed]
+    public function isAuthoringStatus(): bool
+    {
+        $story = $this->story;
+
+        return $story !== null && in_array(
+            $story->status,
+            [StoryStatus::Draft, StoryStatus::PendingApproval, StoryStatus::ChangesRequested],
+            true,
+        );
+    }
+
+    #[Computed]
+    public function decisionPanelVisible(): bool
+    {
+        $story = $this->story;
+
+        return ! $this->editing
+            && $story !== null
+            && ! in_array($story->status, [StoryStatus::Done, StoryStatus::Cancelled, StoryStatus::Rejected], true);
+    }
+
+    /**
+     * Story-runnable AgentRuns: plan-generation runs, latest first.
+     */
+    #[Computed]
+    public function planGenerationRuns()
     {
         if (! $this->story) {
             return collect();
         }
 
-        $taskIds = $this->story->tasks->pluck('id');
-        $subtaskIds = $this->story->tasks->flatMap->subtasks->pluck('id');
-
         return AgentRun::query()
-            ->where(function ($q) use ($taskIds, $subtaskIds) {
-                $q->where(function ($qq) {
-                    $qq->where('runnable_type', Story::class)->where('runnable_id', $this->story_id);
-                });
-                if ($taskIds->isNotEmpty()) {
-                    $q->orWhere(function ($qq) use ($taskIds) {
-                        $qq->where('runnable_type', Task::class)->whereIn('runnable_id', $taskIds);
-                    });
-                }
-                if ($subtaskIds->isNotEmpty()) {
-                    $q->orWhere(function ($qq) use ($subtaskIds) {
-                        $qq->where('runnable_type', Subtask::class)->whereIn('runnable_id', $subtaskIds);
-                    });
-                }
-            })
-            ->with('repo', 'runnable')
+            ->where('runnable_type', Story::class)
+            ->where('runnable_id', $this->story_id)
             ->latest('id')
             ->get();
     }
 }; ?>
 
-<div class="flex flex-col gap-6 p-6" @if ($this->pendingPlanRun) wire:poll.3s @endif>
+<div
+    class="flex p-6"
+    @if ($this->pendingPlanRun) wire:poll.3s @endif
+    x-data="{
+        planRunMode: $wire.entangle('planRunMode'),
+        init() {
+            const saved = localStorage.getItem('specify.planRunMode');
+            if (saved !== null) {
+                this.planRunMode = saved === '1';
+            }
+            this.$watch('planRunMode', v => localStorage.setItem('specify.planRunMode', v ? '1' : '0'));
+        },
+    }"
+>
     @if (! $this->story)
         <flux:text class="text-zinc-500">{{ __('Story not found.') }}</flux:text>
     @else
         @php
             $story = $this->story;
             $project = $story->feature->project;
+            $pill = $this->pill;
         @endphp
+
+        <x-rail :state="$this->railState" class="mr-4" />
+
+        <div class="flex min-w-0 flex-1 flex-col gap-6 lg:flex-row">
+            <div class="flex min-w-0 max-w-4xl flex-1 flex-col gap-6">
+
+        {{-- ── Header ──────────────────────────────────────────── --}}
         <div>
             <a href="{{ route('features.show', ['project' => $project->id, 'feature' => $story->feature_id]) }}" wire:navigate class="text-sm text-zinc-500 underline">
                 &larr; {{ $project->name }} / {{ $story->feature->name }}
@@ -339,6 +597,19 @@ new #[Title('Story')] class extends Component {
 
             @if ($editing)
                 <div class="mt-3 flex flex-col gap-3">
+                    @php $delta = $this->acDelta; @endphp
+                    @if ($delta)
+                        <div data-banner="reset-approval" class="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">
+                            <div class="font-medium">{{ __('Saving will reset this Story to Pending Approval.') }}</div>
+                            <div class="mt-1 text-xs">
+                                {{ __('Plan delta:') }}
+                                <span class="tabular-nums">+{{ $delta['added'] }}</span> {{ __('AC,') }}
+                                <span class="tabular-nums">~{{ $delta['edited'] }}</span> {{ __('edited,') }}
+                                <span class="tabular-nums">-{{ $delta['removed'] }}</span> {{ __('removed') }}
+                            </div>
+                        </div>
+                    @endif
+
                     <flux:input wire:model="editName" :label="__('Name')" />
                     <flux:textarea wire:model="editDescription" :label="__('Description (markdown supported)')" rows="8" />
 
@@ -360,8 +631,9 @@ new #[Title('Story')] class extends Component {
                     </div>
 
                     <div class="flex items-center gap-2">
+                        @php $saveLabel = $this->acDelta ? __('Save & request re-approval') : __('Save'); @endphp
                         <flux:button wire:click="saveEdit" wire:target="saveEdit" wire:loading.attr="disabled" variant="primary">
-                            <span wire:loading.remove wire:target="saveEdit">{{ __('Save') }}</span>
+                            <span wire:loading.remove wire:target="saveEdit">{{ $saveLabel }}</span>
                             <span wire:loading wire:target="saveEdit">{{ __('Saving…') }}</span>
                         </flux:button>
                         <flux:button wire:click="cancelEdit" variant="ghost">{{ __('Cancel') }}</flux:button>
@@ -371,236 +643,308 @@ new #[Title('Story')] class extends Component {
                 <div class="mt-2 flex items-start justify-between gap-3">
                     <flux:heading size="xl">{{ $story->name }}</flux:heading>
                     @if ($this->canEditStory())
-                        <flux:button wire:click="startEdit" size="sm" variant="ghost">{{ __('Edit') }}</flux:button>
+                        <flux:button wire:click="startEdit" size="sm" icon="pencil-square">{{ __('Edit') }}</flux:button>
                     @endif
                 </div>
                 <div class="mt-2 flex flex-wrap items-center gap-2">
-                    <flux:badge>{{ $story->status->value }}</flux:badge>
-                    <flux:badge>rev {{ $story->revision }}</flux:badge>
+                    <x-state-pill :state="$pill['state']" :tally="$pill['tally']" :label="$pill['label']" />
+                    <flux:badge>v{{ $story->revision }}</flux:badge>
                     @if ($story->creator)
                         <flux:badge>{{ __('by') }} {{ $story->creator->name }}</flux:badge>
                     @endif
                 </div>
-                <x-markdown :content="$story->description" class="mt-3" />
-            @endif
-            @php
-                $user = auth()->user();
-                $policy = $story->effectivePolicy();
-                $revisionApprovals = $story->approvals->where('story_revision', $story->revision ?? 1);
-                $effective = [];
-                foreach ($revisionApprovals->sortBy('created_at') as $a) {
-                    $key = (int) $a->approver_id;
-                    if ($a->decision === ApprovalDecision::Approve) {
-                        $effective[$key] = $a;
-                    } elseif ($a->decision === ApprovalDecision::Revoke) {
-                        unset($effective[$key]);
-                    }
-                }
-                $userApproved = isset($effective[$user->id]);
-                $canApprove = $user->canApproveInProject($project);
-                $isAuthor = $story->created_by_id === $user->id;
-                $blockedBySelfApproval = $isAuthor && ! $policy->allow_self_approval;
-                $isAuthoringStatus = in_array($story->status, [StoryStatus::Draft, StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true);
-            @endphp
-
-            <div class="mt-4 flex flex-wrap items-center gap-2">
-                @if ($story->status === StoryStatus::Draft && ($isAuthor || $canApprove))
-                    @php
-                        $autoApproves = $policy->auto_approve || $policy->required_approvals === 0;
-                    @endphp
-                    <flux:button wire:click="submit" wire:target="submit" wire:loading.attr="disabled" variant="primary">
-                        <span wire:loading.remove wire:target="submit">{{ $autoApproves ? __('Generate plan') : __('Submit for approval') }}</span>
-                        <span wire:loading wire:target="submit">{{ __('Working…') }}</span>
-                    </flux:button>
-                @endif
-
-                @php
-                    $autoPromotes = $policy->auto_approve || $policy->required_approvals === 0;
-                @endphp
-
-                @if ($story->status === StoryStatus::PendingApproval && $story->tasks->isNotEmpty() && $autoPromotes && $canApprove)
-                    <flux:button wire:click="startExecution" wire:target="startExecution" wire:loading.attr="disabled" variant="primary">
-                        <span wire:loading.remove wire:target="startExecution">{{ __('Start execution') }}</span>
-                        <span wire:loading wire:target="startExecution">{{ __('Working…') }}</span>
-                    </flux:button>
-                @elseif (in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true) && $canApprove && ! $blockedBySelfApproval)
-                    @if ($userApproved)
-                        <flux:button wire:click="decide('revoke')" wire:target="decide" wire:loading.attr="disabled">{{ __('Revoke approval') }}</flux:button>
-                    @else
-                        <flux:button wire:click="decide('approve')" wire:target="decide" wire:loading.attr="disabled" variant="primary">{{ __('Approve') }}</flux:button>
-                    @endif
-                    <flux:button wire:click="decide('changes_requested')" wire:target="decide" wire:loading.attr="disabled">{{ __('Request changes') }}</flux:button>
-                    <flux:button wire:click="decide('reject')" wire:target="decide" wire:loading.attr="disabled" variant="danger">{{ __('Reject') }}</flux:button>
-                @endif
-
-                @if ($isAuthoringStatus && $canApprove && ! $blockedBySelfApproval && ! $autoPromotes)
-                    <flux:badge>{{ count($effective) }}/{{ $policy->required_approvals }} {{ __('approvals') }}</flux:badge>
-                @endif
-
-                @if ($this->pendingPlanRun)
-                    <flux:badge color="amber">{{ __('Generating plan…') }}</flux:badge>
-                @endif
-
-                @php
-                    $hasIncompleteWork = $story->status === StoryStatus::Approved
-                        && $story->tasks->isNotEmpty()
-                        && $story->tasks->flatMap->subtasks->contains(fn ($s) => $s->status !== TaskStatus::Done);
-                @endphp
-                @if ($hasIncompleteWork && $canApprove)
-                    <flux:button wire:click="resumeExecution" wire:target="resumeExecution" wire:loading.attr="disabled">
-                        <span wire:loading.remove wire:target="resumeExecution">{{ __('Resume execution') }}</span>
-                        <span wire:loading wire:target="resumeExecution">{{ __('Working…') }}</span>
-                    </flux:button>
-                @endif
-            </div>
-
-            @if (in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true) && $canApprove && ! $blockedBySelfApproval && ! $autoPromotes)
-                <flux:textarea
-                    class="mt-2"
-                    wire:model.defer="approvalNote"
-                    :placeholder="__('Notes (optional, attached to your decision)')"
-                />
-            @endif
-
-            @if ($blockedBySelfApproval && ! $autoPromotes && in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true))
-                <flux:text class="mt-3 text-xs text-amber-600">
-                    {{ __('You authored this story; the policy disallows self-approval.') }}
-                </flux:text>
-            @endif
-
-            @if ($story->notes)
-                <details class="mt-3">
-                    <summary class="cursor-pointer text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Notes') }}</summary>
-                    <x-markdown :content="$story->notes" class="mt-2" />
-                </details>
             @endif
         </div>
 
-        @if ($story->acceptanceCriteria->isNotEmpty())
-            <section class="flex flex-col gap-2">
-                <flux:heading size="lg">{{ __('Acceptance criteria') }}</flux:heading>
-                <ul class="text-sm">
-                    @foreach ($story->acceptanceCriteria as $ac)
-                        <li class="py-0.5">
-                            <flux:badge class="mr-2 align-middle">{{ __('AC') }} #{{ $ac->position }}</flux:badge>
-                            {{ $ac->criterion }}
-                            @if ($ac->met)<flux:badge class="ml-2">{{ __('met') }}</flux:badge>@endif
-                        </li>
-                    @endforeach
-                </ul>
-            </section>
-        @endif
+        @unless ($editing)
+            {{-- ── Story body: description + notes (ACs lead the plan section below) ── --}}
+            <section class="flex flex-col gap-3">
+                <x-markdown :content="$story->description" />
 
-        <section class="flex flex-col gap-3">
-            <div class="flex items-center justify-between">
-                <flux:heading size="lg">{{ __('Plan') }}</flux:heading>
-                @if ($story->status === StoryStatus::Approved && $story->tasks->isEmpty() && ! $this->pendingPlanRun && auth()->user()->canApproveInProject($story->feature->project))
-                    <flux:button wire:click="generatePlan" wire:target="generatePlan" wire:loading.attr="disabled" variant="primary">
-                        <span wire:loading.remove wire:target="generatePlan">{{ __('Generate plan') }}</span>
-                        <span wire:loading wire:target="generatePlan">{{ __('Working…') }}</span>
-                    </flux:button>
+                @if ($story->notes)
+                    <details>
+                        <summary class="cursor-pointer text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Notes') }}</summary>
+                        <x-markdown :content="$story->notes" class="mt-2" />
+                    </details>
                 @endif
-            </div>
-            @forelse ($story->tasks->sortBy('position') as $task)
-                <flux:card>
-                    <div class="flex flex-wrap items-center gap-2">
-                        <flux:badge variant="solid">#{{ $task->position }}</flux:badge>
-                        <flux:badge>{{ $task->status->value }}</flux:badge>
-                        @if ($task->acceptanceCriterion)
-                            <flux:badge>{{ __('AC') }} #{{ $task->acceptanceCriterion->position }}</flux:badge>
+            </section>
+        @endunless
+
+        @php
+            $policy = $this->effectivePolicy;
+            $userApproved = $this->userApproved;
+            $canApprove = $this->canApproveStory;
+            $isAuthor = $this->isAuthor;
+            $blockedBySelfApproval = $this->blockedBySelfApproval;
+            $autoPromotes = $this->autoPromotes;
+            $hasIncompleteWork = $story->status === StoryStatus::Approved
+                && $story->tasks->isNotEmpty()
+                && $story->tasks->flatMap->subtasks->contains(fn ($s) => $s->status !== TaskStatus::Done);
+            $needsApprovalNote = in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true)
+                && $canApprove
+                && ! $blockedBySelfApproval
+                && ! $autoPromotes;
+            $hasDraftSubmit = $story->status === StoryStatus::Draft && ($isAuthor || $canApprove);
+            $hasAutoStart = $story->status === StoryStatus::PendingApproval && $story->tasks->isNotEmpty() && $autoPromotes && $canApprove;
+            $hasApprovalActions = in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true) && $canApprove && ! $blockedBySelfApproval;
+            $hasResume = $hasIncompleteWork && $canApprove;
+            $hasAnyDecisionAction = $hasDraftSubmit || $hasAutoStart || $hasApprovalActions || $hasResume;
+            $isTerminal = in_array($story->status, [StoryStatus::Done, StoryStatus::Cancelled, StoryStatus::Rejected], true);
+        @endphp
+
+        @unless ($editing)
+            {{-- ── Plan: ACs → Tasks → Subtasks → runs (AC-led) ────────────── --}}
+            @php
+                $tasksByAc = $story->tasks->groupBy('acceptance_criterion_id');
+                $unmappedTasks = $tasksByAc->get(null, collect())->sortBy('position')->values();
+                $acs = $story->acceptanceCriteria->sortBy('position')->values();
+                $subtaskCount = $story->tasks->reduce(fn ($acc, $task) => $acc + $task->subtasks->count(), 0);
+                $shouldRunMode = $this->hasActiveSubtaskRun;
+                $latestRun = $story->tasks->flatMap->subtasks->flatMap->agentRuns->sortByDesc('id')->first();
+                $branch = $latestRun?->working_branch;
+                $repo = $latestRun?->repo;
+            @endphp
+
+            <section class="flex flex-col gap-3" data-section="plan">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                    <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+                        <flux:heading size="lg">{{ __('Plan') }}</flux:heading>
+                        <flux:text class="text-xs text-zinc-500">
+                            {{ $acs->count() }} {{ __('ACs') }} · {{ $subtaskCount }} {{ __('subtasks') }} · v{{ $story->revision }}
+                        </flux:text>
+                        @if ($repo)
+                            <flux:badge size="sm" icon="folder">{{ $repo->name }}</flux:badge>
                         @endif
-                        @php
-                            $deps = $task->dependencies->map(fn ($d) => '#'.$d->position);
-                        @endphp
-                        @if ($deps->isNotEmpty())
-                            <flux:badge>{{ __('depends on') }} {{ $deps->implode(', ') }}</flux:badge>
+                        @if ($branch)
+                            <flux:badge size="sm" icon="code-bracket">{{ $branch }}</flux:badge>
                         @endif
                     </div>
-                    <flux:heading class="mt-2">{{ $task->name }}</flux:heading>
-                    @if ($task->acceptanceCriterion)
-                        <flux:text class="mt-1 text-sm text-zinc-500"><em>{{ $task->acceptanceCriterion->criterion }}</em></flux:text>
+
+                    <div class="flex items-center gap-2">
+                        @if ($acs->isNotEmpty() || $unmappedTasks->isNotEmpty())
+                            <div class="inline-flex rounded-md border border-zinc-200 p-0.5 text-xs dark:border-zinc-700" role="tablist" data-toggle="plan-mode">
+                                <button
+                                    type="button"
+                                    role="tab"
+                                    @click="planRunMode = false"
+                                    :aria-selected="!planRunMode ? 'true' : 'false'"
+                                    :class="!planRunMode ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900' : 'text-zinc-600 dark:text-zinc-300'"
+                                    class="rounded px-2 py-0.5"
+                                >{{ __('Grooming') }}</button>
+                                <button
+                                    type="button"
+                                    role="tab"
+                                    @click="planRunMode = true"
+                                    :aria-selected="planRunMode ? 'true' : 'false'"
+                                    :class="planRunMode ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900' : 'text-zinc-600 dark:text-zinc-300'"
+                                    class="rounded px-2 py-0.5"
+                                >{{ __('Run') }}</button>
+                            </div>
+                        @endif
+
+                        @if ($story->status === StoryStatus::Approved && $story->tasks->isEmpty() && ! $this->pendingPlanRun && $this->canApproveStory)
+                            <flux:button wire:click="generatePlan" wire:target="generatePlan" wire:loading.attr="disabled" variant="primary">
+                                <span wire:loading.remove wire:target="generatePlan">{{ __('Generate plan') }}</span>
+                                <span wire:loading wire:target="generatePlan">{{ __('Working…') }}</span>
+                            </flux:button>
+                        @endif
+                    </div>
+                </div>
+
+                @forelse ($acs as $ac)
+                    @php
+                        $acTasks = $tasksByAc->get($ac->id, collect())->sortBy('position');
+                    @endphp
+                    <flux:card data-ac="{{ $loop->iteration }}" data-ac-id="{{ $ac->id }}">
+                        <details
+                            class="group"
+                            x-data="{ open: ('{{ $shouldRunMode ? '1' : '0' }}' === '1') || planRunMode }"
+                            x-init="$watch('planRunMode', v => { if (v) open = true; else if ('{{ $shouldRunMode ? '1' : '0' }}' !== '1') open = false; })"
+                            :open="open"
+                            @toggle="open = $event.target.open"
+                        >
+                            <summary class="flex cursor-pointer list-none flex-wrap items-baseline gap-2 text-sm [&::-webkit-details-marker]:hidden">
+                                <span class="text-zinc-400 transition-transform group-open:rotate-90" aria-hidden="true">▸</span>
+                                <flux:badge>{{ __('AC') }} #{{ $loop->iteration }}</flux:badge>
+                                <span class="font-medium">{{ $ac->criterion }}</span>
+                                @if ($ac->met)
+                                    <flux:badge class="ml-1">{{ __('met') }}</flux:badge>
+                                @endif
+                            </summary>
+
+                            @if ($acTasks->isEmpty())
+                                <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No task generated for this AC yet.') }}</flux:text>
+                            @else
+                                @foreach ($acTasks as $task)
+                                    @include('partials.story-task', ['task' => $task])
+                                @endforeach
+                            @endif
+                        </details>
+                    </flux:card>
+                @empty
+                    @if ($this->pendingPlanRun)
+                        <flux:text class="text-zinc-500">{{ __('Generating plan…') }}</flux:text>
+                    @elseif ($story->acceptanceCriteria->isEmpty())
+                        <flux:text class="text-zinc-500">{{ __('No acceptance criteria yet.') }}</flux:text>
                     @endif
-                    @if ($task->description)
-                        <x-markdown :content="$task->description" class="mt-2 text-sm" />
-                    @endif
-                    @if ($task->subtasks->isNotEmpty())
-                        <ol class="mt-3 list-decimal pl-5 text-sm">
-                            @foreach ($task->subtasks->sortBy('position') as $sub)
-                                <li class="py-1">
-                                    <span class="font-medium">{{ $sub->name }}</span>
-                                    <flux:badge class="ml-2">{{ $sub->status->value }}</flux:badge>
-                                    @if ($sub->description)
-                                        <x-markdown :content="$sub->description" class="mt-1 text-xs text-zinc-500" />
-                                    @endif
-                                </li>
+                @endforelse
+
+                @if ($unmappedTasks->isNotEmpty())
+                    <flux:card data-ac="unmapped">
+                        <details :open="planRunMode">
+                            <summary class="cursor-pointer text-sm font-medium">
+                                {{ __('Unmapped tasks') }} ({{ $unmappedTasks->count() }})
+                            </summary>
+                            @foreach ($unmappedTasks as $task)
+                                @include('partials.story-task', ['task' => $task])
                             @endforeach
-                        </ol>
-                    @endif
-                </flux:card>
-            @empty
-                @if ($this->pendingPlanRun)
-                    <flux:text class="text-zinc-500">{{ __('Generating plan…') }}</flux:text>
-                @elseif ($story->status === StoryStatus::Approved)
-                    <flux:text class="text-zinc-500">{{ __('No plan yet — generate one to break this story into tasks and subtasks.') }}</flux:text>
-                @else
+                        </details>
+                    </flux:card>
+                @endif
+
+                @if ($acs->isEmpty() && $story->tasks->isEmpty() && ! $this->pendingPlanRun && $story->status !== StoryStatus::Approved)
                     <flux:text class="text-zinc-500">{{ __('Plan is generated once the story is approved.') }}</flux:text>
                 @endif
-            @endforelse
-        </section>
 
-        <section class="flex flex-col gap-3">
-            <flux:heading size="lg">{{ __('Runs') }}</flux:heading>
-            @forelse ($this->runs as $run)
-                <flux:card>
-                    <div class="flex flex-wrap items-center gap-2">
-                        <flux:badge variant="solid">#{{ $run->id }}</flux:badge>
-                        <flux:badge>{{ $run->status->value }}</flux:badge>
-                        @if ($run->repo)
-                            <flux:badge>{{ $run->repo->name }}</flux:badge>
-                        @endif
-                        @if ($run->working_branch)
-                            <flux:badge>{{ $run->working_branch }}</flux:badge>
-                        @endif
-                        @if ($run->finished_at)
-                            <flux:text class="ml-auto text-xs text-zinc-500">{{ $run->finished_at->diffForHumans() }}</flux:text>
-                        @endif
-                    </div>
-                    @if ($run->runnable instanceof Subtask)
-                        <flux:text class="mt-2 text-sm">{{ $run->runnable->name }}</flux:text>
-                    @elseif ($run->runnable)
-                        <flux:text class="mt-2 text-sm">{{ $run->runnable->name }}</flux:text>
-                    @endif
-                    @if ($url = $run->output['pull_request_url'] ?? null)
-                        <flux:text class="mt-1">
-                            <a href="{{ $url }}" target="_blank" rel="noopener" class="underline">{{ $url }}</a>
-                        </flux:text>
-                    @endif
-                    @if ($run->error_message)
-                        <flux:text class="mt-1 text-red-600">{{ $run->error_message }}</flux:text>
-                    @endif
-                </flux:card>
-            @empty
-                <flux:text class="text-zinc-500">{{ __('No runs yet.') }}</flux:text>
-            @endforelse
-        </section>
+                @php $planGenRuns = $this->planGenerationRuns; @endphp
+                @if ($planGenRuns->isNotEmpty())
+                    <details class="mt-1">
+                        <summary class="cursor-pointer text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Plan generation runs') }} ({{ $planGenRuns->count() }})</summary>
+                        <div class="mt-2 flex flex-col gap-2">
+                            @foreach ($planGenRuns as $run)
+                                <div class="rounded border border-zinc-200 px-2 py-1 dark:border-zinc-700">
+                                    <div class="flex flex-wrap items-center gap-2 text-xs">
+                                        <flux:badge size="sm">#{{ $run->id }}</flux:badge>
+                                        <flux:badge size="sm">{{ $run->status->value }}</flux:badge>
+                                        @if ($run->finished_at)
+                                            <flux:text class="ml-auto text-xs text-zinc-500">{{ $run->finished_at->diffForHumans() }}</flux:text>
+                                        @endif
+                                    </div>
+                                    @if ($run->error_message)
+                                        <flux:text class="mt-1 text-xs text-red-600">{{ $run->error_message }}</flux:text>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </details>
+                @endif
+            </section>
+        @endunless
 
-        <section class="flex flex-col gap-3">
-            <flux:heading size="lg">{{ __('Story approvals') }}</flux:heading>
-            @forelse ($story->approvals->sortByDesc('created_at') as $approval)
-                <flux:card>
-                    <div class="flex flex-wrap items-center gap-2">
-                        <flux:badge>{{ $approval->decision->value }}</flux:badge>
-                        <flux:badge>rev {{ $approval->story_revision }}</flux:badge>
-                        <flux:text class="text-sm">{{ $approval->approver?->name ?? 'unknown' }}</flux:text>
-                        <flux:text class="ml-auto text-xs text-zinc-500">{{ $approval->created_at?->diffForHumans() }}</flux:text>
-                    </div>
-                    @if ($approval->notes)
-                        <flux:text class="mt-1 text-sm">{{ $approval->notes }}</flux:text>
-                    @endif
-                </flux:card>
-            @empty
-                <flux:text class="text-zinc-500">{{ __('No story approvals yet.') }}</flux:text>
-            @endforelse
-        </section>
+            </div>{{-- /center column --}}
+
+            {{-- ── Right rail: decision actions + log + eligible approvers ──── --}}
+            @unless ($editing)
+                @php
+                    $rrCurrent = $story->approvals->where('story_revision', $story->revision ?? 1)->sortBy('created_at')->values();
+                    $rrPrior = $story->approvals->where('story_revision', '!=', $story->revision ?? 1)->sortByDesc('created_at')->values();
+                    $rrPolicy = $this->effectivePolicy;
+                    $rrEligibleVisible = ! $isTerminal
+                        && $rrPolicy
+                        && ($rrPolicy->required_approvals ?? 0) > 1
+                        && in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true);
+                    $rrEligible = $rrEligibleVisible ? $this->eligibleApprovers : collect();
+                    $blockedNotice = $blockedBySelfApproval
+                        && ! $autoPromotes
+                        && in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true);
+                    $decisionVisible = $hasAnyDecisionAction || $blockedNotice || $this->pendingPlanRun;
+                    $showRail = $decisionVisible || $rrCurrent->isNotEmpty() || $rrPrior->isNotEmpty() || $rrEligible->isNotEmpty();
+                @endphp
+                @if ($showRail)
+                    <aside class="flex w-full flex-col gap-4 lg:w-80 lg:flex-none" data-rail-aside>
+                        @if ($decisionVisible)
+                            <section data-section="decision" class="flex flex-col gap-3 rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+                                <flux:text class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Decision') }}</flux:text>
+
+                                @if ($hasAnyDecisionAction)
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        @if ($hasDraftSubmit)
+                                            <flux:button wire:click="submit" wire:target="submit" wire:loading.attr="disabled" variant="primary" class="w-full">
+                                                <span wire:loading.remove wire:target="submit">{{ $autoPromotes ? __('Submit & generate plan') : __('Submit for approval') }}</span>
+                                                <span wire:loading wire:target="submit">{{ __('Working…') }}</span>
+                                            </flux:button>
+                                        @endif
+
+                                        @if ($hasAutoStart)
+                                            <flux:button wire:click="startExecution" wire:target="startExecution" wire:loading.attr="disabled" variant="primary" class="w-full">
+                                                <span wire:loading.remove wire:target="startExecution">{{ __('Start execution') }}</span>
+                                                <span wire:loading wire:target="startExecution">{{ __('Working…') }}</span>
+                                            </flux:button>
+                                        @elseif ($hasApprovalActions)
+                                            @if ($userApproved)
+                                                <flux:button wire:click="decide('revoke')" wire:target="decide" wire:loading.attr="disabled" class="w-full">{{ __('Revoke approval') }}</flux:button>
+                                            @else
+                                                <flux:button wire:click="decide('approve')" wire:target="decide" wire:loading.attr="disabled" variant="primary" class="w-full">{{ __('Approve') }}</flux:button>
+                                            @endif
+                                            <flux:button wire:click="decide('changes_requested')" wire:target="decide" wire:loading.attr="disabled" class="w-full">{{ __('Request changes') }}</flux:button>
+                                            <flux:button wire:click="decide('reject')" wire:target="decide" wire:loading.attr="disabled" variant="danger" class="w-full">{{ __('Reject') }}</flux:button>
+                                        @endif
+
+                                        @if ($hasResume)
+                                            <flux:button wire:click="resumeExecution" wire:target="resumeExecution" wire:loading.attr="disabled" class="w-full">
+                                                <span wire:loading.remove wire:target="resumeExecution">{{ __('Resume execution') }}</span>
+                                                <span wire:loading wire:target="resumeExecution">{{ __('Working…') }}</span>
+                                            </flux:button>
+                                        @endif
+                                    </div>
+                                @endif
+
+                                @if ($needsApprovalNote)
+                                    <flux:textarea
+                                        wire:model.defer="approvalNote"
+                                        :placeholder="__('Notes (optional)')"
+                                        rows="3"
+                                    />
+                                @endif
+
+                                @if ($blockedNotice)
+                                    <flux:text class="text-xs text-amber-600">
+                                        {{ __('You authored this story; the policy disallows self-approval.') }}
+                                    </flux:text>
+                                @endif
+
+                                @if ($this->pendingPlanRun)
+                                    <flux:badge color="amber">{{ __('Generating plan…') }}</flux:badge>
+                                @endif
+                            </section>
+                        @endif
+
+                        @if ($rrCurrent->isNotEmpty() || $rrPrior->isNotEmpty())
+                            <section data-section="decision-log" class="flex flex-col gap-2 rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+                                <flux:text class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Decision log') }}</flux:text>
+                                @forelse ($rrCurrent as $approval)
+                                    <x-decision-row :approval="$approval" />
+                                @empty
+                                    <flux:text class="text-xs text-zinc-500">{{ __('No decisions on this revision yet.') }}</flux:text>
+                                @endforelse
+
+                                @if ($rrPrior->isNotEmpty())
+                                    <details class="mt-1">
+                                        <summary class="cursor-pointer text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Prior revisions') }} ({{ $rrPrior->count() }})</summary>
+                                        <div class="mt-2 flex flex-col gap-2">
+                                            @foreach ($rrPrior as $approval)
+                                                <x-decision-row :approval="$approval" />
+                                            @endforeach
+                                        </div>
+                                    </details>
+                                @endif
+                            </section>
+                        @endif
+
+                        @if ($rrEligible->isNotEmpty())
+                            <section data-section="eligible-approvers" class="flex flex-col gap-2 rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+                                <flux:text class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Eligible approvers') }}</flux:text>
+                                <ul class="text-sm">
+                                    @foreach ($rrEligible as $u)
+                                        <li class="py-0.5">{{ $u->name }}</li>
+                                    @endforeach
+                                </ul>
+                            </section>
+                        @endif
+                    </aside>
+                @endif
+            @endunless
+
+        </div>{{-- /two-column wrapper --}}
     @endif
 </div>

--- a/resources/views/pages/subtasks/⚡show.blade.php
+++ b/resources/views/pages/subtasks/⚡show.blade.php
@@ -1,0 +1,173 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Enums\TaskStatus;
+use App\Models\Subtask;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+new #[Title('Subtask')] class extends Component {
+    public int $project_id;
+
+    public int $story_id;
+
+    public int $subtask_id;
+
+    public function mount(int $project, int $story, int $subtask): void
+    {
+        $this->project_id = (int) $project;
+        $this->story_id = (int) $story;
+        $this->subtask_id = (int) $subtask;
+
+        $loaded = $this->subtask;
+        abort_unless($loaded, 404);
+
+        $user = Auth::user();
+        if ((int) $user->current_project_id !== $this->project_id) {
+            $user->forceFill(['current_project_id' => $this->project_id])->save();
+        }
+    }
+
+    #[Computed]
+    public function subtask(): ?Subtask
+    {
+        return Subtask::query()
+            ->whereHas('task.story.feature', fn ($q) => $q
+                ->where('project_id', $this->project_id)
+                ->whereIn('project_id', Auth::user()->accessibleProjectIds())
+            )
+            ->whereHas('task.story', fn ($q) => $q->where('id', $this->story_id))
+            ->with([
+                'task.story.feature.project',
+                'task.dependencies',
+                'agentRuns.repo',
+                'proposedByRun',
+            ])
+            ->find($this->subtask_id);
+    }
+
+    /**
+     * AgentRuns ordered newest-first. Multiple-runs case is the race-mode
+     * leaderboard (ADR-0006); the single-run case is the common path.
+     */
+    #[Computed]
+    public function runs()
+    {
+        return $this->subtask?->agentRuns->sortByDesc('id')->values() ?? collect();
+    }
+}; ?>
+
+<div class="flex p-6">
+    @if (! $this->subtask)
+        <flux:text class="text-zinc-500">{{ __('Subtask not found.') }}</flux:text>
+    @else
+        @php
+            $subtask = $this->subtask;
+            $task = $subtask->task;
+            $story = $task->story;
+            $feature = $story->feature;
+            $project = $feature->project;
+            $runs = $this->runs;
+            $isRace = $runs->count() > 1 && $runs->groupBy('runnable_id')->count() === 1;
+        @endphp
+
+        @php
+            $rail = match ($subtask->status) {
+                TaskStatus::Done => 'run_complete',
+                TaskStatus::InProgress => 'running',
+                TaskStatus::Blocked => 'run_failed',
+                default => 'draft',
+            };
+        @endphp
+        <x-rail :state="$rail" class="mr-4" />
+
+        <div class="flex min-w-0 max-w-4xl flex-1 flex-col gap-6">
+            <nav aria-label="Breadcrumb" class="flex flex-wrap items-center gap-1 text-sm text-zinc-500" data-section="breadcrumb">
+                <a href="{{ route('projects.show', $project) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $project->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('features.show', ['project' => $project, 'feature' => $feature]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $feature->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('stories.show', ['project' => $project, 'story' => $story]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $story->name }}</a>
+                <span aria-hidden="true">›</span>
+                <span class="text-zinc-700 dark:text-zinc-300" aria-current="page">{{ $subtask->name }}</span>
+            </nav>
+
+            <div>
+                <div class="flex flex-wrap items-center gap-2 text-xs">
+                    <flux:badge variant="solid">{{ __('Subtask') }} #{{ $subtask->position }}</flux:badge>
+                    <flux:badge>{{ $subtask->status->value }}</flux:badge>
+                    <flux:badge>{{ __('Task') }} #{{ $task->position }}: {{ $task->name }}</flux:badge>
+                    @if ($subtask->proposed_by_run_id)
+                        <flux:badge color="amber" title="{{ __('Appended mid-run by') }} #{{ $subtask->proposed_by_run_id }} (ADR-0005)">{{ __('appended') }}</flux:badge>
+                    @endif
+                </div>
+                <flux:heading size="xl" class="mt-2">{{ $subtask->name }}</flux:heading>
+                @if ($subtask->description)
+                    <x-markdown :content="$subtask->description" class="mt-2" />
+                @endif
+            </div>
+
+            <section class="flex flex-col gap-3" data-section="runs">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                    <flux:heading size="lg">{{ __('Runs') }}</flux:heading>
+                    @if ($isRace)
+                        <flux:badge color="sky" title="{{ __('Race mode: multiple drivers ran in parallel; the first success wins (ADR-0006)') }}">{{ __('Race · :n drivers', ['n' => $runs->count()]) }}</flux:badge>
+                    @endif
+                </div>
+                @forelse ($runs as $run)
+                    @php
+                        $runRail = match ($run->status) {
+                            AgentRunStatus::Succeeded => 'run_complete',
+                            AgentRunStatus::Running, AgentRunStatus::Queued => 'running',
+                            AgentRunStatus::Failed, AgentRunStatus::Aborted => 'run_failed',
+                            default => 'draft',
+                        };
+                        $duration = $run->started_at && $run->finished_at
+                            ? $run->started_at->diffInSeconds($run->finished_at)
+                            : null;
+                    @endphp
+                    <a
+                        href="{{ route('runs.show', ['project' => $project, 'story' => $story, 'subtask' => $subtask, 'run' => $run]) }}"
+                        wire:navigate
+                        class="flex items-stretch gap-3 rounded-lg border border-zinc-200 p-3 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                        data-run-row="{{ $run->id }}"
+                    >
+                        <x-rail :state="$runRail" class="!w-0.5" />
+                        <div class="min-w-0 flex-1">
+                            <div class="flex flex-wrap items-center gap-2 text-xs">
+                                <flux:badge variant="solid" size="sm">{{ __('run') }} #{{ $run->id }}</flux:badge>
+                                <x-state-pill :state="$runRail" :label="$run->status->value" />
+                                @if ($run->executor_driver)
+                                    <flux:badge size="sm">{{ $run->executor_driver }}</flux:badge>
+                                @endif
+                                @if ($run->kind && $run->kind !== 'execute')
+                                    <flux:badge color="purple" size="sm">{{ $run->kind }}</flux:badge>
+                                @endif
+                                @if ($duration !== null)
+                                    <flux:badge size="sm">{{ $duration }}s</flux:badge>
+                                @endif
+                                @if ($run->finished_at)
+                                    <flux:text class="ml-auto text-xs text-zinc-500">{{ $run->finished_at->diffForHumans() }}</flux:text>
+                                @elseif ($run->started_at)
+                                    <flux:text class="ml-auto text-xs text-zinc-500">{{ __('started') }} {{ $run->started_at->diffForHumans() }}</flux:text>
+                                @endif
+                            </div>
+                            @if ($url = $run->output['pull_request_url'] ?? null)
+                                <flux:text class="mt-1 truncate text-xs">
+                                    <span class="text-zinc-500">{{ __('PR:') }}</span> {{ $url }}
+                                </flux:text>
+                            @endif
+                            @if ($run->error_message)
+                                <flux:text class="mt-1 truncate text-xs text-rose-600 dark:text-rose-400">{{ Str::limit($run->error_message, 200) }}</flux:text>
+                            @endif
+                        </div>
+                    </a>
+                @empty
+                    <flux:text class="text-zinc-500">{{ __('No runs yet for this subtask.') }}</flux:text>
+                @endforelse
+            </section>
+        </div>
+    @endif
+</div>

--- a/resources/views/pages/⚡dashboard.blade.php
+++ b/resources/views/pages/⚡dashboard.blade.php
@@ -93,7 +93,7 @@ new #[Title('Dashboard')] class extends Component {
     <flux:heading size="xl">{{ __('Dashboard') }}</flux:heading>
 
     <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-        <a href="{{ route('inbox') }}" wire:navigate class="rounded-xl border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900">
+        <a href="{{ route('triage') }}" wire:navigate class="rounded-xl border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900">
             <div class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Pending stories') }}</div>
             <div class="mt-1 text-3xl font-semibold">{{ $this->pendingStoryCount }}</div>
         </a>

--- a/resources/views/pages/⚡dashboard.blade.php
+++ b/resources/views/pages/⚡dashboard.blade.php
@@ -90,6 +90,12 @@ new #[Title('Dashboard')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-6 p-6">
+    @php
+        $currentProjectId = auth()->user()->current_project_id;
+        $runsHref = $currentProjectId ? route('runs.index', ['project' => $currentProjectId]) : route('projects.index');
+        $failedRunsHref = $currentProjectId ? route('runs.index', ['project' => $currentProjectId, 'status' => 'failed']) : route('projects.index');
+    @endphp
+
     <flux:heading size="xl">{{ __('Dashboard') }}</flux:heading>
 
     <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
@@ -97,11 +103,11 @@ new #[Title('Dashboard')] class extends Component {
             <div class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Pending stories') }}</div>
             <div class="mt-1 text-3xl font-semibold">{{ $this->pendingStoryCount }}</div>
         </a>
-        <a href="{{ route('runs.index') }}" wire:navigate class="rounded-xl border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900">
+        <a href="{{ $runsHref }}" wire:navigate class="rounded-xl border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900">
             <div class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Executing stories') }}</div>
             <div class="mt-1 text-3xl font-semibold">{{ $this->executingStoryCount }}</div>
         </a>
-        <a href="{{ route('runs.index', ['status' => 'failed']) }}" wire:navigate class="rounded-xl border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900">
+        <a href="{{ $failedRunsHref }}" wire:navigate class="rounded-xl border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900">
             <div class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Failed runs') }}</div>
             <div class="mt-1 text-3xl font-semibold {{ $this->failedRunCount > 0 ? 'text-red-600' : '' }}">{{ $this->failedRunCount }}</div>
         </a>
@@ -138,7 +144,7 @@ new #[Title('Dashboard')] class extends Component {
             @empty
                 <flux:text class="text-zinc-500">{{ __('No runs yet.') }}</flux:text>
             @endforelse
-            <a href="{{ route('runs.index') }}" wire:navigate class="text-sm underline">{{ __('See all runs') }} &rarr;</a>
+            <a href="{{ $runsHref }}" wire:navigate class="text-sm underline">{{ __('See all runs') }} &rarr;</a>
         </section>
 
         <section class="flex flex-col gap-3">

--- a/resources/views/pages/⚡triage.blade.php
+++ b/resources/views/pages/⚡triage.blade.php
@@ -9,7 +9,7 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Component;
 
-new #[Title('Inbox')] class extends Component {
+new #[Title('Triage')] class extends Component {
     public array $notes = [];
 
     #[Computed]
@@ -58,7 +58,7 @@ new #[Title('Inbox')] class extends Component {
 }; ?>
 
 <div class="flex flex-col gap-8 p-6">
-    <flux:heading size="xl">{{ __('Inbox') }}</flux:heading>
+    <flux:heading size="xl">{{ __('Triage') }}</flux:heading>
 
     @php
         $user = auth()->user();

--- a/resources/views/partials/story-task.blade.php
+++ b/resources/views/partials/story-task.blade.php
@@ -1,0 +1,105 @@
+@php
+    /** @var \App\Models\Task $task */
+    $deps = $task->dependencies->map(fn ($d) => '#'.$d->position);
+@endphp
+
+<div class="mt-4 border-l-2 border-zinc-100 pl-3 dark:border-zinc-800" data-task-id="{{ $task->id }}">
+    <div class="flex flex-wrap items-center gap-2 text-xs">
+        <flux:badge variant="solid" size="sm">#{{ $task->position }}</flux:badge>
+        <flux:badge size="sm">{{ $task->status->value }}</flux:badge>
+        @if ($deps->isNotEmpty())
+            <flux:badge size="sm">{{ __('depends on') }} {{ $deps->implode(', ') }}</flux:badge>
+        @endif
+    </div>
+
+    <flux:heading class="mt-1" size="sm">{{ $task->name }}</flux:heading>
+
+    @if ($task->description)
+        <x-markdown :content="$task->description" class="mt-1 text-sm text-zinc-600 dark:text-zinc-400" />
+    @endif
+
+    @if ($task->subtasks->isNotEmpty())
+        <ol class="mt-3 flex list-decimal flex-col gap-3 pl-5 text-sm marker:text-zinc-400">
+            @foreach ($task->subtasks->sortBy('position') as $sub)
+                @php
+                    $runs = $sub->agentRuns->sortByDesc('id')->values();
+                    $latestRun = $runs->first();
+                    $priorRuns = $runs->slice(1);
+                    $appended = ! is_null($sub->proposed_by_run_id ?? null);
+                    $hasError = $latestRun && $latestRun->error_message;
+                @endphp
+                <li data-subtask-id="{{ $sub->id }}">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <span class="font-medium">{{ $sub->name }}</span>
+                        <flux:badge size="sm">{{ $sub->status->value }}</flux:badge>
+                        @if ($appended)
+                            <span title="{{ __('Appended by Run') }} #{{ $sub->proposed_by_run_id }}" data-provenance class="text-xs text-amber-600 dark:text-amber-400">+</span>
+                        @endif
+                    </div>
+                    @if ($sub->description)
+                        <x-markdown :content="$sub->description" class="mt-1 text-xs text-zinc-500" />
+                    @endif
+
+                    @if ($latestRun)
+                        <div class="mt-2 overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-700">
+                            <div class="flex flex-wrap items-center gap-2 bg-zinc-50 px-2 py-1 text-xs dark:bg-zinc-800/50">
+                                <flux:badge size="sm">{{ __('run') }} #{{ $latestRun->id }}</flux:badge>
+                                <flux:badge size="sm">{{ $latestRun->status->value }}</flux:badge>
+                                @if ($latestRun->finished_at)
+                                    <flux:text class="ml-auto text-xs text-zinc-500">{{ $latestRun->finished_at->diffForHumans() }}</flux:text>
+                                @endif
+                            </div>
+                            <div class="px-2 py-1.5">
+                                @if ($url = $latestRun->output['pull_request_url'] ?? null)
+                                    <flux:text class="text-xs">
+                                        <a href="{{ $url }}" target="_blank" rel="noopener" class="underline">{{ $url }}</a>
+                                    </flux:text>
+                                @endif
+                                @if ($hasError)
+                                    <details>
+                                        <summary class="cursor-pointer select-none text-xs font-medium text-rose-700 hover:text-rose-900 dark:text-rose-400 dark:hover:text-rose-300">
+                                            {{ __('Error output') }}
+                                        </summary>
+                                        <pre class="mt-1 max-h-48 overflow-auto rounded bg-rose-50 p-2 font-mono text-[11px] leading-snug text-rose-900 dark:bg-rose-950/40 dark:text-rose-200">{{ $latestRun->error_message }}</pre>
+                                    </details>
+                                @endif
+                            </div>
+
+                            @if ($priorRuns->isNotEmpty())
+                                <details class="border-t border-zinc-200 dark:border-zinc-700">
+                                    <summary class="cursor-pointer px-2 py-1 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Run history') }} ({{ $priorRuns->count() }})</summary>
+                                    <div class="flex flex-col">
+                                        @foreach ($priorRuns as $run)
+                                            <div class="border-t border-zinc-100 px-2 py-1 dark:border-zinc-800">
+                                                <div class="flex flex-wrap items-center gap-2 text-xs">
+                                                    <flux:badge size="sm">#{{ $run->id }}</flux:badge>
+                                                    <flux:badge size="sm">{{ $run->status->value }}</flux:badge>
+                                                    @if ($run->finished_at)
+                                                        <flux:text class="ml-auto text-xs text-zinc-500">{{ $run->finished_at->diffForHumans() }}</flux:text>
+                                                    @endif
+                                                </div>
+                                                @if ($url = $run->output['pull_request_url'] ?? null)
+                                                    <flux:text class="mt-1 text-xs">
+                                                        <a href="{{ $url }}" target="_blank" rel="noopener" class="underline">{{ $url }}</a>
+                                                    </flux:text>
+                                                @endif
+                                                @if ($run->error_message)
+                                                    <details class="mt-1">
+                                                        <summary class="cursor-pointer select-none text-xs font-medium text-rose-700 hover:text-rose-900 dark:text-rose-400 dark:hover:text-rose-300">
+                                                            {{ __('Error output') }}
+                                                        </summary>
+                                                        <pre class="mt-1 max-h-32 overflow-auto rounded bg-rose-50 p-2 font-mono text-[11px] leading-snug text-rose-900 dark:bg-rose-950/40 dark:text-rose-200">{{ $run->error_message }}</pre>
+                                                    </details>
+                                                @endif
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </details>
+                            @endif
+                        </div>
+                    @endif
+                </li>
+            @endforeach
+        </ol>
+    @endif
+</div>

--- a/resources/views/partials/story-task.blade.php
+++ b/resources/views/partials/story-task.blade.php
@@ -30,7 +30,11 @@
                 @endphp
                 <li data-subtask-id="{{ $sub->id }}">
                     <div class="flex flex-wrap items-center gap-2">
-                        <span class="font-medium">{{ $sub->name }}</span>
+                        <a
+                            href="{{ route('subtasks.show', ['project' => $task->story->feature->project_id, 'story' => $task->story_id, 'subtask' => $sub->id]) }}"
+                            wire:navigate
+                            class="font-medium hover:underline"
+                        >{{ $sub->name }}</a>
                         <flux:badge size="sm">{{ $sub->status->value }}</flux:badge>
                         @if ($appended)
                             <span title="{{ __('Appended by Run') }} #{{ $sub->proposed_by_run_id }}" data-provenance class="text-xs text-amber-600 dark:text-amber-400">+</span>
@@ -41,14 +45,22 @@
                     @endif
 
                     @if ($latestRun)
+                        @php
+                            $runUrl = route('runs.show', [
+                                'project' => $task->story->feature->project_id,
+                                'story' => $task->story_id,
+                                'subtask' => $sub->id,
+                                'run' => $latestRun->id,
+                            ]);
+                        @endphp
                         <div class="mt-2 overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-700">
-                            <div class="flex flex-wrap items-center gap-2 bg-zinc-50 px-2 py-1 text-xs dark:bg-zinc-800/50">
+                            <a href="{{ $runUrl }}" wire:navigate class="flex flex-wrap items-center gap-2 bg-zinc-50 px-2 py-1 text-xs hover:bg-zinc-100 dark:bg-zinc-800/50 dark:hover:bg-zinc-800">
                                 <flux:badge size="sm">{{ __('run') }} #{{ $latestRun->id }}</flux:badge>
                                 <flux:badge size="sm">{{ $latestRun->status->value }}</flux:badge>
                                 @if ($latestRun->finished_at)
                                     <flux:text class="ml-auto text-xs text-zinc-500">{{ $latestRun->finished_at->diffForHumans() }}</flux:text>
                                 @endif
-                            </div>
+                            </a>
                             <div class="px-2 py-1.5">
                                 @if ($url = $latestRun->output['pull_request_url'] ?? null)
                                     <flux:text class="text-xs">
@@ -70,14 +82,22 @@
                                     <summary class="cursor-pointer px-2 py-1 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Run history') }} ({{ $priorRuns->count() }})</summary>
                                     <div class="flex flex-col">
                                         @foreach ($priorRuns as $run)
+                                            @php
+                                                $priorRunUrl = route('runs.show', [
+                                                    'project' => $task->story->feature->project_id,
+                                                    'story' => $task->story_id,
+                                                    'subtask' => $sub->id,
+                                                    'run' => $run->id,
+                                                ]);
+                                            @endphp
                                             <div class="border-t border-zinc-100 px-2 py-1 dark:border-zinc-800">
-                                                <div class="flex flex-wrap items-center gap-2 text-xs">
+                                                <a href="{{ $priorRunUrl }}" wire:navigate class="flex flex-wrap items-center gap-2 text-xs hover:underline">
                                                     <flux:badge size="sm">#{{ $run->id }}</flux:badge>
                                                     <flux:badge size="sm">{{ $run->status->value }}</flux:badge>
                                                     @if ($run->finished_at)
                                                         <flux:text class="ml-auto text-xs text-zinc-500">{{ $run->finished_at->diffForHumans() }}</flux:text>
                                                     @endif
-                                                </div>
+                                                </a>
                                                 @if ($url = $run->output['pull_request_url'] ?? null)
                                                     <flux:text class="mt-1 text-xs">
                                                         <a href="{{ $url }}" target="_blank" rel="noopener" class="underline">{{ $url }}</a>

--- a/resources/views/partials/story-task.blade.php
+++ b/resources/views/partials/story-task.blade.php
@@ -37,7 +37,17 @@
                         >{{ $sub->name }}</a>
                         <flux:badge size="sm">{{ $sub->status->value }}</flux:badge>
                         @if ($appended)
-                            <span title="{{ __('Appended by Run') }} #{{ $sub->proposed_by_run_id }}" data-provenance class="text-xs text-amber-600 dark:text-amber-400">+</span>
+                            @php $provenanceLabel = __('Appended by Run').' #'.$sub->proposed_by_run_id; @endphp
+                            <span
+                                title="{{ $provenanceLabel }}"
+                                aria-label="{{ $provenanceLabel }}"
+                                role="img"
+                                data-provenance
+                                class="text-xs text-amber-600 dark:text-amber-400"
+                            >
+                                <span aria-hidden="true">+</span>
+                                <span class="sr-only">{{ $provenanceLabel }}</span>
+                            </span>
                         @endif
                     </div>
                     @if ($sub->description)

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,19 +80,32 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::permanentRedirect('inbox', 'triage');
     Route::permanentRedirect('events', 'activity');
 
-    // Project-scoped legacy redirects: resolve via the user's current project.
-    // If no current project is set, fall back to the project picker.
+    // Project-scoped legacy redirects: resolve via the user's current project,
+    // but only if it's still accessible. If pinned project was deleted or
+    // membership revoked, fall back to the project picker rather than a
+    // broken project URL.
+    $resolveActiveProjectId = function () {
+        $user = auth()->user();
+        $pinned = $user->current_project_id;
+        if (! $pinned) {
+            return null;
+        }
+
+        return in_array((int) $pinned, $user->accessibleProjectIds(), true)
+            ? (int) $pinned
+            : null;
+    };
     foreach (['stories' => 'stories.index', 'runs' => 'runs.index', 'repos' => 'repos.index'] as $legacy => $named) {
-        Route::get($legacy, function () use ($named) {
-            $projectId = auth()->user()->current_project_id;
+        Route::get($legacy, function () use ($named, $resolveActiveProjectId) {
+            $projectId = $resolveActiveProjectId();
 
             return $projectId
                 ? redirect()->route($named, ['project' => $projectId], 301)
                 : redirect()->route('projects.index', [], 301);
         });
     }
-    Route::get('stories/create', function () {
-        $projectId = auth()->user()->current_project_id;
+    Route::get('stories/create', function () use ($resolveActiveProjectId) {
+        $projectId = $resolveActiveProjectId();
 
         return $projectId
             ? redirect()->route('stories.create', ['project' => $projectId], 301)

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,16 +22,35 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('projects', 'pages::projects.index')->name('projects.index');
     Route::livewire('projects/{project}', 'pages::projects.show')->name('projects.show');
     Route::livewire('projects/{project}/features/{feature}', 'pages::features.show')->name('features.show');
-    Route::livewire('stories', 'pages::stories.index')->name('stories.index');
-    Route::livewire('stories/create', 'pages::stories.create')->name('stories.create');
+    Route::livewire('projects/{project}/stories', 'pages::stories.index')->name('stories.index');
+    Route::livewire('projects/{project}/stories/create', 'pages::stories.create')->name('stories.create');
+    Route::livewire('projects/{project}/runs', 'pages::runs.index')->name('runs.index');
+    Route::livewire('projects/{project}/repos', 'pages::repos.index')->name('repos.index');
     Route::livewire('stories/{story}', 'pages::stories.show')->name('stories.show');
-    Route::livewire('runs', 'pages::runs.index')->name('runs.index');
-    Route::livewire('repos', 'pages::repos.index')->name('repos.index');
 
     // Legacy URL redirects (ADR-0012). PR descriptions, Slack links, and
     // notification emails written against the old paths must continue to resolve.
     Route::permanentRedirect('inbox', 'triage');
     Route::permanentRedirect('events', 'activity');
+
+    // Project-scoped legacy redirects: resolve via the user's current project.
+    // If no current project is set, fall back to the project picker.
+    foreach (['stories' => 'stories.index', 'runs' => 'runs.index', 'repos' => 'repos.index'] as $legacy => $named) {
+        Route::get($legacy, function () use ($named) {
+            $projectId = auth()->user()->current_project_id;
+
+            return $projectId
+                ? redirect()->route($named, ['project' => $projectId], 301)
+                : redirect()->route('projects.index', [], 301);
+        });
+    }
+    Route::get('stories/create', function () {
+        $projectId = auth()->user()->current_project_id;
+
+        return $projectId
+            ? redirect()->route('stories.create', ['project' => $projectId], 301)
+            : redirect()->route('projects.index', [], 301);
+    });
 });
 
 require __DIR__.'/settings.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,9 @@
 
 use App\Http\Controllers\Auth\SocialiteController;
 use App\Http\Controllers\Webhooks\GithubWebhookController;
+use App\Models\AgentRun;
+use App\Models\Story;
+use App\Models\Subtask;
 use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'welcome')->name('home');
@@ -26,7 +29,34 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('projects/{project}/stories/create', 'pages::stories.create')->name('stories.create');
     Route::livewire('projects/{project}/runs', 'pages::runs.index')->name('runs.index');
     Route::livewire('projects/{project}/repos', 'pages::repos.index')->name('repos.index');
-    Route::livewire('stories/{story}', 'pages::stories.show')->name('stories.show');
+    Route::livewire('projects/{project}/stories/{story}', 'pages::stories.show')->name('stories.show');
+
+    // Legacy /stories/{story} → /projects/{p}/stories/{s} (resolve via story).
+    Route::get('stories/{story}', function (int $story) {
+        $s = Story::query()
+            ->whereHas('feature', fn ($q) => $q->whereIn('project_id', auth()->user()->accessibleProjectIds()))
+            ->find($story);
+        abort_unless($s, 404);
+
+        return redirect()->route('stories.show', ['project' => $s->feature->project_id, 'story' => $s->id], 301);
+    });
+
+    // Legacy /runs/{run} → canonical run console URL (Slice 3 lands the
+    // nested route; for now redirect to the parent Story document).
+    Route::get('runs/{run}', function (int $run) {
+        $r = AgentRun::query()->find($run);
+        abort_unless($r, 404);
+
+        $story = match ($r->runnable_type) {
+            Story::class => Story::find($r->runnable_id),
+            Subtask::class => Subtask::find($r->runnable_id)?->task?->story,
+            default => null,
+        };
+        abort_unless($story, 404);
+        abort_unless(in_array($story->feature->project_id, auth()->user()->accessibleProjectIds(), true), 404);
+
+        return redirect()->route('stories.show', ['project' => $story->feature->project_id, 'story' => $story->id], 301);
+    });
 
     // Legacy URL redirects (ADR-0012). PR descriptions, Slack links, and
     // notification emails written against the old paths must continue to resolve.

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,8 @@ Route::get('auth/{provider}/callback', [SocialiteController::class, 'callback'])
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('dashboard', 'pages::dashboard')->name('dashboard');
-    Route::livewire('inbox', 'pages::inbox')->name('inbox');
+    Route::livewire('triage', 'pages::triage')->name('triage');
+    Route::livewire('activity', 'pages::activity.index')->name('activity.index');
     Route::livewire('projects', 'pages::projects.index')->name('projects.index');
     Route::livewire('projects/{project}', 'pages::projects.show')->name('projects.show');
     Route::livewire('projects/{project}/features/{feature}', 'pages::features.show')->name('features.show');
@@ -25,8 +26,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('stories/create', 'pages::stories.create')->name('stories.create');
     Route::livewire('stories/{story}', 'pages::stories.show')->name('stories.show');
     Route::livewire('runs', 'pages::runs.index')->name('runs.index');
-    Route::livewire('events', 'pages::events.index')->name('events.index');
     Route::livewire('repos', 'pages::repos.index')->name('repos.index');
+
+    // Legacy URL redirects (ADR-0012). PR descriptions, Slack links, and
+    // notification emails written against the old paths must continue to resolve.
+    Route::permanentRedirect('inbox', 'triage');
+    Route::permanentRedirect('events', 'activity');
 });
 
 require __DIR__.'/settings.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('projects/{project}/runs', 'pages::runs.index')->name('runs.index');
     Route::livewire('projects/{project}/repos', 'pages::repos.index')->name('repos.index');
     Route::livewire('projects/{project}/stories/{story}', 'pages::stories.show')->name('stories.show');
+    Route::livewire('projects/{project}/stories/{story}/subtasks/{subtask}', 'pages::subtasks.show')->name('subtasks.show');
+    Route::livewire('projects/{project}/stories/{story}/subtasks/{subtask}/runs/{run}', 'pages::runs.show')->name('runs.show');
 
     // Legacy /stories/{story} → /projects/{p}/stories/{s} (resolve via story).
     Route::get('stories/{story}', function (int $story) {
@@ -41,21 +43,36 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return redirect()->route('stories.show', ['project' => $s->feature->project_id, 'story' => $s->id], 301);
     });
 
-    // Legacy /runs/{run} → canonical run console URL (Slice 3 lands the
-    // nested route; for now redirect to the parent Story document).
+    // Legacy /runs/{run} → canonical nested run console. Plan-generation
+    // runs (Story-runnable) have no Subtask parent and redirect to the
+    // Story document instead.
     Route::get('runs/{run}', function (int $run) {
         $r = AgentRun::query()->find($run);
         abort_unless($r, 404);
 
-        $story = match ($r->runnable_type) {
-            Story::class => Story::find($r->runnable_id),
-            Subtask::class => Subtask::find($r->runnable_id)?->task?->story,
-            default => null,
-        };
-        abort_unless($story, 404);
-        abort_unless(in_array($story->feature->project_id, auth()->user()->accessibleProjectIds(), true), 404);
+        if ($r->runnable_type === Story::class) {
+            $story = Story::find($r->runnable_id);
+            abort_unless($story, 404);
+            abort_unless(in_array($story->feature->project_id, auth()->user()->accessibleProjectIds(), true), 404);
 
-        return redirect()->route('stories.show', ['project' => $story->feature->project_id, 'story' => $story->id], 301);
+            return redirect()->route('stories.show', ['project' => $story->feature->project_id, 'story' => $story->id], 301);
+        }
+
+        if ($r->runnable_type === Subtask::class) {
+            $subtask = Subtask::with('task.story.feature')->find($r->runnable_id);
+            abort_unless($subtask?->task?->story, 404);
+            $story = $subtask->task->story;
+            abort_unless(in_array($story->feature->project_id, auth()->user()->accessibleProjectIds(), true), 404);
+
+            return redirect()->route('runs.show', [
+                'project' => $story->feature->project_id,
+                'story' => $story->id,
+                'subtask' => $subtask->id,
+                'run' => $r->id,
+            ], 301);
+        }
+
+        abort(404);
     });
 
     // Legacy URL redirects (ADR-0012). PR descriptions, Slack links, and

--- a/tests/Feature/IaRedirectsTest.php
+++ b/tests/Feature/IaRedirectsTest.php
@@ -1,6 +1,11 @@
 <?php
 
+use App\Models\AgentRun;
+use App\Models\Feature;
 use App\Models\Project;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Workspace;
@@ -80,4 +85,40 @@ test('legacy /stories falls back to projects index when no current project', fun
         ->get('/stories')
         ->assertStatus(301)
         ->assertRedirect('/projects');
+});
+
+test('/stories/{id} 301-redirects to project-scoped url', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+
+    $this->actingAs($user)
+        ->get('/stories/'.$story->id)
+        ->assertStatus(301)
+        ->assertRedirect("/projects/{$project->id}/stories/{$story->id}");
+});
+
+test('/runs/{id} 301-redirects to canonical story document', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get('/runs/'.$run->id)
+        ->assertStatus(301)
+        ->assertRedirect("/projects/{$project->id}/stories/{$story->id}");
 });

--- a/tests/Feature/IaRedirectsTest.php
+++ b/tests/Feature/IaRedirectsTest.php
@@ -102,7 +102,7 @@ test('/stories/{id} 301-redirects to project-scoped url', function () {
         ->assertRedirect("/projects/{$project->id}/stories/{$story->id}");
 });
 
-test('/runs/{id} 301-redirects to canonical story document', function () {
+test('/runs/{id} 301-redirects to nested run console for subtask runs', function () {
     $ws = Workspace::factory()->create();
     $team = Team::factory()->for($ws)->create();
     $user = User::factory()->create();
@@ -115,6 +115,25 @@ test('/runs/{id} 301-redirects to canonical story document', function () {
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get('/runs/'.$run->id)
+        ->assertStatus(301)
+        ->assertRedirect("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}");
+});
+
+test('/runs/{id} 301-redirects to story doc for plan-generation (Story-runnable) runs', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Story::class,
+        'runnable_id' => $story->id,
     ]);
 
     $this->actingAs($user)

--- a/tests/Feature/IaRedirectsTest.php
+++ b/tests/Feature/IaRedirectsTest.php
@@ -87,6 +87,25 @@ test('legacy /stories falls back to projects index when no current project', fun
         ->assertRedirect('/projects');
 });
 
+test('legacy /stories falls back to projects index when current_project_id is stale (no longer accessible)', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $accessible = Project::factory()->for($team)->create();
+
+    // A project the user cannot access — but the user has it pinned (stale).
+    $otherWs = Workspace::factory()->create();
+    $otherTeam = Team::factory()->for($otherWs)->create();
+    $stale = Project::factory()->for($otherTeam)->create();
+    $user->forceFill(['current_project_id' => $stale->id])->save();
+
+    $this->actingAs($user)
+        ->get('/stories')
+        ->assertStatus(301)
+        ->assertRedirect('/projects');
+});
+
 test('/stories/{id} 301-redirects to project-scoped url', function () {
     $ws = Workspace::factory()->create();
     $team = Team::factory()->for($ws)->create();

--- a/tests/Feature/IaRedirectsTest.php
+++ b/tests/Feature/IaRedirectsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('/inbox 301-redirects to /triage', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user)
+        ->get('/inbox')
+        ->assertStatus(301)
+        ->assertRedirect('/triage');
+});
+
+test('/events 301-redirects to /activity', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user)
+        ->get('/events')
+        ->assertStatus(301)
+        ->assertRedirect('/activity');
+});
+
+test('triage and activity routes resolve', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    expect(route('triage'))->toEndWith('/triage');
+    expect(route('activity.index'))->toEndWith('/activity');
+});

--- a/tests/Feature/IaRedirectsTest.php
+++ b/tests/Feature/IaRedirectsTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Project;
+use App\Models\Team;
 use App\Models\User;
+use App\Models\Workspace;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -27,4 +30,54 @@ test('triage and activity routes resolve', function () {
 
     expect(route('triage'))->toEndWith('/triage');
     expect(route('activity.index'))->toEndWith('/activity');
+});
+
+test('/stories 301-redirects to project-scoped url when current project is set', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $user->forceFill(['current_project_id' => $project->id])->save();
+
+    $this->actingAs($user)
+        ->get('/stories')
+        ->assertStatus(301)
+        ->assertRedirect("/projects/{$project->id}/stories");
+});
+
+test('/runs 301-redirects to project-scoped url when current project is set', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $user->forceFill(['current_project_id' => $project->id])->save();
+
+    $this->actingAs($user)
+        ->get('/runs')
+        ->assertStatus(301)
+        ->assertRedirect("/projects/{$project->id}/runs");
+});
+
+test('/repos 301-redirects to project-scoped url when current project is set', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $user->forceFill(['current_project_id' => $project->id])->save();
+
+    $this->actingAs($user)
+        ->get('/repos')
+        ->assertStatus(301)
+        ->assertRedirect("/projects/{$project->id}/repos");
+});
+
+test('legacy /stories falls back to projects index when no current project', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user)
+        ->get('/stories')
+        ->assertStatus(301)
+        ->assertRedirect('/projects');
 });

--- a/tests/Feature/ReposIndexTest.php
+++ b/tests/Feature/ReposIndexTest.php
@@ -30,14 +30,6 @@ afterEach(function () {
     Cache::flush();
 });
 
-test('shows the prompt to select a project when none is pinned', function () {
-    ['user' => $user] = repoScene(pin: false);
-    $this->actingAs($user);
-
-    Livewire::test('pages::repos.index')
-        ->assertSee('Select a project to manage its repositories.');
-});
-
 test('lists project repos with a no-webhook badge by default', function () {
     ['user' => $user, 'project' => $project, 'workspace' => $ws] = repoScene();
     $repo = Repo::factory()->for($ws)->create([
@@ -47,7 +39,7 @@ test('lists project repos with a no-webhook badge by default', function () {
     $project->attachRepo($repo);
     $this->actingAs($user);
 
-    Livewire::test('pages::repos.index')
+    Livewire::test('pages::repos.index', ['project' => $project->id])
         ->assertSee('backend')
         ->assertSee('no webhook');
 });
@@ -60,7 +52,7 @@ test('admin can mark a repo primary; setPrimary flips the pivot flag', function 
     $project->attachRepo($b);
     $this->actingAs($user);
 
-    Livewire::test('pages::repos.index')
+    Livewire::test('pages::repos.index', ['project' => $project->id])
         ->call('setPrimary', $b->id)
         ->assertHasNoErrors();
 
@@ -74,7 +66,7 @@ test('member cannot setPrimary', function () {
     $project->attachRepo($repo);
     $this->actingAs($user);
 
-    Livewire::test('pages::repos.index')
+    Livewire::test('pages::repos.index', ['project' => $project->id])
         ->call('setPrimary', $repo->id)
         ->assertStatus(403);
 });
@@ -88,7 +80,7 @@ test('remove detaches the project pivot AND deletes the workspace repo', functio
     $project->attachRepo($repo);
     $this->actingAs($user);
 
-    Livewire::test('pages::repos.index')
+    Livewire::test('pages::repos.index', ['project' => $project->id])
         ->call('remove', $repo->id)
         ->assertHasNoErrors();
 
@@ -102,7 +94,7 @@ test('member cannot remove a repo', function () {
     $project->attachRepo($repo);
     $this->actingAs($user);
 
-    Livewire::test('pages::repos.index')
+    Livewire::test('pages::repos.index', ['project' => $project->id])
         ->call('remove', $repo->id)
         ->assertStatus(403);
 
@@ -126,7 +118,7 @@ test('addGithubRepo creates a workspace repo and attaches it to the project', fu
         'api.github.com/repos/datashaman/specify/hooks*' => Http::response(['id' => 1], 201),
     ]);
 
-    Livewire::test('pages::repos.index')
+    Livewire::test('pages::repos.index', ['project' => $project->id])
         ->call('addGithubRepo', 'datashaman/specify')
         ->assertHasNoErrors();
 
@@ -137,10 +129,10 @@ test('addGithubRepo creates a workspace repo and attaches it to the project', fu
 });
 
 test('member cannot addGithubRepo', function () {
-    ['user' => $user] = repoScene(TeamRole::Member);
+    ['user' => $user, 'project' => $project] = repoScene(TeamRole::Member);
     $this->actingAs($user);
 
-    Livewire::test('pages::repos.index')
+    Livewire::test('pages::repos.index', ['project' => $project->id])
         ->call('addGithubRepo', 'datashaman/specify')
         ->assertStatus(403);
 

--- a/tests/Feature/RunHistoryTest.php
+++ b/tests/Feature/RunHistoryTest.php
@@ -32,11 +32,11 @@ function runScene(): array
 }
 
 test('runs page redirects unauthenticated users', function () {
-    $this->get(route('runs.index'))->assertRedirect(route('login'));
+    $this->get('/runs')->assertRedirect(route('login'));
 });
 
 test('lists runs scoped to the user\'s teams', function () {
-    ['user' => $user, 'task' => $task] = runScene();
+    ['user' => $user, 'task' => $task, 'project' => $project] = runScene();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'visible-sub']);
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -47,13 +47,13 @@ test('lists runs scoped to the user\'s teams', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::runs.index')
+    Livewire::test('pages::runs.index', ['project' => $project->id])
         ->assertSee('visible-sub')
         ->assertSee('https://github.com/o/r/pull/1');
 });
 
 test('does not show runs from outside the user\'s teams', function () {
-    ['user' => $user] = runScene();
+    ['user' => $user, 'project' => $project] = runScene();
 
     $other = Workspace::factory()->create();
     $otherTeam = Team::factory()->for($other)->create();
@@ -70,11 +70,11 @@ test('does not show runs from outside the user\'s teams', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::runs.index')->assertDontSee('hidden-sub');
+    Livewire::test('pages::runs.index', ['project' => $project->id])->assertDontSee('hidden-sub');
 });
 
 test('shows PR merged badge when webhook recorded a merge', function () {
-    ['user' => $user, 'task' => $task] = runScene();
+    ['user' => $user, 'task' => $task, 'project' => $project] = runScene();
     $sub = Subtask::factory()->for($task)->create(['name' => 'merged-sub']);
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -89,7 +89,7 @@ test('shows PR merged badge when webhook recorded a merge', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::runs.index')
+    Livewire::test('pages::runs.index', ['project' => $project->id])
         ->assertSee('merged-sub')
         ->assertSee('PR merged');
 });
@@ -112,13 +112,13 @@ test('shows repo name and tokens on the run card', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::runs.index')
+    Livewire::test('pages::runs.index', ['project' => $project->id])
         ->assertSee('backend')
         ->assertSee('1234/567 tok');
 });
 
 test('status filter narrows the list', function () {
-    ['user' => $user, 'task' => $task] = runScene();
+    ['user' => $user, 'task' => $task, 'project' => $project] = runScene();
     $a = Subtask::factory()->for($task)->create(['name' => 'sub-running']);
     $b = Subtask::factory()->for($task)->create(['name' => 'sub-failed']);
     AgentRun::factory()->create([
@@ -134,7 +134,7 @@ test('status filter narrows the list', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::runs.index')
+    Livewire::test('pages::runs.index', ['project' => $project->id])
         ->assertSee('sub-running')
         ->assertSee('sub-failed')
         ->set('status', 'failed')

--- a/tests/Feature/StoriesIndexTest.php
+++ b/tests/Feature/StoriesIndexTest.php
@@ -23,7 +23,7 @@ function storyIndexScene(): array
 }
 
 test('lists stories scoped to user teams', function () {
-    ['user' => $user, 'feature' => $feature] = storyIndexScene();
+    ['user' => $user, 'project' => $project, 'feature' => $feature] = storyIndexScene();
     Story::factory()->for($feature)->create(['name' => 'mine', 'status' => StoryStatus::Approved]);
 
     $other = Workspace::factory()->create();
@@ -34,19 +34,19 @@ test('lists stories scoped to user teams', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::stories.index')
+    Livewire::test('pages::stories.index', ['project' => $project->id])
         ->assertSee('mine')
         ->assertDontSee('theirs');
 });
 
 test('status filter narrows the list', function () {
-    ['user' => $user, 'feature' => $feature] = storyIndexScene();
+    ['user' => $user, 'project' => $project, 'feature' => $feature] = storyIndexScene();
     Story::factory()->for($feature)->create(['name' => 'draft-story', 'status' => StoryStatus::Draft]);
     Story::factory()->for($feature)->create(['name' => 'approved-story', 'status' => StoryStatus::Approved]);
 
     $this->actingAs($user);
 
-    Livewire::test('pages::stories.index')
+    Livewire::test('pages::stories.index', ['project' => $project->id])
         ->assertSee('draft-story')
         ->assertSee('approved-story')
         ->set('status', 'approved')
@@ -55,5 +55,5 @@ test('status filter narrows the list', function () {
 });
 
 test('redirects guests', function () {
-    $this->get(route('stories.index'))->assertRedirect(route('login'));
+    $this->get('/stories')->assertRedirect(route('login'));
 });

--- a/tests/Feature/StoryAuthoringTest.php
+++ b/tests/Feature/StoryAuthoringTest.php
@@ -29,11 +29,11 @@ function authorScene(): array
 }
 
 test('save draft creates a Story in Draft with acceptance criteria', function () {
-    ['user' => $user, 'feature' => $feature] = authorScene();
+    ['user' => $user, 'project' => $project, 'feature' => $feature] = authorScene();
 
     $this->actingAs($user);
 
-    Livewire::test('pages::stories.create')
+    Livewire::test('pages::stories.create', ['project' => $project->id])
         ->set('feature_id', $feature->id)
         ->set('name', 'Authored from UI')
         ->set('description', 'Reviewers can author new stories.')
@@ -57,7 +57,7 @@ test('save & submit transitions the story for approval', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::stories.create')
+    Livewire::test('pages::stories.create', ['project' => $project->id])
         ->set('feature_id', $feature->id)
         ->set('name', 'Submit me')
         ->set('description', 'desc')
@@ -69,7 +69,7 @@ test('save & submit transitions the story for approval', function () {
 });
 
 test('cannot save against a feature outside the user\'s teams', function () {
-    ['user' => $user] = authorScene();
+    ['user' => $user, 'project' => $project] = authorScene();
     $other = Workspace::factory()->create();
     $otherTeam = Team::factory()->for($other)->create();
     $otherProject = Project::factory()->for($otherTeam)->create();
@@ -77,7 +77,7 @@ test('cannot save against a feature outside the user\'s teams', function () {
 
     $this->actingAs($user);
 
-    expect(fn () => Livewire::test('pages::stories.create')
+    expect(fn () => Livewire::test('pages::stories.create', ['project' => $project->id])
         ->set('feature_id', $otherFeature->id)
         ->set('name', 'Sneak')
         ->set('description', 'no')
@@ -86,5 +86,5 @@ test('cannot save against a feature outside the user\'s teams', function () {
 });
 
 test('unauthenticated visitors are redirected', function () {
-    $this->get(route('stories.create'))->assertRedirect(route('login'));
+    $this->get('/stories/create')->assertRedirect(route('login'));
 });

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -1,0 +1,342 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Enums\ApprovalDecision;
+use App\Enums\StoryStatus;
+use App\Enums\TeamRole;
+use App\Models\AcceptanceCriterion;
+use App\Models\AgentRun;
+use App\Models\ApprovalPolicy;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\StoryApproval;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Livewire\Livewire;
+
+function showPageScene(array $opts = []): array
+{
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Owner);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create([
+        'name' => $opts['story_name'] ?? 'show-page-story',
+        'status' => $opts['status'] ?? StoryStatus::Draft,
+        'revision' => $opts['revision'] ?? 1,
+        'created_by_id' => $opts['author_id'] ?? $user->id,
+    ]);
+
+    return compact('ws', 'team', 'user', 'project', 'feature', 'story');
+}
+
+function attachPolicy(Workspace $ws, int $required, bool $allowSelf = false): ApprovalPolicy
+{
+    return ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_WORKSPACE,
+        'scope_id' => $ws->id,
+        'required_approvals' => $required,
+        'allow_self_approval' => $allowSelf,
+        'auto_approve' => false,
+    ]);
+}
+
+/**
+ * Force a Story into a target status without firing the revision-bump /
+ * ApprovalService::recompute chain. Use after creating ACs in tests, since
+ * AcceptanceCriterion::saved bumps revision and would otherwise revert
+ * Approved → PendingApproval when a threshold isn't met by approvals.
+ */
+function forceStoryStatus(Story $story, StoryStatus $status, ?int $revision = null): void
+{
+    Story::withoutEvents(function () use ($story, $status, $revision) {
+        $story->forceFill(array_filter([
+            'status' => $status->value,
+            'revision' => $revision,
+        ]))->save();
+    });
+}
+
+test('approved story renders rail=approved and tally pill 2/2', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 2);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-rail="approved"')
+        ->assertSeeHtml('data-pill="approved"')
+        ->assertSee('2/2');
+});
+
+test('pending story renders rail=pending and tally 1/2 reflects current approvals', function () {
+    $other = User::factory()->create();
+    $s = showPageScene(['status' => StoryStatus::PendingApproval, 'author_id' => $other->id]);
+    $s['team']->addMember($other, TeamRole::Member);
+    attachPolicy($s['ws'], required: 2);
+
+    StoryApproval::create([
+        'story_id' => $s['story']->id,
+        'approver_id' => $other->id,
+        'decision' => ApprovalDecision::Approve,
+        'story_revision' => 1,
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-rail="pending"')
+        ->assertSeeHtml('data-pill="pending"')
+        ->assertSee('1/2');
+});
+
+test('changes-requested story renders rail and pill without tally', function () {
+    $s = showPageScene(['status' => StoryStatus::ChangesRequested]);
+    attachPolicy($s['ws'], required: 2);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-rail="changes_requested"')
+        ->assertSeeHtml('data-pill="changes_requested"')
+        ->assertSee('Changes requested')
+        ->assertDontSee('1/2')
+        ->assertDontSee('2/2');
+});
+
+test('decision log right rail renders one row per StoryApproval for current revision', function () {
+    $alice = User::factory()->create(['name' => 'alice']);
+    $bob = User::factory()->create(['name' => 'bob']);
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    $s['team']->addMember($alice, TeamRole::Member);
+    $s['team']->addMember($bob, TeamRole::Member);
+    attachPolicy($s['ws'], required: 2);
+
+    StoryApproval::create([
+        'story_id' => $s['story']->id,
+        'approver_id' => $alice->id,
+        'decision' => ApprovalDecision::Approve,
+        'story_revision' => 1,
+    ]);
+    StoryApproval::create([
+        'story_id' => $s['story']->id,
+        'approver_id' => $bob->id,
+        'decision' => ApprovalDecision::Approve,
+        'story_revision' => 1,
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-section="decision-log"')
+        ->assertSeeInOrder(['alice', 'bob']);
+});
+
+test('author cannot approve own pending story when allow_self_approval=false', function () {
+    $s = showPageScene(['status' => StoryStatus::PendingApproval]);
+    attachPolicy($s['ws'], required: 1, allowSelf: false);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertDontSee('Approve')
+        ->assertSee('disallows self-approval');
+});
+
+test('author can approve own pending story when allow_self_approval=true', function () {
+    $s = showPageScene(['status' => StoryStatus::PendingApproval]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSee('Approve');
+});
+
+test('eligible-approvers section renders only when threshold > 1', function () {
+    $other = User::factory()->create(['name' => 'second-eligible']);
+    $s = showPageScene(['status' => StoryStatus::PendingApproval]);
+    $s['team']->addMember($other, TeamRole::Admin);
+    attachPolicy($s['ws'], required: 2);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-section="eligible-approvers"')
+        ->assertSee('second-eligible');
+});
+
+test('eligible-approvers section hidden when threshold = 1', function () {
+    $s = showPageScene(['status' => StoryStatus::PendingApproval]);
+    attachPolicy($s['ws'], required: 1);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertDontSeeHtml('data-section="eligible-approvers"');
+});
+
+test('plan section is AC-led: AC text leads, Task name follows', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1);
+
+    $ac = AcceptanceCriterion::create([
+        'story_id' => $s['story']->id,
+        'position' => 1,
+        'criterion' => 'AC-text-must-lead',
+    ]);
+    Task::factory()->for($s['story'])->create([
+        'name' => 'task-name-secondary',
+        'position' => 1,
+        'acceptance_criterion_id' => $ac->id,
+    ]);
+
+    $this->actingAs($s['user']);
+
+    $html = Livewire::test('pages::stories.show', ['story' => $s['story']->id])->html();
+    $acIdx = strpos($html, 'AC-text-must-lead');
+    $taskIdx = strpos($html, 'task-name-secondary');
+
+    expect($acIdx)->not->toBeFalse()
+        ->and($taskIdx)->not->toBeFalse()
+        ->and($acIdx)->toBeLessThan($taskIdx);
+});
+
+test('task missing acceptance_criterion_id renders under Unmapped tasks', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1);
+
+    Task::factory()->for($s['story'])->create([
+        'name' => 'orphan-task',
+        'position' => 1,
+        'acceptance_criterion_id' => null,
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-ac="unmapped"')
+        ->assertSee('orphan-task');
+});
+
+test('appended subtask renders provenance glyph and tooltip referencing originating run id', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1);
+
+    $ac = AcceptanceCriterion::create([
+        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'ac',
+    ]);
+    $task = Task::factory()->for($s['story'])->create([
+        'position' => 1,
+        'acceptance_criterion_id' => $ac->id,
+    ]);
+    $sourceSub = Subtask::factory()->for($task)->create(['name' => 'source-sub', 'position' => 1]);
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $sourceSub->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+    Subtask::factory()->for($task)->create([
+        'name' => 'appended-sub',
+        'position' => 2,
+        'proposed_by_run_id' => $run->id,
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-provenance')
+        ->assertSeeHtml('Appended by Run #'.$run->id);
+});
+
+test('reset-approval banner renders with delta when AC count changes during edit on Approved story', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft]);
+    attachPolicy($s['ws'], required: 1);
+
+    $original = AcceptanceCriterion::create([
+        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'original-ac',
+    ]);
+    forceStoryStatus($s['story'], StoryStatus::Approved);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('startEdit')
+        ->set('editCriteria', [
+            ['id' => $original->id, 'criterion' => 'original-ac'],
+            ['id' => null, 'criterion' => 'newly-added-ac'],
+        ])
+        ->assertSeeHtml('data-banner="reset-approval"')
+        ->assertSee('+1')
+        ->assertSee('Save & request re-approval');
+});
+
+test('reset-approval banner renders ~1 when an existing AC text is edited on Approved story', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft]);
+    attachPolicy($s['ws'], required: 1);
+
+    $original = AcceptanceCriterion::create([
+        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'original-ac',
+    ]);
+    forceStoryStatus($s['story'], StoryStatus::Approved);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('startEdit')
+        ->set('editCriteria', [
+            ['id' => $original->id, 'criterion' => 'edited-ac-text'],
+        ])
+        ->assertSeeHtml('data-banner="reset-approval"')
+        ->assertSee('~1')
+        ->assertSee('Save & request re-approval');
+});
+
+test('reset-approval banner does not render when nothing changes during edit', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft]);
+    attachPolicy($s['ws'], required: 1);
+
+    AcceptanceCriterion::create([
+        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'unchanged-ac',
+    ]);
+    forceStoryStatus($s['story'], StoryStatus::Approved);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('startEdit')
+        ->assertDontSeeHtml('data-banner="reset-approval"')
+        ->assertSee('Save')
+        ->assertDontSee('Save & request re-approval');
+});
+
+test('plan section renders with grooming/run toggle controls', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1);
+    AcceptanceCriterion::create([
+        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'has-an-ac',
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSeeHtml('data-toggle="plan-mode"')
+        ->assertSee('Grooming')
+        ->assertSee('Run');
+});
+
+test('plan toggle is hidden when story has no ACs and no unmapped tasks', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertDontSeeHtml('data-toggle="plan-mode"');
+});

--- a/tests/Feature/SubtaskAndRunShowTest.php
+++ b/tests/Feature/SubtaskAndRunShowTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Enums\TeamRole;
+use App\Models\AgentRun;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function subtaskScene(): array
+{
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Owner);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $task = Task::factory()->for($story)->create(['name' => 'parent-task', 'position' => 1]);
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'parent-subtask', 'position' => 1]);
+
+    return compact('user', 'project', 'feature', 'story', 'task', 'subtask');
+}
+
+test('subtask page renders breadcrumb and subtask details', function () {
+    $s = subtaskScene();
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::subtasks.show', [
+        'project' => $s['project']->id,
+        'story' => $s['story']->id,
+        'subtask' => $s['subtask']->id,
+    ])
+        ->assertSee('parent-subtask')
+        ->assertSee('parent-task')
+        ->assertSeeHtml('data-section="breadcrumb"')
+        ->assertSeeHtml('data-section="runs"');
+});
+
+test('subtask page shows race-mode badge when there are >1 runs', function () {
+    $s = subtaskScene();
+    AgentRun::factory()->for($s['subtask'], 'runnable')->create(['executor_driver' => 'specify', 'status' => AgentRunStatus::Succeeded]);
+    AgentRun::factory()->for($s['subtask'], 'runnable')->create(['executor_driver' => 'claude-code', 'status' => AgentRunStatus::Failed]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::subtasks.show', [
+        'project' => $s['project']->id,
+        'story' => $s['story']->id,
+        'subtask' => $s['subtask']->id,
+    ])
+        ->assertSee('Race · 2 drivers');
+});
+
+test('run console renders breadcrumb, status pill, and tab controls', function () {
+    $s = subtaskScene();
+    $run = AgentRun::factory()->for($s['subtask'], 'runnable')->create([
+        'status' => AgentRunStatus::Succeeded,
+        'executor_driver' => 'specify',
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::runs.show', [
+        'project' => $s['project']->id,
+        'story' => $s['story']->id,
+        'subtask' => $s['subtask']->id,
+        'run' => $run->id,
+    ])
+        ->assertSeeHtml('data-section="breadcrumb"')
+        ->assertSeeHtml('data-section="run-tabs"')
+        ->assertSee('Run #'.$run->id)
+        ->assertSee('Logs')
+        ->assertSee('Diff')
+        ->assertSee('Pull request');
+});
+
+test('run console 404s via HTTP when project URL doesnt match the runs project', function () {
+    $s = subtaskScene();
+    $run = AgentRun::factory()->for($s['subtask'], 'runnable')->create();
+    $otherProject = Project::factory()->for($s['user']->teams()->first())->create();
+
+    $this->actingAs($s['user'])
+        ->get("/projects/{$otherProject->id}/stories/{$s['story']->id}/subtasks/{$s['subtask']->id}/runs/{$run->id}")
+        ->assertNotFound();
+});

--- a/tests/Feature/TriageTest.php
+++ b/tests/Feature/TriageTest.php
@@ -49,7 +49,7 @@ function pendingStoryFor(Feature $feature, string $name = 'Visible story'): Stor
 }
 
 test('inbox redirects unauthenticated users', function () {
-    $this->get(route('inbox'))->assertRedirect(route('login'));
+    $this->get(route('triage'))->assertRedirect(route('login'));
 });
 
 test('inbox lists pending stories in scope', function () {
@@ -59,7 +59,7 @@ test('inbox lists pending stories in scope', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->assertSee('Visible story');
 });
 
@@ -74,7 +74,7 @@ test('inbox excludes items from teams the user does not belong to', function () 
 
     $this->actingAs($user);
 
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->assertDontSee('Hidden story');
 });
 
@@ -84,7 +84,7 @@ test('approving a story flips its status', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->call('decide', $story->id, 'approve');
 
     expect($story->fresh()->status)->toBe(StoryStatus::Approved);
@@ -96,7 +96,7 @@ test('Member sees only the no-permission notice (no buttons)', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->assertSee('Visible to member')
         ->assertSee('Your role does not permit')
         ->assertDontSee('Approve');
@@ -120,7 +120,7 @@ test('inbox shows approval count and approver names', function () {
     ]);
 
     $this->actingAs($user);
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->assertSee('1/2 approvals')
         ->assertSee('Alice');
 });
@@ -136,7 +136,7 @@ test('Revoke replaces Approve button after the user has approved', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->call('decide', $story->id, 'approve')
         ->assertSee('Revoke approval');
 });
@@ -147,9 +147,9 @@ test('Members can view the inbox but cannot approve', function () {
 
     $this->actingAs($user);
 
-    Livewire::test('pages::inbox')->assertSee('Visible to member');
+    Livewire::test('pages::triage')->assertSee('Visible to member');
 
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->call('decide', $story->id, 'approve')
         ->assertStatus(403);
 
@@ -166,7 +166,7 @@ test('pinning a project narrows the inbox to that project only', function () {
     $user->switchProject($projectA);
     $this->actingAs($user->fresh());
 
-    Livewire::test('pages::inbox')
+    Livewire::test('pages::triage')
         ->assertSee('in-A')
         ->assertDontSee('in-B');
 });
@@ -182,6 +182,6 @@ test('deciding on an out-of-scope item 404s', function () {
 
     $this->actingAs($user);
 
-    expect(fn () => Livewire::test('pages::inbox')->call('decide', $otherStory->id, 'approve'))
+    expect(fn () => Livewire::test('pages::triage')->call('decide', $otherStory->id, 'approve'))
         ->toThrow(ModelNotFoundException::class);
 });


### PR DESCRIPTION
## Summary

Two coherent landings stacked on this branch:

1. **Story document visual redesign** (`ba9b0bd`) — AC-led plan, left-edge state rail, state pill with approval tally, right-rail decision panel + decision log + eligible approvers, run console with collapsible monospace error blocks.
2. **ADR-0012: project-first information architecture** — sidebar split into Workspace (Triage, Activity) and Project (Overview, Features, Stories, Runs, Repos) sections; every record-type listing scoped to `/projects/{p}/...`; Story document at `/projects/{p}/stories/{s}` with full breadcrumb; new Subtask drawer at `/projects/{p}/stories/{s}/subtasks/{st}`; new nested Run console at `/projects/{p}/stories/{s}/subtasks/{st}/runs/{r}`; Feature page gets the Story chrome with rolled-up state rail and per-status tally chips.

Every legacy URL 301-redirects to the canonical nested form so PR descriptions, Slack links, and notification emails written against the old paths continue to resolve. ADR-0012 is the load-bearing reference for the four-slice migration; it ships Accepted alongside the implementation.

Three Proposed ADRs (0009 snapshots, 0010 cancel/retry, 0011 streaming events) are also included — they were drafted in the same design grilling and remain Proposed; their implementations are follow-ups.

## What's in scope

- `docs/adr/0009-0012` — 4 ADRs (0012 Accepted, 0009/0010/0011 Proposed)
- `CONTEXT.md` — domain glossary captured in the grilling session
- `docs/proposals/ui-design-brief.md` — reconciled brief that drove the redesign
- `routes/web.php` — every project-scoped route + every legacy redirect
- New Volt pages: `pages/triage.blade.php`, `pages/activity/⚡index.blade.php`, `pages/subtasks/⚡show.blade.php`, `pages/runs/⚡show.blade.php`
- New Blade components: `<x-rail>`, `<x-state-pill>`, `<x-decision-row>`, `partials/story-task.blade.php`
- Sidebar layout rebuilt around the two-section IA
- Tests: `StoryShowPageTest`, `IaRedirectsTest`, `SubtaskAndRunShowTest`, plus updates to `TriageTest` (renamed), `StoriesIndexTest`, `RunHistoryTest`, `ReposIndexTest`, `StoryAuthoringTest` to pass `project` to scoped pages.

## Verification

- Full suite: 291/291 green, Pint clean (`composer test`)
- Visual smoke: completed across Pending / Approved / Done / Run-mode / Edit / Subtask drawer / Run console pages on the local dev environment

## Test plan

- [ ] Visit `/triage` — sidebar matches the new shape; Triage queue renders
- [ ] Visit `/inbox` — 301 to `/triage`
- [ ] Visit `/events` — 301 to `/activity`
- [ ] Visit `/stories/{any-id}` — 301 to `/projects/{p}/stories/{s}`
- [ ] Visit `/runs/{any-id}` — 301 to nested run console (or Story doc for plan-gen runs)
- [ ] Visit a Story; click a subtask name → drawer opens; click a run badge → run console opens
- [ ] Switch projects via the dropdown; sidebar Stories/Runs/Repos links update; current project sticks across navigations
- [ ] Edit a Story, add an AC, banner shows `+1 AC, ~0 edited, -0 removed` with "Save & request re-approval"

🤖 Generated with [Claude Code](https://claude.com/claude-code)