### PR TITLE
chore: adopt user-scope harness at project scope

### DIFF
--- a/.claude/commands/critique.md
+++ b/.claude/commands/critique.md
@@ -1,0 +1,19 @@
+---
+description: Critique the most recent change before continuing — diff re-read + advisor() pass
+---
+
+A deliberate critique pass *between* steps, without waiting for Stop. Use mid-flow when an interpretation is about to harden into a chain of edits, or before declaring a milestone done.
+
+Procedure:
+
+1. **Re-read the change.** Pick the branch that matches the repo state — don't run all three:
+   - **Dirty working tree (git):** `git diff HEAD` for tracked changes, then `git status --porcelain` and `Read` any `??` (untracked) entries directly — `git diff` skips brand-new files.
+   - **Clean tree, change is the last commit (git):** `git show HEAD` to re-read what was just committed. Catches formatter output, Bash-generated files, and edits from earlier turns that the transcript may have aged out.
+   - **Fresh repo with no commits, or not a git repo:** summarise the last few `Edit`/`Write`/`Bash` calls that touched files, working from the tool transcript.
+2. **Critique it yourself first.** One paragraph: what does this change actually do, what could be wrong, what assumption is it leaning on?
+3. **Call `advisor()`.** The advisor sees the full transcript — frame the question concretely. Examples: "Is the off-by-one in `foo()` actually a bug or am I misreading the loop?", "Does this migration handle the concurrent-write case I claimed it did?", "I rewrote X to use Y — is the boundary correct, or did I leak Y's concerns into a caller?"
+4. **Report a punch list.** Under 200 words. What stands, what's shaky, what's the next concrete check.
+
+If `$ARGUMENTS` is provided, treat it as a scope hint — `/critique migration safety`, `/critique the test I just wrote` — and focus the diff re-read and the advisor question on that.
+
+Do not start new implementation work in this turn. The output of `/critique` is *findings*, not edits — the user (or the next turn) decides what to do about them.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,34 @@
+---
+description: Draft a Goal/Constraints/Acceptance plan for the task in $ARGUMENTS, then enter plan mode
+---
+
+Before writing any code, produce a plan in this exact shape:
+
+## Goal
+One sentence. The outcome, not the activity.
+
+## Constraints
+Bulleted. Include:
+- Files / modules in scope (and explicitly out of scope).
+- Stack/version constraints (look at CLAUDE.md, AGENTS.md, composer.json, package.json).
+- Backwards-compat or migration concerns.
+- Performance, security, or ergonomic budgets the user has flagged.
+
+## Acceptance criteria
+Bulleted, testable. Each one should be checkable by running a command or reading a diff. Examples:
+- `composer lint:check` passes.
+- `php artisan test --filter=Foo` passes with new cases X and Y.
+- `/route X` returns 200 with payload shape Z.
+- No new TODOs left behind.
+
+## Approach
+3–7 bullets, ordered. The smallest plan that covers the goal. Identify the *risky* step and how you'll de-risk (spike, isolated test, advisor() call).
+
+## Open questions
+Anything that would change the approach materially. If the answer is guessable from the codebase, go look — don't ask.
+
+---
+
+Task: $ARGUMENTS
+
+After producing the plan, ask the user to approve or amend before any edits. If they say "go", enter plan-mode-style execution: small steps, run the verification check after each material change, and use `advisor()` once before declaring done.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,22 @@
+---
+description: Run the project's pass/fail verification check (harness-check.sh, or stack-default lint+types+tests)
+---
+
+Run the project's verification check and report pass/fail with concise output. Use this before declaring any task done.
+
+Order of preference:
+
+1. If `./scripts/harness-check.sh` exists and is executable → run it.
+2. Else if `composer.json` exists with a `lint:check` script → run `composer lint:check && composer test` (and `npm run types:check` if `package.json` exists).
+3. Else if `package.json` exists → run `npm run lint:check && npm run types:check && npm test` (skip any that aren't defined).
+4. Else if `pyproject.toml` exists → `ruff check . && mypy . && pytest -q`.
+5. Else if `Cargo.toml` → `cargo check && cargo test`.
+6. Else if `go.mod` → `go vet ./... && go test ./...`.
+
+Report:
+- ✅ pass → one line.
+- ❌ fail → the failing command, the salient lines from output (not full log), and the smallest fix proposal.
+
+Do NOT propose a fix that disables a rule unless the user explicitly asks. Never use `--no-verify`.
+
+If `$ARGUMENTS` is provided, treat it as a path filter — run checks scoped to that path where the tool supports it.

--- a/.claude/hooks/block-force-push.sh
+++ b/.claude/hooks/block-force-push.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash. Block destructive operations.
+# Reads JSON on stdin: {tool_name, tool_input: {command, ...}, ...}
+# Exit 2 = block + tell model why. Exit 0 = allow.
+#
+# Matching strategy: split the command on shell separators (; && || | newline),
+# then for each *segment*, look at its leading words. This avoids false positives
+# from strings inside `echo`, `printf`, comments, heredocs, etc.
+
+set -u
+input="$(cat)"
+cmd="$(printf '%s' "$input" | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin); print(d.get("tool_input",{}).get("command",""))
+except Exception: pass' 2>/dev/null || true)"
+
+[ -z "$cmd" ] && exit 0
+
+block() {
+  printf 'BLOCKED by ~/.claude/hooks/block-force-push.sh\nSegment: %s\nReason: %s\nIf you genuinely need this, ask the user first.\n' "$1" "$2" >&2
+  exit 2
+}
+
+# Split into segments on ; && || | and newlines. Lone & (background) is not
+# split — none of the patterns we block are about backgrounding.
+segments="$(CLAUDE_HOOK_CMD="$cmd" python3 - <<'PY'
+import os, re
+src = os.environ.get("CLAUDE_HOOK_CMD","")
+out = []
+buf = []
+i = 0
+in_s = None
+while i < len(src):
+    c = src[i]
+    if in_s:
+        buf.append(c)
+        if c == in_s and (i == 0 or src[i-1] != "\\"):
+            in_s = None
+    elif c in ("'", '"'):
+        in_s = c
+        buf.append(c)
+    elif c in (";", "\n"):
+        out.append("".join(buf)); buf = []
+    elif c == "&" and i+1 < len(src) and src[i+1] == "&":
+        out.append("".join(buf)); buf = []; i += 1
+    elif c == "|" and i+1 < len(src) and src[i+1] == "|":
+        out.append("".join(buf)); buf = []; i += 1
+    elif c == "|":
+        out.append("".join(buf)); buf = []
+    else:
+        buf.append(c)
+    i += 1
+out.append("".join(buf))
+for seg in out:
+    s = seg.strip()
+    if s: print(s)
+PY
+)"
+
+while IFS= read -r seg; do
+  [ -z "$seg" ] && continue
+
+  case "$seg" in
+    echo*|printf*|cat*|"# "*|"#"*) continue ;;
+  esac
+
+  case "$seg" in *"--force-with-lease"*) continue ;; esac
+
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+push[[:space:]].*(--force|[[:space:]]-f[[:space:]]).*[[:space:]](main|master|HEAD:main|HEAD:master)([[:space:]]|$)'; then
+    block "$seg" "force-push to main/master"
+  fi
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+push[[:space:]].*(--force|[[:space:]]-f[[:space:]])'; then
+    block "$seg" "force-push without --force-with-lease"
+  fi
+  # Refspec push-delete: `git push origin :main`, `git push origin :refs/heads/main`.
+  # The leading colon means "delete" — equivalent to a force-overwrite of nothing
+  # over the protected branch. Block protected names only, same list as branch -D.
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+push[[:space:]]+[^[:space:]]+[[:space:]]+:(refs/heads/)?(main|master|develop|trunk|production|prod|staging|release[/-])'; then
+    block "$seg" "refspec push-delete of protected branch (push origin :branch)"
+  fi
+  # Explicit `--delete` flag.
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+push[[:space:]].*--delete[[:space:]]+([^[:space:]]+[[:space:]]+)*(main|master|develop|trunk|production|prod|staging|release[/-])'; then
+    block "$seg" "git push --delete on protected branch"
+  fi
+  # `+` refspec prefix is force without `--force`. Block when target is protected.
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+push[[:space:]].*[[:space:]]\+[^[:space:]:]*:(refs/heads/)?(main|master|develop|trunk|production|prod|staging|release[/-])'; then
+    block "$seg" "force-push via +refspec to protected branch"
+  fi
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+reset[[:space:]]+--hard[[:space:]]+(origin|upstream)/'; then
+    block "$seg" "hard reset to remote"
+  fi
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+(checkout|restore)[[:space:]]+\.[[:space:]]*$'; then
+    block "$seg" "wholesale discard of working tree"
+  fi
+  # Force-delete branch — only block on protected names. Worktree workflows
+  # rely on `git branch -D` for completed feature branches, so the rule has
+  # to be specific. Block: main, master, develop, trunk, production, staging,
+  # and any release/* or release-* branch.
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+branch[[:space:]]+-D[[:space:]]+(main|master|develop|trunk|production|prod|staging|release[/-])'; then
+    block "$seg" "force-delete protected branch"
+  fi
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+(commit|merge|push|rebase)[[:space:]].*--no-verify'; then
+    block "$seg" "skipping git hooks (--no-verify)"
+  fi
+  # The \$HOME pattern matches the literal string "$HOME" in user shell commands.
+  # Single quotes preserve the regex unchanged for grep — SC2016 is a false
+  # positive here (we don't want shell to expand $HOME).
+  # shellcheck disable=SC2016
+  if echo "$seg" | grep -Eq '^[[:space:]]*rm[[:space:]]+(-[rRf]+[[:space:]]+)+(/|~|\$HOME|/\*|~/?\*)([[:space:]]|$)'; then
+    block "$seg" "rm -rf on \$HOME or /"
+  fi
+  if echo "$seg" | grep -Eq '^[[:space:]]*git[[:space:]]+clean[[:space:]].*-f[dx]*[[:space:]]*$'; then
+    block "$seg" "git clean -fd (destroys untracked work)"
+  fi
+  if echo "$seg" | grep -Eq '^[[:space:]]*chmod[[:space:]]+-R[[:space:]]+777'; then
+    block "$seg" "chmod -R 777"
+  fi
+done <<< "$segments"
+
+exit 0

