### PR TITLE
feat(adr-0010): cancel + retry semantics for AgentRuns

### DIFF
--- a/app/Enums/AgentRunStatus.php
+++ b/app/Enums/AgentRunStatus.php
@@ -5,7 +5,8 @@ namespace App\Enums;
 /**
  * Status of an AgentRun (a single dispatched plan-generation or task-execution job).
  *
- * Append-only on the AgentRun row; failures move to Failed, manual cancels to Aborted.
+ * Append-only on the AgentRun row. Cancelled = cooperative user-requested stop
+ * between pipeline phases (ADR-0010); Aborted = operator force-aborted a stuck run.
  */
 enum AgentRunStatus: string
 {
@@ -14,4 +15,21 @@ enum AgentRunStatus: string
     case Succeeded = 'succeeded';
     case Failed = 'failed';
     case Aborted = 'aborted';
+    case Cancelled = 'cancelled';
+
+    public function isTerminal(): bool
+    {
+        return match ($this) {
+            self::Succeeded, self::Failed, self::Aborted, self::Cancelled => true,
+            default => false,
+        };
+    }
+
+    public function isFailure(): bool
+    {
+        return match ($this) {
+            self::Failed, self::Aborted, self::Cancelled => true,
+            default => false,
+        };
+    }
 }

--- a/app/Jobs/ExecuteSubtaskJob.php
+++ b/app/Jobs/ExecuteSubtaskJob.php
@@ -36,6 +36,13 @@ class ExecuteSubtaskJob implements ShouldQueue
     {
         $run = AgentRun::findOrFail($this->agentRunId);
 
+        // ADR-0010: a Queued run can be cancelled before the worker picks
+        // it up; respect the terminal state instead of overwriting it via
+        // markRunning. Append-only invariant means terminal stays terminal.
+        if ($run->isTerminal()) {
+            return;
+        }
+
         if (! $run->runnable instanceof Subtask) {
             $execution->markFailed($run, 'Subtask for AgentRun not found.');
 
@@ -67,6 +74,7 @@ class ExecuteSubtaskJob implements ShouldQueue
             SubtaskRunOutcome::STATE_PULL_REQUEST_FAILED,
             SubtaskRunOutcome::STATE_ALREADY_COMPLETE => $execution->markSucceeded($run, $outcome->output, $outcome->diff),
             SubtaskRunOutcome::STATE_NO_DIFF => $execution->markFailed($run, $outcome->error ?? 'Subtask run failed.'),
+            SubtaskRunOutcome::STATE_CANCELLED => $execution->markCancelled($run, $outcome->error),
         };
 
         if ($outcome->isSucceeded()) {

--- a/app/Jobs/ExecuteSubtaskJob.php
+++ b/app/Jobs/ExecuteSubtaskJob.php
@@ -49,7 +49,13 @@ class ExecuteSubtaskJob implements ShouldQueue
             return;
         }
 
-        $execution->markRunning($run);
+        // markRunning is conditional on persisted status === Queued; if the
+        // row was Cancelled between findOrFail and here, the UPDATE matches
+        // zero rows and we abort the job entirely (closes the queued-cancel
+        // race — ADR-0010).
+        if (! $execution->markRunning($run)) {
+            return;
+        }
 
         $driver = $run->executor_driver ?? $executors->defaultDriver();
 

--- a/app/Jobs/OpenPullRequestJob.php
+++ b/app/Jobs/OpenPullRequestJob.php
@@ -65,7 +65,31 @@ class OpenPullRequestJob implements ShouldQueue
         }
 
         try {
-            $existing = $provider->findOpenPullRequest($repo, $branch);
+            // Re-check inside the lock: a concurrent retry job may have
+            // stamped the URL while we were queued / waiting for the lock.
+            // Without this, two retries can both fall through to create()
+            // on providers whose findOpenPullRequest() returns null
+            // (Bitbucket / GitLab) — opening duplicate MRs.
+            $run = $run->fresh() ?? $run;
+            if (! empty(((array) $run->output)['pull_request_url'] ?? null)) {
+                Log::info('specify.subtask.pr_retry.already_open', [
+                    'run_id' => $run->getKey(),
+                ]);
+
+                return;
+            }
+
+            try {
+                $existing = $provider->findOpenPullRequest($repo, $branch);
+            } catch (Throwable $e) {
+                // findOpenPullRequest is best-effort: a malformed repo URL
+                // or transient API error should be recorded as a normal
+                // pr_retry failure, not crash the queue worker.
+                $this->recordError($run, $e->getMessage());
+
+                return;
+            }
+
             if ($existing !== null && ($existing['url'] ?? '') !== '') {
                 $this->stampSuccess($run, $existing);
 

--- a/app/Jobs/OpenPullRequestJob.php
+++ b/app/Jobs/OpenPullRequestJob.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use App\Services\PullRequests\PrPayloadBuilder;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * ADR-0010 Phase C: re-attempt PR-open for a Succeeded AgentRun whose
+ * `pull_request_error` is set and `pull_request_url` is empty (ADR-0004:
+ * PR-after-push is non-fatal, so the run is Succeeded but PR-less).
+ *
+ * Idempotent: if `findOpenPullRequest` returns a hit for the run's branch,
+ * adopt that PR's URL rather than open a duplicate. Concurrent retries on
+ * the same AgentRun are serialised via a `Cache::lock` keyed by run id.
+ *
+ * The AgentRun's terminal status is preserved — only `output.pull_request_url`
+ * and `output.pull_request_error` change.
+ */
+class OpenPullRequestJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public int $agentRunId) {}
+
+    public function handle(): void
+    {
+        $run = AgentRun::find($this->agentRunId);
+        if ($run === null) {
+            return;
+        }
+
+        $repo = $run->repo;
+        $branch = $run->working_branch;
+        if ($repo === null || $branch === null || $branch === '') {
+            $this->recordError($run, 'Run has no repo or working_branch; cannot open PR.');
+
+            return;
+        }
+
+        if (! $run->runnable instanceof Subtask) {
+            $this->recordError($run, 'Run is not a subtask run; cannot open PR.');
+
+            return;
+        }
+
+        $provider = $repo->pullRequestProvider();
+        if ($provider === null) {
+            $this->recordError($run, 'Repo provider does not support pull requests.');
+
+            return;
+        }
+
+        $lock = Cache::lock('agent_run.pr_open.'.$run->getKey(), 60);
+        if (! $lock->get()) {
+            Log::info('specify.subtask.pr_retry.locked', ['run_id' => $run->getKey()]);
+
+            return;
+        }
+
+        try {
+            $existing = $provider->findOpenPullRequest($repo, $branch);
+            if ($existing !== null && ($existing['url'] ?? '') !== '') {
+                $this->stampSuccess($run, $existing);
+
+                return;
+            }
+
+            $subtask = $run->runnable;
+            $output = (array) $run->output;
+
+            try {
+                $pr = $provider->createPullRequest(
+                    repo: $repo,
+                    head: $branch,
+                    base: $repo->default_branch,
+                    title: PrPayloadBuilder::title($subtask, $run->executor_driver),
+                    body: PrPayloadBuilder::body($subtask, $output),
+                );
+                $this->stampSuccess($run, $pr);
+            } catch (Throwable $e) {
+                $this->recordError($run, $e->getMessage());
+            }
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * @param  array{url: string, number: int|string, id: int|string}  $pr
+     */
+    private function stampSuccess(AgentRun $run, array $pr): void
+    {
+        $output = (array) $run->output;
+        $output['pull_request_url'] = $pr['url'];
+        $output['pull_request_number'] = $pr['number'];
+        unset($output['pull_request_error']);
+        $run->forceFill(['output' => $output])->save();
+
+        Log::info('specify.subtask.pr_retry.opened', [
+            'run_id' => $run->getKey(),
+            'url' => $pr['url'],
+        ]);
+    }
+
+    private function recordError(AgentRun $run, string $message): void
+    {
+        $output = (array) $run->output;
+        $output['pull_request_error'] = $message;
+        $run->forceFill(['output' => $output])->save();
+
+        Log::warning('specify.subtask.pr_retry.failed', [
+            'run_id' => $run->getKey(),
+            'error' => $message,
+        ]);
+    }
+}

--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -33,6 +33,7 @@ use RuntimeException;
     'input', 'output', 'diff', 'error_message',
     'tokens_input', 'tokens_output',
     'started_at', 'finished_at',
+    'cancel_requested', 'retry_of_id',
 ])]
 class AgentRun extends Model
 {
@@ -55,6 +56,7 @@ class AgentRun extends Model
             'tokens_output' => 'integer',
             'started_at' => 'datetime',
             'finished_at' => 'datetime',
+            'cancel_requested' => 'boolean',
         ];
     }
 
@@ -75,10 +77,11 @@ class AgentRun extends Model
 
     public function isTerminal(): bool
     {
-        return in_array($this->status, [
-            AgentRunStatus::Succeeded,
-            AgentRunStatus::Failed,
-            AgentRunStatus::Aborted,
-        ], true);
+        return $this->status->isTerminal();
+    }
+
+    public function retryOf(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'retry_of_id');
     }
 }

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -291,6 +291,71 @@ class ExecutionService
     }
 
     /**
+     * Mark an AgentRun Cancelled — cooperative cancel observed at a pipeline
+     * phase boundary (ADR-0010). Failure-class for cascade purposes; siblings
+     * count as losers.
+     */
+    public function markCancelled(AgentRun $run, ?string $reason = null): void
+    {
+        $run->forceFill([
+            'status' => AgentRunStatus::Cancelled->value,
+            'error_message' => $reason ?? 'Cancelled by user.',
+            'finished_at' => now(),
+        ])->save();
+
+        if ($run->runnable_type === Subtask::class) {
+            $this->finalizeSubtaskFromRun($run);
+        }
+    }
+
+    /**
+     * Request cooperative cancellation of an AgentRun (ADR-0010).
+     *
+     * Queued runs short-circuit straight to Cancelled (the job hasn't
+     * started, so there's nothing to cooperate with). Running runs have the
+     * `cancel_requested` flag set; the pipeline's poll points observe it
+     * between phases and transition to Cancelled. Terminal runs are no-ops.
+     *
+     * Returns true if anything changed.
+     */
+    public function cancelRun(AgentRun $run, ?string $reason = null): bool
+    {
+        if ($run->isTerminal()) {
+            return false;
+        }
+
+        if ($run->status === AgentRunStatus::Queued) {
+            $this->markCancelled($run, $reason);
+
+            return true;
+        }
+
+        $run->forceFill(['cancel_requested' => true])->save();
+
+        return true;
+    }
+
+    /**
+     * Convenience: cancel every still-open AgentRun for a Subtask. Useful for
+     * race mode where one button cancels all sibling drivers (ADR-0010).
+     *
+     * @return int Number of runs whose state changed.
+     */
+    public function cancelSubtask(Subtask $subtask, ?string $reason = null): int
+    {
+        $changed = 0;
+        foreach ($subtask->agentRuns()
+            ->whereIn('status', [AgentRunStatus::Queued->value, AgentRunStatus::Running->value])
+            ->get() as $run) {
+            if ($this->cancelRun($run, $reason)) {
+                $changed++;
+            }
+        }
+
+        return $changed;
+    }
+
+    /**
      * Cascade gate. Called whenever a Subtask AgentRun reaches a terminal
      * state. Defers if any sibling on the same Subtask is still Queued or
      * Running. Once all siblings have terminated:

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Enums\AgentRunKind;
 use App\Enums\AgentRunStatus;
+use App\Enums\ApprovalDecision;
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Jobs\ExecuteSubtaskJob;
@@ -142,7 +143,7 @@ class ExecutionService
         });
     }
 
-    private function createAndDispatchRun(Subtask $subtask, ?StoryApproval $approval, ?Repo $repo, string $driver, ?string $branchSuffix): AgentRun
+    private function createAndDispatchRun(Subtask $subtask, ?StoryApproval $approval, ?Repo $repo, string $driver, ?string $branchSuffix, ?int $retryOfId = null): AgentRun
     {
         $run = AgentRun::create([
             'runnable_type' => $subtask->getMorphClass(),
@@ -153,6 +154,7 @@ class ExecutionService
             'authorizing_approval_type' => $approval?->getMorphClass(),
             'authorizing_approval_id' => $approval?->getKey(),
             'status' => AgentRunStatus::Queued,
+            'retry_of_id' => $retryOfId,
         ]);
 
         ExecuteSubtaskJob::dispatch($run->getKey());
@@ -333,6 +335,58 @@ class ExecutionService
         $run->forceFill(['cancel_requested' => true])->save();
 
         return true;
+    }
+
+    /**
+     * Retry a Subtask Execute run by dispatching a fresh sibling AgentRun
+     * that points at the prior run via `retry_of_id` (ADR-0010).
+     *
+     * Authorization re-resolves through the current StoryApproval — if the
+     * Story has been edited since (revision bumped → approval reset), the
+     * retry binds to the current approving approval. Throws when the Story
+     * is not Approved (revoked / changes-requested / superseded).
+     *
+     * Race mode: this retries one driver. The driver defaults to the prior
+     * run's `executor_driver` so a single-sibling retry is just "do that
+     * one again". Pass `$driver` to override.
+     */
+    public function retrySubtaskExecution(Subtask $subtask, AgentRun $fromRun, ?string $driver = null): AgentRun
+    {
+        if ($fromRun->runnable_type !== Subtask::class || (int) $fromRun->runnable_id !== (int) $subtask->getKey()) {
+            throw new RuntimeException('Run does not belong to this subtask.');
+        }
+        if ($fromRun->kind === AgentRunKind::RespondToReview) {
+            throw new RuntimeException('Review-response runs are not retryable; new review events re-fire automatically.');
+        }
+        if (! $fromRun->isTerminal()) {
+            throw new RuntimeException('Cannot retry a run that is still in flight.');
+        }
+
+        $story = $subtask->task?->story;
+        if (! $story || $story->status !== StoryStatus::Approved) {
+            throw new RuntimeException('Story is not Approved; retry is gated on a current approval.');
+        }
+
+        $approval = StoryApproval::query()
+            ->where('story_id', $story->getKey())
+            ->where('story_revision', $story->revision ?? 1)
+            ->where('decision', ApprovalDecision::Approve->value)
+            ->latest('created_at')
+            ->first();
+
+        $repo = $fromRun->repo ?? $story->feature?->project?->primaryRepo();
+        $resolvedDriver = $driver ?? $fromRun->executor_driver ?? $this->executors->defaultDriver();
+        $race = $this->executors->raceDrivers();
+        $branchSuffix = in_array($resolvedDriver, $race, true) ? $resolvedDriver : null;
+
+        return $this->createAndDispatchRun(
+            $subtask,
+            $approval,
+            $repo,
+            $resolvedDriver,
+            $branchSuffix,
+            $fromRun->getKey(),
+        );
     }
 
     /**

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -9,6 +9,7 @@ use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Jobs\ExecuteSubtaskJob;
 use App\Jobs\GenerateTasksJob;
+use App\Jobs\OpenPullRequestJob;
 use App\Jobs\RespondToPrReviewJob;
 use App\Models\AgentRun;
 use App\Models\Repo;

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -234,13 +234,34 @@ class ExecutionService
             ->values();
     }
 
-    /** Transition an AgentRun to Running and stamp `started_at`. */
-    public function markRunning(AgentRun $run): void
+    /**
+     * Transition an AgentRun to Running and stamp `started_at`.
+     *
+     * Conditional on the persisted status still being Queued — closes the
+     * queued-cancel race (ADR-0010): if `cancelRun()` flipped the row to
+     * Cancelled between the worker's `findOrFail` and this call, the
+     * UPDATE matches zero rows and we return false so the caller bails.
+     */
+    public function markRunning(AgentRun $run): bool
     {
+        $affected = AgentRun::query()
+            ->whereKey($run->getKey())
+            ->where('status', AgentRunStatus::Queued->value)
+            ->update([
+                'status' => AgentRunStatus::Running->value,
+                'started_at' => now(),
+            ]);
+
+        if ($affected === 0) {
+            return false;
+        }
+
         $run->forceFill([
             'status' => AgentRunStatus::Running->value,
             'started_at' => now(),
-        ])->save();
+        ])->syncOriginal();
+
+        return true;
     }
 
     /**
@@ -327,13 +348,18 @@ class ExecutionService
             return false;
         }
 
+        // Set the audit flag in both branches: a Queued run that flips
+        // straight to Cancelled still records *that the cancel was
+        // requested*, matching ADR-0010's "cancel_requested is part of the
+        // audit trail" claim. Without this, a Queued cancel would leave a
+        // Cancelled run with cancel_requested=false and reviewers couldn't
+        // tell whether the run terminated cooperatively or because the
+        // worker never picked it up.
+        $run->forceFill(['cancel_requested' => true])->save();
+
         if ($run->status === AgentRunStatus::Queued) {
             $this->markCancelled($run, $reason);
-
-            return true;
         }
-
-        $run->forceFill(['cancel_requested' => true])->save();
 
         return true;
     }
@@ -361,6 +387,13 @@ class ExecutionService
         }
         if (! $fromRun->isTerminal()) {
             throw new RuntimeException('Cannot retry a run that is still in flight.');
+        }
+        // Service-level invariant: only failure-class runs can be retried.
+        // The UI hides Retry on Succeeded runs already, but a non-UI
+        // caller (MCP tool, internal automation) without this guard could
+        // re-dispatch an already-successful Subtask and double-open PRs.
+        if (! $fromRun->status->isFailure()) {
+            throw new RuntimeException('Only failed / cancelled / aborted runs can be retried.');
         }
 
         $story = $subtask->task?->story;

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -390,6 +390,28 @@ class ExecutionService
     }
 
     /**
+     * Retry the PR-open step for a Succeeded run whose previous open()
+     * attempt failed (ADR-0004 — non-fatal — so the run is Succeeded but
+     * `pull_request_error` is set and `pull_request_url` is empty).
+     *
+     * The AgentRun's terminal status is preserved; only its output is
+     * updated. See OpenPullRequestJob for idempotency + locking semantics
+     * (ADR-0010).
+     */
+    public function retryPullRequestOpen(AgentRun $run): void
+    {
+        if ($run->status !== AgentRunStatus::Succeeded) {
+            throw new RuntimeException('PR retry only applies to Succeeded runs.');
+        }
+        $output = (array) $run->output;
+        if (! empty($output['pull_request_url'])) {
+            throw new RuntimeException('Run already has a pull_request_url; nothing to retry.');
+        }
+
+        OpenPullRequestJob::dispatch($run->getKey());
+    }
+
+    /**
      * Convenience: cancel every still-open AgentRun for a Subtask. Useful for
      * race mode where one button cancels all sibling drivers (ADR-0010).
      *

--- a/app/Services/PullRequests/BitbucketPullRequestProvider.php
+++ b/app/Services/PullRequests/BitbucketPullRequestProvider.php
@@ -47,6 +47,11 @@ class BitbucketPullRequestProvider implements PullRequestProvider
         ];
     }
 
+    public function findOpenPullRequest(Repo $repo, string $head): ?array
+    {
+        return null;
+    }
+
     /**
      * @return array{0: string, 1: string}
      */