--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Write|Edit. Run the project's formatter if available.
+# Silent on success, prints output on failure (advisory — non-blocking).
+
+set -u
+cd "$(pwd)" || exit 0
+
+run() { "$@" >/dev/null 2>&1 || { echo "format hint: '$*' had non-zero exit"; return 0; }; }
+
+# Laravel/PHP
+if [ -f vendor/bin/pint ]; then
+  run vendor/bin/pint --quiet
+fi
+
+# Node — only if a format script exists
+if [ -f package.json ] && grep -q '"format"' package.json 2>/dev/null; then
+  if command -v bun >/dev/null 2>&1; then
+    run bun run format
+  elif command -v npm >/dev/null 2>&1; then
+    run npm run format --silent
+  fi
+fi
+
+# Python — ruff if config exists
+if [ -f pyproject.toml ] && grep -q 'ruff' pyproject.toml 2>/dev/null && command -v ruff >/dev/null 2>&1; then
+  run ruff format .
+fi
+
+# Go
+if [ -f go.mod ] && command -v gofmt >/dev/null 2>&1; then
+  run gofmt -w .
+fi
+
+# Rust
+if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
+  run cargo fmt --quiet
+fi
+
+exit 0

--- a/.claude/hooks/post-compact-reinject.sh
+++ b/.claude/hooks/post-compact-reinject.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# PostCompact hook. Re-inject the project's CLAUDE.md (and AGENTS.md if present)
+# so context-compression doesn't strip the operating contract.
+# Output goes to the model.
+
+set -u
+
+emit() {
+  [ -f "$1" ] || return 0
+  echo
+  echo "--- $1 (re-injected after compact) ---"
+  cat "$1"
+}
+
+emit ./CLAUDE.md
+emit ./AGENTS.md
+emit ~/.claude/CLAUDE.md
+
+exit 0