--- a/app/Services/PullRequests/GithubPullRequestProvider.php
+++ b/app/Services/PullRequests/GithubPullRequestProvider.php
@@ -50,6 +50,43 @@ class GithubPullRequestProvider implements PullRequestProvider
         ];
     }
 
+    public function findOpenPullRequest(Repo $repo, string $head): ?array
+    {
+        if ($repo->access_token === null || $repo->access_token === '') {
+            return null;
+        }
+
+        [$owner, $name] = $this->parseOwnerRepo($repo->url);
+        $apiBase = rtrim((string) config('specify.github.api_base', 'https://api.github.com'), '/');
+
+        $response = Http::withHeaders([
+            'Accept' => 'application/vnd.github+json',
+            'Authorization' => 'Bearer '.$repo->access_token,
+            'X-GitHub-Api-Version' => '2022-11-28',
+        ])->get("{$apiBase}/repos/{$owner}/{$name}/pulls", [
+            'head' => $owner.':'.$head,
+            'state' => 'open',
+            'per_page' => 1,
+        ]);
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        $data = $response->json();
+        if (! is_array($data) || $data === []) {
+            return null;
+        }
+
+        $pr = $data[0];
+
+        return [
+            'url' => (string) ($pr['html_url'] ?? ''),
+            'number' => $pr['number'] ?? 0,
+            'id' => $pr['id'] ?? 0,
+        ];
+    }
+
     /**
      * @return array{0: string, 1: string}
      */

--- a/app/Services/PullRequests/GitlabPullRequestProvider.php
+++ b/app/Services/PullRequests/GitlabPullRequestProvider.php
@@ -49,6 +49,11 @@ class GitlabPullRequestProvider implements PullRequestProvider
         ];
     }
 
+    public function findOpenPullRequest(Repo $repo, string $head): ?array
+    {
+        return null;
+    }
+
     private function parseProjectPath(string $url): string
     {
         $url = preg_replace('/\.git$/', '', $url);

--- a/app/Services/PullRequests/PullRequestProvider.php
+++ b/app/Services/PullRequests/PullRequestProvider.php
@@ -19,4 +19,19 @@ interface PullRequestProvider
      * @return array{url: string, number: int|string, id: int|string}
      */
     public function createPullRequest(Repo $repo, string $head, string $base, string $title, ?string $body = null): array;
+
+    /**
+     * Locate an *open* pull / merge request on `$repo` whose source branch is
+     * `$head`. Used by `ExecutionService::retryPullRequestOpen` (ADR-0010) to
+     * make PR retry idempotent — if a previous open call actually succeeded
+     * on the upstream side and only the response was lost, adopt the
+     * existing PR rather than open a duplicate.
+     *
+     * Implementations that don't support lookup return null; the retry then
+     * falls back to attempting create and surfacing the duplicate-PR error
+     * (ADR-0004 — non-fatal).
+     *
+     * @return array{url: string, number: int|string, id: int|string}|null
+     */
+    public function findOpenPullRequest(Repo $repo, string $head): ?array;
 }

--- a/app/Services/SubtaskRunOutcome.php
+++ b/app/Services/SubtaskRunOutcome.php
@@ -26,6 +26,8 @@ class SubtaskRunOutcome
 
     public const STATE_ALREADY_COMPLETE = 'already_complete';
 
+    public const STATE_CANCELLED = 'cancelled';
+
     /**
      * @param  array<string, mixed>  $output
      */
@@ -73,6 +75,15 @@ class SubtaskRunOutcome
     public static function alreadyComplete(array $output): self
     {
         return new self(self::STATE_ALREADY_COMPLETE, $output, null, null);
+    }
+
+    /**
+     * Cooperative cancel observed at a pipeline phase boundary (ADR-0010).
+     * Failure-class — the cascade treats it as Blocked.
+     */
+    public static function cancelled(string $reason = 'Cancelled by user.'): self
+    {
+        return new self(self::STATE_CANCELLED, [], null, $reason);
     }
 
     /**

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -58,6 +58,10 @@ class SubtaskRunPipeline
             'executor_driver' => $agentRun->executor_driver,
         ]);
 
+        if ($this->cancelObserved($agentRun, 'before_prepare', $logCtx)) {
+            return SubtaskRunOutcome::cancelled();
+        }
+
         $repo = $agentRun->repo;
         $workingDir = null;
 
@@ -70,6 +74,10 @@ class SubtaskRunPipeline
             $workingDir = $this->workspace->prepare($repo, $agentRun);
             $this->workspace->checkoutBranch($workingDir, $branch, baseBranch: $repo->default_branch);
             Log::info('specify.subtask.workspace.ready', $logCtx + ['working_dir' => $workingDir]);
+        }
+
+        if ($this->cancelObserved($agentRun, 'before_execute', $logCtx)) {
+            return SubtaskRunOutcome::cancelled();
         }
 
         $contextBrief = $this->contextBuilder->build($subtask, $workingDir, $repo);
@@ -87,6 +95,11 @@ class SubtaskRunPipeline
         }
 
         $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null);
+
+        if ($this->cancelObserved($agentRun, 'after_execute', $logCtx)) {
+            return SubtaskRunOutcome::cancelled();
+        }
+
         $output = $result->toArray();
         if ($contextBrief !== '') {
             $output['context_brief'] = $contextBrief;
@@ -156,6 +169,10 @@ class SubtaskRunPipeline
         $output = $this->applyProposedSubtasks($subtask, $result->proposedSubtasks, $agentRun, $output, $logCtx);
 
         if (config('specify.workspace.push_after_commit', true)) {
+            if ($this->cancelObserved($agentRun, 'before_push', $logCtx)) {
+                return SubtaskRunOutcome::cancelled();
+            }
+
             $branch = $this->branchFor($agentRun);
             $this->workspace->push($workingDir, $branch);
             $output['pushed'] = true;
@@ -218,6 +235,24 @@ class SubtaskRunPipeline
     private function branchFor(AgentRun $agentRun): string
     {
         return $agentRun->working_branch ?? 'specify/run-'.$agentRun->getKey();
+    }
+
+    /**
+     * Re-fetch `cancel_requested` from the DB and log when observed (ADR-0010).
+     * Re-read because the in-memory model is stale relative to a sibling
+     * cancel-request transaction issued while this pipeline was mid-flight.
+     */
+    private function cancelObserved(AgentRun $agentRun, string $phase, array $logCtx): bool
+    {
+        $requested = (bool) AgentRun::query()
+            ->whereKey($agentRun->getKey())
+            ->value('cancel_requested');
+
+        if ($requested) {
+            Log::info('specify.subtask.cancel_observed', $logCtx + ['phase' => $phase]);
+        }
+
+        return $requested;
     }
 
     /**

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -77,6 +77,8 @@ class SubtaskRunPipeline
         }
 
         if ($this->cancelObserved($agentRun, 'before_execute', $logCtx)) {
+            $this->discardLocalChangesIfPossible($workingDir, $agentRun, $repo, $logCtx);
+
             return SubtaskRunOutcome::cancelled();
         }
 
@@ -97,6 +99,8 @@ class SubtaskRunPipeline
         $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null);
 
         if ($this->cancelObserved($agentRun, 'after_execute', $logCtx)) {
+            $this->discardLocalChangesIfPossible($workingDir, $agentRun, $repo, $logCtx);
+
             return SubtaskRunOutcome::cancelled();
         }
 
@@ -170,6 +174,8 @@ class SubtaskRunPipeline
 
         if (config('specify.workspace.push_after_commit', true)) {
             if ($this->cancelObserved($agentRun, 'before_push', $logCtx)) {
+                $this->discardLocalChangesIfPossible($workingDir, $agentRun, $repo, $logCtx);
+
                 return SubtaskRunOutcome::cancelled();
             }
 
@@ -235,6 +241,33 @@ class SubtaskRunPipeline
     private function branchFor(AgentRun $agentRun): string
     {
         return $agentRun->working_branch ?? 'specify/run-'.$agentRun->getKey();
+    }
+
+    /**
+     * Reset the working branch on cooperative cancel so a future retry
+     * doesn't start from a partial commit (ADR-0010). No-op when the
+     * executor never needed a working directory.
+     */
+    private function discardLocalChangesIfPossible(?string $workingDir, AgentRun $agentRun, ?Repo $repo, array $logCtx): void
+    {
+        if ($workingDir === null || $repo === null) {
+            return;
+        }
+
+        try {
+            $this->workspace->discardLocalChanges(
+                $workingDir,
+                $this->branchFor($agentRun),
+                $repo->default_branch,
+            );
+        } catch (Throwable $e) {
+            // Cleanup is best-effort; surface in logs but never let it
+            // turn a clean cancel into a queue exception.
+            Log::warning('specify.subtask.cancel_cleanup_failed', $logCtx + [
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/app/Services/WorkspaceRunner.php
+++ b/app/Services/WorkspaceRunner.php
@@ -198,6 +198,39 @@ class WorkspaceRunner
     }
 
     /**
+     * Discard any local-only commits on $branch by hard-resetting it to
+     * `origin/$baseBranch` and clearing the working tree (ADR-0010).
+     *
+     * Called when the pipeline observes a cooperative cancel mid-flight:
+     * a partial commit on the local working branch must not survive into
+     * the shared per-story workspace, otherwise a future retry would start
+     * from the cancelled commit. If the branch was already pushed
+     * (origin/<branch> exists), the local copy is reset to the remote
+     * tip rather than the base — the published work is the source of
+     * truth and only local-ahead commits get discarded.
+     */
+    public function discardLocalChanges(string $workingDir, string $branch, string $baseBranch): void
+    {
+        $this->run(['git', 'reset', '--hard', 'HEAD'], $workingDir, allowFailure: true);
+        $this->run(['git', 'clean', '-fdx'], $workingDir, allowFailure: true);
+
+        $remote = $this->run(
+            ['git', 'rev-parse', '--verify', '--quiet', 'refs/remotes/origin/'.$branch],
+            $workingDir,
+            allowFailure: true,
+        );
+
+        if ($remote['exitCode'] === 0) {
+            $this->run(['git', 'reset', '--hard', 'origin/'.$branch], $workingDir, allowFailure: true);
+
+            return;
+        }
+
+        $this->run(['git', 'fetch', 'origin', $baseBranch], $workingDir, allowFailure: true);
+        $this->run(['git', 'reset', '--hard', 'origin/'.$baseBranch], $workingDir, allowFailure: true);
+    }
+
+    /**
      * Push the named branch to origin so reviewers can inspect the diff out-of-band.
      */
     public function push(string $workingDir, string $branch): void

--- a/database/migrations/2026_05_02_060100_add_cancel_and_retry_columns_to_agent_runs.php
+++ b/database/migrations/2026_05_02_060100_add_cancel_and_retry_columns_to_agent_runs.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR-0010: cooperative cancel + retry chain for AgentRuns.
+ *
+ * - cancel_requested: flag the SubtaskRunPipeline polls between phases.
+ * - retry_of_id: chain pointer; the new run that retries an earlier one
+ *   records the prior run's id so reviewers can ask "how many attempts
+ *   did this Subtask take?".
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agent_runs', function (Blueprint $t) {
+            $t->boolean('cancel_requested')->default(false)->after('status');
+            $t->foreignId('retry_of_id')->nullable()->after('cancel_requested')
+                ->constrained('agent_runs')->nullOnDelete();
+            $t->index('cancel_requested');
+            $t->index('retry_of_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_runs', function (Blueprint $t) {
+            $t->dropForeign(['retry_of_id']);
+            $t->dropIndex(['retry_of_id']);
+            $t->dropIndex(['cancel_requested']);
+            $t->dropColumn(['cancel_requested', 'retry_of_id']);
+        });
+    }
+};

--- a/docs/adr/0010-cancel-and-retry-for-agent-runs.md
+++ b/docs/adr/0010-cancel-and-retry-for-agent-runs.md
@@ -29,7 +29,7 @@ Concrete shape:
 
 ### Cancel
 
-- New column `agent_runs.cancel_requested` (boolean, default false). Set by `ExecutionService::cancelRun(AgentRun)`; cleared on terminal state.
+- New column `agent_runs.cancel_requested` (boolean, default false). Set by `ExecutionService::cancelRun(AgentRun)`. The flag is write-once (set true on cancel request) and survives the terminal transition as part of the audit trail — `agent_runs` is append-only, so a reviewer querying "was this Cancelled run cancel-requested?" gets a yes that matches the row's terminal status.
 - `SubtaskRunPipeline` polls the flag between phases (prepare / checkout / execute / commit / diff / push / open PR). When set, it transitions to a new terminal state `Cancelled` (Failure-class — the cascade treats it as Blocked).
 - `Executor` interface gains an optional `supportsCooperativeCancel(): bool` capability (default false). Drivers that opt in receive a `CancelToken` argument on `execute()` and may check it between tool calls. `LaravelAiExecutor` opts in (the agent loop is ours); `CliExecutor` does not (CLI process is opaque). Cancel for non-cooperating drivers waits for the next pipeline-phase boundary or the configured timeout.
 - New state `AgentRunStatus::Cancelled`. `SubtaskRunOutcome::cancelled()` factory; `isFailure()` true.

--- a/docs/adr/0010-cancel-and-retry-for-agent-runs.md
+++ b/docs/adr/0010-cancel-and-retry-for-agent-runs.md
@@ -1,7 +1,7 @@
 # 0010. Cancel and retry semantics for AgentRuns
 
 Date: 2026-05-02
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,7 +16,7 @@ except to mark them Superseded.
 | [0007](0007-already-complete-subtasks.md) | Already-complete subtasks | Accepted |
 | [0008](0008-pr-review-feedback-via-webhooks.md) | PR review feedback closes the loop via webhooks | Accepted |
 | [0009](0009-story-snapshots-for-run-authorisation.md) | Story snapshots for run authorisation | Proposed |
-| [0010](0010-cancel-and-retry-for-agent-runs.md) | Cancel and retry semantics for AgentRuns | Proposed |
+| [0010](0010-cancel-and-retry-for-agent-runs.md) | Cancel and retry semantics for AgentRuns | Accepted |
 | [0011](0011-streaming-progress-events-from-executors.md) | Streaming progress events from executors | Proposed |
 | [0012](0012-project-first-information-architecture.md) | Project-first information architecture | Accepted |
 

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\AgentRunKind;
 use App\Enums\AgentRunStatus;
 use App\Models\AgentRun;
 use App\Models\Subtask;
@@ -48,6 +49,25 @@ new #[Title('Run')] class extends Component {
         unset($this->run);
     }
 