--- a/.claude/hooks/verify-before-stop.sh
+++ b/.claude/hooks/verify-before-stop.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Stop hook. Refuse to stop if there are uncommitted code changes AND the
+# project's verification check fails. Allow stop on read-only sessions
+# (no working-tree changes) so investigation/exploration can end naturally.
+#
+# Override at any time: CLAUDE_SKIP_VERIFY=1
+# Exit 2 = block stop and feed stderr back to the model.
+
+set -u
+
+# Explicit opt-out — for sessions where you intentionally want to stop with
+# work in progress (e.g., handing off to the user, mid-debug breakpoint).
+[ "${CLAUDE_SKIP_VERIFY:-}" = "1" ] && exit 0
+
+# Only enforce on sessions that have actually modified the tree. Without this,
+# a read-only session ("explain this code", "what does X do") gets trapped if
+# pre-existing tests fail. We want the hook to fire when CLAUDE made changes,
+# not when the user happens to be in a broken-tree state.
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
+    # Clean working tree — nothing to verify. Allow stop.
+    exit 0
+  fi
+else
+  # Not a git repo — be permissive. Verify-on-stop is a sharp tool; only use it
+  # where we have a clear "code was changed" signal.
+  exit 0
+fi
+
+# Working tree is dirty. Run the verification check.
+if [ -x ./scripts/harness-check.sh ]; then
+  if ! out="$(./scripts/harness-check.sh 2>&1)"; then
+    printf 'Stop blocked: harness-check.sh failed (working tree has changes).\n\n%s\n\nFix the failure, or set CLAUDE_SKIP_VERIFY=1 to stop anyway (e.g. handing off to user).\n' "$out" >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+# Fallback — language-default fast checks. Only run when explicitly available.
+if [ -f composer.json ] && grep -q '"lint:check"' composer.json 2>/dev/null; then
+  if ! out="$(composer lint:check 2>&1)"; then
+    printf 'Stop blocked: composer lint:check failed (working tree has changes).\n\n%s\n\nSet CLAUDE_SKIP_VERIFY=1 to override.\n' "$out" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-force-push.sh"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-on-edit.sh"
+          }
+        ],
+        "matcher": "Write|Edit"
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-compact-reinject.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-before-stop.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# scripts/harness-check.sh — project pass/fail gate.
+# Called by ~/.claude/hooks/verify-before-stop.sh and `/verify`.
+# Returns non-zero on the first failed sensor.
+#
+# Specify's canonical gate is `composer test`, which itself chains
+# `pint --test` (lint) and `php artisan test` (the Pest suite).
+# Wall-clock is ~40s for the full suite — over the suggested 10s
+# budget, but it's the only check that actually verifies correctness
+# and there's no faster proxy on this codebase.
+set -uo pipefail
+
+step() {
+  local label="$1"; shift
+  echo "→ $label"
+  if "$@"; then return 0; fi
+  echo "❌ harness-check failed: $label" >&2
+  exit 1
+}
+
+step "composer test" composer test
+
+echo "✅ harness-check passed"