+    public function retryPr(ExecutionService $execution): void
+    {
+        $run = $this->run;
+        abort_unless($run, 404);
+
+        try {
+            $execution->retryPullRequestOpen($run);
+        } catch (\RuntimeException $e) {
+            // Surface but don't crash the page — invariant violations
+            // (already-open PR, non-Succeeded run) are expected user errors.
+            session()->flash('pr_retry_error', $e->getMessage());
+
+            return;
+        }
+
+        session()->flash('pr_retry_dispatched', __('PR retry dispatched.'));
+        unset($this->run);
+    }
+
     public function retry(ExecutionService $execution): void
     {
         $run = $this->run;
@@ -56,13 +76,22 @@ new #[Title('Run')] class extends Component {
         if (! $run->isTerminal() || ! $run->status->isFailure()) {
             return;
         }
+        if ($run->kind === AgentRunKind::RespondToReview) {
+            return;
+        }
 
         $subtask = $run->runnable;
         if (! $subtask instanceof Subtask) {
             return;
         }
 
-        $newRun = $execution->retrySubtaskExecution($subtask, $run);
+        try {
+            $newRun = $execution->retrySubtaskExecution($subtask, $run);
+        } catch (\RuntimeException $e) {
+            session()->flash('retry_error', $e->getMessage());
+
+            return;
+        }
 
         $this->redirect(route('runs.show', [
             'project' => $this->project_id,
@@ -117,7 +146,12 @@ new #[Title('Run')] class extends Component {
             };
             $canCancel = ! $run->isTerminal();
             $cancelPending = $canCancel && (bool) $run->cancel_requested;
-            $canRetry = $run->isTerminal() && $run->status->isFailure();
+            // Review-response runs (ADR-0008) re-fire automatically on the
+            // next review event and are explicitly not retryable through
+            // the manual chain (ADR-0010).
+            $canRetry = $run->isTerminal()
+                && $run->status->isFailure()
+                && $run->kind !== AgentRunKind::RespondToReview;
             $duration = $run->started_at && $run->finished_at
                 ? $run->started_at->diffInSeconds($run->finished_at)
                 : null;
@@ -209,6 +243,13 @@ new #[Title('Run')] class extends Component {
                 @endif
             </div>
 
+            @if (session('retry_error'))
+                <flux:callout icon="exclamation-triangle" color="rose">
+                    <flux:callout.heading>{{ __('Retry failed') }}</flux:callout.heading>
+                    <flux:callout.text>{{ session('retry_error') }}</flux:callout.text>
+                </flux:callout>
+            @endif
+
             @if ($run->error_message)
                 <details class="rounded-md border border-rose-200 bg-rose-50 dark:border-rose-900/40 dark:bg-rose-950/30" open>
                     <summary class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-rose-800 dark:text-rose-300">
@@ -267,6 +308,16 @@ new #[Title('Run')] class extends Component {
                         <flux:text class="text-zinc-500">{{ __('No diff captured for this run.') }}</flux:text>
                     @endif
                 @elseif ($tab === 'pr')
+                    @if (session('pr_retry_dispatched'))
+                        <flux:callout icon="check-circle" color="emerald">
+                            <flux:callout.text>{{ session('pr_retry_dispatched') }}</flux:callout.text>
+                        </flux:callout>
+                    @endif
+                    @if (session('pr_retry_error'))
+                        <flux:callout icon="exclamation-triangle" color="rose">
+                            <flux:callout.text>{{ session('pr_retry_error') }}</flux:callout.text>
+                        </flux:callout>
+                    @endif
                     @if ($prUrl)
                         <flux:card>
                             <div class="flex flex-wrap items-center gap-2">
@@ -282,6 +333,17 @@ new #[Title('Run')] class extends Component {
                                 @endif
                             </div>
                         </flux:card>
+                    @elseif ($prError && $run->status === AgentRunStatus::Succeeded)
+                        <div class="flex flex-wrap items-center gap-2">
+                            <flux:button
+                                size="sm"
+                                variant="primary"
+                                icon="arrow-path"
+                                wire:click="retryPr"
+                                data-action="retry-pr"
+                            >{{ __('Retry PR open') }}</flux:button>
+                            <flux:text class="text-xs text-zinc-500">{{ __('Re-attempt PR creation; idempotent — adopts an existing PR if one is already open for this branch.') }}</flux:text>
+                        </div>
                     @else
                         <flux:text class="text-zinc-500">{{ __('No pull request opened for this run.') }}</flux:text>
                     @endif

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -3,6 +3,7 @@
 use App\Enums\AgentRunStatus;
 use App\Models\AgentRun;
 use App\Models\Subtask;
+use App\Services\ExecutionService;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
@@ -32,6 +33,19 @@ new #[Title('Run')] class extends Component {
         if ((int) $user->current_project_id !== $this->project_id) {
             $user->forceFill(['current_project_id' => $this->project_id])->save();
         }
+    }
+
+    public function cancel(ExecutionService $execution): void
+    {
+        $run = $this->run;
+        abort_unless($run, 404);
+
+        if ($run->isTerminal()) {
+            return;
+        }
+
+        $execution->cancelRun($run, 'Cancelled from run console.');
+        unset($this->run);
     }
 
     #[Computed]
@@ -74,9 +88,11 @@ new #[Title('Run')] class extends Component {
             $rail = match ($run->status) {
                 AgentRunStatus::Succeeded => 'run_complete',
                 AgentRunStatus::Running, AgentRunStatus::Queued => 'running',
-                AgentRunStatus::Failed, AgentRunStatus::Aborted => 'run_failed',
+                AgentRunStatus::Failed, AgentRunStatus::Aborted, AgentRunStatus::Cancelled => 'run_failed',
                 default => 'draft',
             };
+            $canCancel = ! $run->isTerminal();
+            $cancelPending = $canCancel && (bool) $run->cancel_requested;
             $duration = $run->started_at && $run->finished_at
                 ? $run->started_at->diffInSeconds($run->finished_at)
                 : null;
@@ -106,6 +122,21 @@ new #[Title('Run')] class extends Component {
                     <x-state-pill :state="$rail" :label="$run->status->value" />
                     @if ($run->kind && $run->kind->value !== 'execute')
                         <flux:badge color="purple">{{ $run->kind->value }}</flux:badge>
+                    @endif
+                    @if ($cancelPending)
+                        <flux:badge size="sm" color="amber" icon="clock">{{ __('cancel pending') }}</flux:badge>
+                    @endif
+                    @if ($canCancel)
+                        <flux:button
+                            size="sm"
+                            variant="subtle"
+                            icon="x-mark"
+                            wire:click="cancel"
+                            wire:confirm="{{ __('Cancel this run? In-flight tool calls finish; the pipeline stops at the next phase boundary.') }}"
+                            :disabled="$cancelPending"
+                            class="ml-auto"
+                            data-action="cancel-run"
+                        >{{ $cancelPending ? __('Cancelling…') : __('Cancel run') }}</flux:button>
                     @endif
                 </div>
                 <div class="mt-2 flex flex-wrap items-center gap-2 text-xs">

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -48,6 +48,30 @@ new #[Title('Run')] class extends Component {
         unset($this->run);
     }
 
+    public function retry(ExecutionService $execution): void
+    {
+        $run = $this->run;
+        abort_unless($run, 404);
+
+        if (! $run->isTerminal() || ! $run->status->isFailure()) {
+            return;
+        }
+
+        $subtask = $run->runnable;
+        if (! $subtask instanceof Subtask) {
+            return;
+        }
+
+        $newRun = $execution->retrySubtaskExecution($subtask, $run);
+
+        $this->redirect(route('runs.show', [
+            'project' => $this->project_id,
+            'story' => $this->story_id,
+            'subtask' => $this->subtask_id,
+            'run' => $newRun->id,
+        ]), navigate: true);
+    }
+
     #[Computed]
     public function run(): ?AgentRun
     {
@@ -93,6 +117,7 @@ new #[Title('Run')] class extends Component {
             };
             $canCancel = ! $run->isTerminal();
             $cancelPending = $canCancel && (bool) $run->cancel_requested;
+            $canRetry = $run->isTerminal() && $run->status->isFailure();
             $duration = $run->started_at && $run->finished_at
                 ? $run->started_at->diffInSeconds($run->finished_at)
                 : null;
@@ -123,6 +148,13 @@ new #[Title('Run')] class extends Component {
                     @if ($run->kind && $run->kind->value !== 'execute')
                         <flux:badge color="purple">{{ $run->kind->value }}</flux:badge>
                     @endif
+                    @if ($run->retry_of_id)
+                        <a
+                            href="{{ route('runs.show', ['project' => $project, 'story' => $story, 'subtask' => $subtask, 'run' => $run->retry_of_id]) }}"
+                            wire:navigate
+                            class="text-xs text-zinc-500 underline hover:text-zinc-700 dark:hover:text-zinc-300"
+                        >{{ __('retry of') }} #{{ $run->retry_of_id }}</a>
+                    @endif
                     @if ($cancelPending)
                         <flux:badge size="sm" color="amber" icon="clock">{{ __('cancel pending') }}</flux:badge>
                     @endif
@@ -137,6 +169,17 @@ new #[Title('Run')] class extends Component {
                             class="ml-auto"
                             data-action="cancel-run"
                         >{{ $cancelPending ? __('Cancelling…') : __('Cancel run') }}</flux:button>
+                    @endif
+                    @if ($canRetry)
+                        <flux:button
+                            size="sm"
+                            variant="primary"
+                            icon="arrow-path"
+                            wire:click="retry"
+                            wire:confirm="{{ __('Dispatch a fresh AgentRun for this subtask? The new run is authorised against the current StoryApproval.') }}"
+                            class="ml-auto"
+                            data-action="retry-run"
+                        >{{ __('Retry') }}</flux:button>
                     @endif
                 </div>
                 <div class="mt-2 flex flex-wrap items-center gap-2 text-xs">

--- a/tests/Feature/AgentRunCancelTest.php
+++ b/tests/Feature/AgentRunCancelTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     config(['queue.default' => 'sync']);
 });
 
-test('cancelRun on a Queued run transitions to Cancelled directly', function () {
+test('cancelRun on a Queued run transitions to Cancelled and records the audit flag', function () {
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => Subtask::factory()->create()->id,
@@ -28,7 +28,11 @@ test('cancelRun on a Queued run transitions to Cancelled directly', function () 
     app(ExecutionService::class)->cancelRun($run);
 
     expect($run->fresh()->status)->toBe(AgentRunStatus::Cancelled);
-    expect($run->fresh()->cancel_requested)->toBeFalse();
+    // ADR-0010: the flag stays set after the terminal transition so a
+    // Cancelled run is distinguishable from one that terminated via some
+    // other path. (The Queued path used to leave the flag false; that was
+    // a divergence from the ADR text.)
+    expect($run->fresh()->cancel_requested)->toBeTrue();
 });
 
 test('cancelRun on a Running run sets cancel_requested but stays Running', function () {
@@ -112,6 +116,7 @@ test('cancelSubtask cancels every still-open AgentRun on the Subtask', function 
 
     expect($changed)->toBe(2);
     expect($queued->fresh()->status)->toBe(AgentRunStatus::Cancelled);
+    expect($queued->fresh()->cancel_requested)->toBeTrue();
     expect($running->fresh()->cancel_requested)->toBeTrue();
     expect($done->fresh()->status)->toBe(AgentRunStatus::Succeeded);
 });
@@ -187,6 +192,29 @@ test('Queued run cancelled before the worker picks up the job stays Cancelled', 
     expect($fresh->status)->toBe(AgentRunStatus::Cancelled);
     expect($fresh->started_at)->toBeNull();
     expect($fresh->output['pull_request_url'] ?? null)->toBeNull();
+});
+
+test('markRunning loses the queued-cancel race when the row is Cancelled mid-handle', function () {
+    // Simulates: ExecuteSubtaskJob::handle() loads the AgentRun (still
+    // Queued at that snapshot), then cancelRun runs in another transaction
+    // and flips the row to Cancelled before markRunning fires. The
+    // conditional UPDATE must match zero rows so we don't overwrite the
+    // terminal state — closes the queued-cancel race (ADR-0010).
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->id,
+        'status' => AgentRunStatus::Queued,
+    ]);
+
+    AgentRun::query()->whereKey($run->getKey())->update([
+        'status' => AgentRunStatus::Cancelled->value,
+        'cancel_requested' => true,
+    ]);
+
+    $went = app(ExecutionService::class)->markRunning($run);
+
+    expect($went)->toBeFalse();
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Cancelled);
 });
 
 test('AgentRunStatus::Cancelled is a failure-class terminal state', function () {

--- a/tests/Feature/AgentRunCancelTest.php
+++ b/tests/Feature/AgentRunCancelTest.php
@@ -1,0 +1,195 @@
+<?php
+
+use App\Ai\Agents\SubtaskExecutor;
+use App\Enums\AgentRunStatus;
+use App\Enums\TaskStatus;
+use App\Jobs\ExecuteSubtaskJob;
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use App\Models\User;
+use App\Services\ExecutionService;
+use App\Services\Executors\ExecutorFactory;
+use App\Services\SubtaskRunPipeline;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['queue.default' => 'sync']);
+});
+
+test('cancelRun on a Queued run transitions to Cancelled directly', function () {
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->id,
+        'status' => AgentRunStatus::Queued,
+    ]);
+
+    app(ExecutionService::class)->cancelRun($run);
+
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Cancelled);
+    expect($run->fresh()->cancel_requested)->toBeFalse();
+});
+
+test('cancelRun on a Running run sets cancel_requested but stays Running', function () {
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    app(ExecutionService::class)->cancelRun($run);
+
+    $fresh = $run->fresh();
+    expect($fresh->status)->toBe(AgentRunStatus::Running);
+    expect($fresh->cancel_requested)->toBeTrue();
+});
+
+test('cancelRun on a terminal run is a no-op', function () {
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    $changed = app(ExecutionService::class)->cancelRun($run);
+
+    expect($changed)->toBeFalse();
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Succeeded);
+    expect($run->fresh()->cancel_requested)->toBeFalse();
+});
+
+test('SubtaskRunPipeline observes cancel_requested mid-execute and marks the run Cancelled', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    SubtaskExecutor::fake(function () use ($subtask) {
+        AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->where('runnable_id', $subtask->id)
+            ->update(['cancel_requested' => true]);
+
+        return [
+            'summary' => 'agent finished but cancel was requested',
+            'files_changed' => [],
+            'commit_message' => 'noop',
+        ];
+    });
+
+    app(ExecutionService::class)->startStoryExecution($story);
+
+    $run = AgentRun::query()
+        ->where('runnable_type', Subtask::class)
+        ->where('runnable_id', $subtask->id)
+        ->latest('id')
+        ->first();
+
+    expect($run->status)->toBe(AgentRunStatus::Cancelled);
+    expect($run->error_message)->toContain('Cancelled');
+    expect($subtask->fresh()->status)->toBe(TaskStatus::Blocked);
+});
+
+test('cancelSubtask cancels every still-open AgentRun on the Subtask', function () {
+    $subtask = Subtask::factory()->create();
+
+    $queued = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Queued,
+    ]);
+    $running = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+    $done = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    $changed = app(ExecutionService::class)->cancelSubtask($subtask);
+
+    expect($changed)->toBe(2);
+    expect($queued->fresh()->status)->toBe(AgentRunStatus::Cancelled);
+    expect($running->fresh()->cancel_requested)->toBeTrue();
+    expect($done->fresh()->status)->toBe(AgentRunStatus::Succeeded);
+});
+
+test('Run console exposes a Cancel button while the run is open', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $project = $story->feature->project;
+    $member = User::factory()->create();
+    $project->team->addMember($member);
+
+    $this->actingAs($member)
+        ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
+        ->assertOk()
+        ->assertSee('Cancel run');
+});
+
+test('Run console hides the Cancel button on terminal runs', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    $project = $story->feature->project;
+    $member = User::factory()->create();
+    $project->team->addMember($member);
+
+    $this->actingAs($member)
+        ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
+        ->assertOk()
+        ->assertDontSee('Cancel run');
+});
+
+test('Queued run cancelled before the worker picks up the job stays Cancelled', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    // Construct a Queued run as if dispatch happened on a queued worker that
+    // hasn't picked it up. Cancel before invoking the job manually.
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $story->feature->project->primaryRepo()->id,
+        'working_branch' => 'specify/'.$story->feature->slug.'/'.$story->slug,
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Queued,
+    ]);
+
+    app(ExecutionService::class)->cancelRun($run);
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Cancelled);
+
+    SubtaskExecutor::fake(fn () => [
+        'summary' => 'should not run',
+        'files_changed' => ['app/A.php'],
+        'commit_message' => 'should not commit',
+    ]);
+    (new ExecuteSubtaskJob($run->id))->handle(
+        app(ExecutionService::class),
+        app(SubtaskRunPipeline::class),
+        app(ExecutorFactory::class),
+    );
+
+    $fresh = $run->fresh();
+    expect($fresh->status)->toBe(AgentRunStatus::Cancelled);
+    expect($fresh->started_at)->toBeNull();
+    expect($fresh->output['pull_request_url'] ?? null)->toBeNull();
+});
+
+test('AgentRunStatus::Cancelled is a failure-class terminal state', function () {
+    expect(AgentRunStatus::Cancelled->isTerminal())->toBeTrue();
+    expect(AgentRunStatus::Cancelled->isFailure())->toBeTrue();
+});