### PR DESCRIPTION
## Summary
- Retrofits the four user-scope harness guardrails (block destructive git, format on edit, post-compact re-inject, verify-before-stop) into the project so teammates running Claude Code get the same surface.
- Adds three slash commands: \`/verify\`, \`/plan\`, \`/critique\`.
- Drops \`scripts/harness-check.sh\` as the project's pass/fail gate. Trimmed to \`composer test\` — the only check that meaningfully verifies correctness here.

## Why
Anything Claude Code does on this branch passes through the \`Stop\` hook, which runs \`scripts/harness-check.sh\` before the agent can hand back. Today that gate doesn't exist on the project; this PR ships it.

## What teammates see
- **Not on Claude Code:** nothing changes. \`.claude/settings.json\` is only read by Claude Code; \`scripts/harness-check.sh\` is plain bash.
- **On Claude Code:** the four hooks load on next session start. Anyone who already has user-scope harness installed will see project hooks layer on top of the user ones (they don't conflict — different paths).

## Test plan
- [x] \`bash scripts/harness-check.sh\` passes (320/320 Pest tests).
- [x] \`bash ~/.claude/skills/harness/scripts/doctor.sh\` reports 11/11 pass.
- [x] \`.claude/settings.json\` is valid JSON; only the \`hooks\` key is touched.
- [ ] On Claude Code: restart the session, edit a file → format-on-edit.sh fires; \`git push --force\` → blocked by block-force-push.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)