--- a/tests/Feature/AgentRunPrRetryTest.php
+++ b/tests/Feature/AgentRunPrRetryTest.php
@@ -40,6 +40,39 @@ test('retryPullRequestOpen refuses runs that already have a PR url', function ()
         ->toThrow(RuntimeException::class, 'already');
 });
 
+test('retryPullRequestOpen dispatches the OpenPullRequestJob end-to-end', function () {
+    Http::fake([
+        'api.github.com/repos/*/pulls?head*' => Http::response([
+            ['html_url' => 'https://github.com/o/r/pull/77', 'number' => 77, 'id' => 7],
+        ], 200),
+    ]);
+
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        'url' => 'https://github.com/o/r',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'rate limited'],
+    ]);
+
+    app(ExecutionService::class)->retryPullRequestOpen($run);
+
+    $fresh = $run->fresh();
+    expect($fresh->output['pull_request_url'])->toBe('https://github.com/o/r/pull/77');
+});
+
 test('OpenPullRequestJob opens a fresh PR and stamps the run output', function () {
     Http::fake([
         'api.github.com/repos/*/pulls?head*' => Http::response([], 200),

--- a/tests/Feature/AgentRunPrRetryTest.php
+++ b/tests/Feature/AgentRunPrRetryTest.php
@@ -73,6 +73,76 @@ test('retryPullRequestOpen dispatches the OpenPullRequestJob end-to-end', functi
     expect($fresh->output['pull_request_url'])->toBe('https://github.com/o/r/pull/77');
 });
 
+test('OpenPullRequestJob bails inside the lock when a concurrent retry already stamped the URL', function () {
+    // Two queued retries: first one stamps the URL while the second is
+    // still queued; the second wakes up, acquires the lock, must bail
+    // before calling create() — without this guard, providers that
+    // return null from findOpenPullRequest (Bitbucket / GitLab) would
+    // open duplicate MRs.
+    Http::fake([
+        'api.github.com/*' => Http::response(['html_url' => 'should-not-be-called', 'number' => 0, 'id' => 0], 201),
+    ]);
+
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        'url' => 'https://github.com/o/r',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => [
+            'pull_request_error' => 'first attempt failed',
+            'pull_request_url' => 'https://github.com/o/r/pull/100',
+        ],
+    ]);
+
+    (new OpenPullRequestJob($run->id))->handle();
+
+    Http::assertNothingSent();
+    expect($run->fresh()->output['pull_request_url'])->toBe('https://github.com/o/r/pull/100');
+});
+
+test('OpenPullRequestJob records find() exceptions as pull_request_error instead of crashing the worker', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        // Malformed URL: parseOwnerRepo throws a RuntimeException — the
+        // job must capture this as a normal pr_retry failure rather than
+        // letting the exception escape the queue worker.
+        'url' => 'not-a-valid-url',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'previous attempt blew up'],
+    ]);
+
+    (new OpenPullRequestJob($run->id))->handle();
+
+    $fresh = $run->fresh();
+    expect($fresh->status)->toBe(AgentRunStatus::Succeeded);
+    expect($fresh->output['pull_request_error'])->toContain('Unable to parse');
+});
+
 test('OpenPullRequestJob opens a fresh PR and stamps the run output', function () {
     Http::fake([
         'api.github.com/repos/*/pulls?head*' => Http::response([], 200),

--- a/tests/Feature/AgentRunPrRetryTest.php
+++ b/tests/Feature/AgentRunPrRetryTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Enums\RepoProvider;
+use App\Jobs\OpenPullRequestJob;
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use App\Models\User;
+use App\Services\ExecutionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['queue.default' => 'sync']);
+});
+
+test('retryPullRequestOpen refuses runs that are not Succeeded', function () {
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->id,
+        'status' => AgentRunStatus::Failed,
+    ]);
+
+    expect(fn () => app(ExecutionService::class)->retryPullRequestOpen($run))
+        ->toThrow(RuntimeException::class, 'Succeeded');
+});
+
+test('retryPullRequestOpen refuses runs that already have a PR url', function () {
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->id,
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_url' => 'https://github.com/x/y/pull/1'],
+    ]);
+
+    expect(fn () => app(ExecutionService::class)->retryPullRequestOpen($run))
+        ->toThrow(RuntimeException::class, 'already');
+});
+
+test('OpenPullRequestJob opens a fresh PR and stamps the run output', function () {
+    Http::fake([
+        'api.github.com/repos/*/pulls?head*' => Http::response([], 200),
+        'api.github.com/repos/*/pulls' => Http::response([
+            'html_url' => 'https://github.com/o/r/pull/42',
+            'number' => 42,
+            'id' => 999,
+        ], 201),
+    ]);
+
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        'url' => 'https://github.com/o/r',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'previous attempt blew up'],
+    ]);
+
+    (new OpenPullRequestJob($run->id))->handle();
+
+    $fresh = $run->fresh();
+    expect($fresh->output['pull_request_url'])->toBe('https://github.com/o/r/pull/42');
+    expect($fresh->output['pull_request_number'])->toBe(42);
+    expect($fresh->output)->not->toHaveKey('pull_request_error');
+    expect($fresh->status)->toBe(AgentRunStatus::Succeeded);
+});
+
+test('OpenPullRequestJob adopts an existing open PR rather than opening a duplicate', function () {
+    Http::fake([
+        'api.github.com/repos/*/pulls?head*' => Http::response([
+            ['html_url' => 'https://github.com/o/r/pull/7', 'number' => 7, 'id' => 70],
+        ], 200),
+    ]);
+
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        'url' => 'https://github.com/o/r',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'previous attempt blew up'],
+    ]);
+
+    (new OpenPullRequestJob($run->id))->handle();
+
+    $fresh = $run->fresh();
+    expect($fresh->output['pull_request_url'])->toBe('https://github.com/o/r/pull/7');
+    expect($fresh->output['pull_request_number'])->toBe(7);
+    Http::assertSentCount(1);
+});
+
+test('OpenPullRequestJob records pull_request_error on provider failure', function () {
+    Http::fake([
+        'api.github.com/repos/*/pulls?head*' => Http::response([], 200),
+        'api.github.com/repos/*/pulls' => Http::response(['message' => 'kaboom'], 500),
+    ]);
+
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        'url' => 'https://github.com/o/r',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'first failure'],
+    ]);
+
+    (new OpenPullRequestJob($run->id))->handle();
+
+    $fresh = $run->fresh();
+    expect($fresh->output)->toHaveKey('pull_request_error');
+    expect($fresh->output['pull_request_error'])->toContain('500');
+    expect($fresh->status)->toBe(AgentRunStatus::Succeeded);
+    expect($fresh->output)->not->toHaveKey('pull_request_url');
+});
+
+test('Run console exposes Retry PR on Succeeded runs with pull_request_error', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $repo = $story->feature->project->primaryRepo();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'rate limited'],
+    ]);
+
+    $project = $story->feature->project;
+    $member = User::factory()->create();
+    $project->team->addMember($member);
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::runs.show', [
+        'project' => $project->id,
+        'story' => $story->id,
+        'subtask' => $subtask->id,
+        'run' => $run->id,
+    ])
+        ->call('setTab', 'pr')
+        ->assertSee('Retry PR open');
+});

--- a/tests/Feature/AgentRunRetryTest.php
+++ b/tests/Feature/AgentRunRetryTest.php
@@ -146,6 +146,24 @@ test('retry on a RespondToReview run is rejected by the service', function () {
         ->toThrow(RuntimeException::class, 'Review-response');
 });
 
+test('retrySubtaskExecution rejects Succeeded runs at the service layer', function () {
+    // The UI gates Retry behind isFailure(), but the service contract must
+    // hold that line on its own — non-UI callers (MCP tools, internal
+    // automation) must not be able to re-dispatch an already-successful
+    // Subtask and double-open PRs.
+    $story = approvedStoryInProjectWithRepo();
+    $story->forceFill(['status' => StoryStatus::Approved->value])->save();
+    $subtask = $story->fresh()->tasks()->first()->subtasks()->first();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    expect(fn () => app(ExecutionService::class)->retrySubtaskExecution($subtask, $run))
+        ->toThrow(RuntimeException::class, 'failed / cancelled / aborted');
+});
+
 test('Run console links a retry back to its origin run', function () {
     $story = approvedStoryInProjectWithRepo();
     $subtask = $story->tasks()->first()->subtasks()->first();

--- a/tests/Feature/AgentRunRetryTest.php
+++ b/tests/Feature/AgentRunRetryTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Ai\Agents\SubtaskExecutor;
+use App\Enums\AgentRunStatus;
+use App\Enums\StoryStatus;
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use App\Models\User;
+use App\Services\ExecutionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['queue.default' => 'sync']);
+    SubtaskExecutor::fake(fn () => [
+        'summary' => 'noop',
+        'files_changed' => [],
+        'commit_message' => 'noop',
+    ]);
+});
+
+test('retrySubtaskExecution dispatches a fresh AgentRun pointing at the prior run', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $first = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $story->feature->project->primaryRepo()->id,
+        'status' => AgentRunStatus::Failed,
+        'executor_driver' => 'fake',
+    ]);
+
+    SubtaskExecutor::fake(fn () => [
+        'summary' => 'retry attempt',
+        'files_changed' => ['app/A.php'],
+        'commit_message' => 'retry: do the thing',
+    ]);
+
+    $retry = app(ExecutionService::class)->retrySubtaskExecution($subtask, $first);
+
+    expect($retry->retry_of_id)->toBe($first->id);
+    expect($retry->id)->not->toBe($first->id);
+    expect($retry->executor_driver)->toBe('fake');
+});
+
+test('retry refuses an in-flight run', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $running = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    expect(fn () => app(ExecutionService::class)->retrySubtaskExecution($subtask, $running))
+        ->toThrow(RuntimeException::class, 'still in flight');
+});
+
+test('retry refuses when the Story is no longer Approved', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $failed = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Failed,
+    ]);
+
+    $story->forceFill(['status' => StoryStatus::ChangesRequested->value])->save();
+
+    expect(fn () => app(ExecutionService::class)->retrySubtaskExecution($subtask, $failed))
+        ->toThrow(RuntimeException::class, 'not Approved');
+});
+
+test('Run console exposes a Retry button on terminal failure runs', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Failed,
+    ]);
+
+    $project = $story->feature->project;
+    $member = User::factory()->create();
+    $project->team->addMember($member);
+
+    $this->actingAs($member)
+        ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
+        ->assertOk()
+        ->assertSee('Retry');
+});
+
+test('Run console hides Retry on Succeeded runs', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    $project = $story->feature->project;
+    $member = User::factory()->create();
+    $project->team->addMember($member);
+
+    $this->actingAs($member)
+        ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
+        ->assertOk()
+        ->assertDontSee('Retry');
+});
+
+test('Run console links a retry back to its origin run', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $origin = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Failed,
+    ]);
+    $retry = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+        'retry_of_id' => $origin->id,
+    ]);
+
+    $project = $story->feature->project;
+    $member = User::factory()->create();
+    $project->team->addMember($member);
+
+    $this->actingAs($member)
+        ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$retry->id}")
+        ->assertOk()
+        ->assertSee('retry of')
+        ->assertSee("#{$origin->id}");
+});

--- a/tests/Feature/AgentRunRetryTest.php
+++ b/tests/Feature/AgentRunRetryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Ai\Agents\SubtaskExecutor;
+use App\Enums\AgentRunKind;
 use App\Enums\AgentRunStatus;
 use App\Enums\StoryStatus;
 use App\Models\AgentRun;
@@ -109,6 +110,40 @@ test('Run console hides Retry on Succeeded runs', function () {
         ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
         ->assertOk()
         ->assertDontSee('Retry');
+});
+
+test('Run console hides Retry on RespondToReview runs (re-fires automatically)', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Failed,
+        'kind' => AgentRunKind::RespondToReview,
+    ]);
+
+    $project = $story->feature->project;
+    $member = User::factory()->create();
+    $project->team->addMember($member);
+
+    $this->actingAs($member)
+        ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
+        ->assertOk()
+        ->assertDontSee('Retry');
+});
+
+test('retry on a RespondToReview run is rejected by the service', function () {
+    $story = approvedStoryInProjectWithRepo();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Failed,
+        'kind' => AgentRunKind::RespondToReview,
+    ]);
+
+    expect(fn () => app(ExecutionService::class)->retrySubtaskExecution($subtask, $run))
+        ->toThrow(RuntimeException::class, 'Review-response');
 });
 
 test('Run console links a retry back to its origin run', function () {


### PR DESCRIPTION
## Summary
- **Phase A — cooperative cancel.** New `cancel_requested` flag on `agent_runs`; `SubtaskRunPipeline` polls between phases (before_prepare / before_execute / after_execute / before_push). Queued runs cancel directly; Running runs flag-and-stop at the next boundary. `ExecuteSubtaskJob` refuses to start a terminal run, closing the queued-cancel-then-worker-picks-up race.
- **Phase B — retry creates a new AgentRun.** `retry_of_id` FK chains attempts; retry re-resolves authorisation through the current `StoryApproval` and throws when the Story is no longer Approved. Retry button on the Run console; "retry of #N" link wires the chain. Hidden for `RespondToReview` runs (ADR-0008 — they re-fire automatically).
- **Phase C — retry the PR open step.** `OpenPullRequestJob` is idempotent via the new `PullRequestProvider::findOpenPullRequest()` (GitHub: real lookup; Bitbucket / GitLab: null fallback). Concurrent retries serialised by `Cache::lock` keyed on agent_run_id. Retry PR button on the PR tab when `pull_request_error` is set.

## Test plan
- [x] `composer test` (Pint + Pest) — 315 tests / 777 assertions green.
- [x] 9 cancel tests (queued → Cancelled directly, running → flag set, terminal no-op, mid-execute pipeline observation, race regression, console rendering, status helpers).
- [x] 7 retry tests (happy path, in-flight refusal, story-not-Approved refusal, RespondToReview gate, console rendering).
- [x] 6 PR-retry tests (idempotent adopt of existing PR, lock-protected create on success, error capture preserves Succeeded, console exposes button only when applicable).
- [ ] Visual smoke (Playwright) — Cancel a Running run, Retry a Failed run, Retry PR on a Succeeded-with-error run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)