### PR TITLE
fix: GithubPullRequestProvider PR-find + harness-check stale-cwd guard

### DIFF
--- a/app/Services/PullRequests/GithubPullRequestProvider.php
+++ b/app/Services/PullRequests/GithubPullRequestProvider.php
@@ -58,45 +58,80 @@ class GithubPullRequestProvider implements PullRequestProvider
 
         [$owner, $name] = $this->parseOwnerRepo($repo->url);
         $apiBase = rtrim((string) config('specify.github.api_base', 'https://api.github.com'), '/');
+        $headRepo = $owner.'/'.$name;
 
         // GitHub's `head=user:branch` query-param filter is brittle:
         // it's documented for fork PRs and silently returns empty for
         // same-repo PRs whose head ref contains slashes (which all our
         // `specify/<feature>/<story>` branches do). Smoke testing on a
         // real repo confirmed the filtered request returned [] while the
-        // PR was open. The robust fix is to list open PRs (page 1, 100
-        // entries — a fresh retry adopts a recently-opened PR, which
-        // will always be on page 1 in any realistic queue) and match the
-        // head.ref client-side ourselves.
-        $response = Http::withHeaders([
-            'Accept' => 'application/vnd.github+json',
-            'Authorization' => 'Bearer '.$repo->access_token,
-            'X-GitHub-Api-Version' => '2022-11-28',
-        ])->get("{$apiBase}/repos/{$owner}/{$name}/pulls", [
-            'state' => 'open',
-            'per_page' => 100,
-        ]);
+        // PR was open. The robust fix is to list open PRs and match the
+        // head.ref client-side, paginating via the `Link: rel="next"`
+        // header. Cap at MAX_PAGES * 100 PRs so a runaway queue can't
+        // burn the API budget.
+        $url = "{$apiBase}/repos/{$owner}/{$name}/pulls?state=open&per_page=100";
+        $maxPages = (int) config('specify.github.find_pr_max_pages', 10);
 
-        if (! $response->successful()) {
-            return null;
-        }
+        for ($page = 0; $page < $maxPages; $page++) {
+            $response = Http::withHeaders([
+                'Accept' => 'application/vnd.github+json',
+                'Authorization' => 'Bearer '.$repo->access_token,
+                'X-GitHub-Api-Version' => '2022-11-28',
+            ])->get($url);
 
-        $data = $response->json();
-        if (! is_array($data) || $data === []) {
-            return null;
-        }
-
-        foreach ($data as $pr) {
-            if (! is_array($pr)) {
-                continue;
+            if (! $response->successful()) {
+                return null;
             }
-            if (($pr['head']['ref'] ?? null) === $head) {
+
+            $data = $response->json();
+            if (! is_array($data) || $data === []) {
+                return null;
+            }
+
+            foreach ($data as $pr) {
+                if (! is_array($pr)) {
+                    continue;
+                }
+                if (($pr['head']['ref'] ?? null) !== $head) {
+                    continue;
+                }
+                // Cross-repo guard: the open-PR list includes fork PRs
+                // whose head.ref can collide with a same-repo branch.
+                // Only adopt PRs whose head is on the destination repo
+                // — `createPullRequest` always sends `head` as a bare
+                // branch name, so the PR we want is always same-repo.
+                if (($pr['head']['repo']['full_name'] ?? null) !== $headRepo) {
+                    continue;
+                }
+
                 return [
                     'url' => (string) ($pr['html_url'] ?? ''),
                     'number' => $pr['number'] ?? 0,
                     'id' => $pr['id'] ?? 0,
                 ];
             }
+
+            $next = $this->nextPageUrl($response->header('Link'));
+            if ($next === null) {
+                return null;
+            }
+            $url = $next;
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse the next-page URL out of a GitHub `Link` header
+     * (`<https://...?page=2>; rel="next", <...>; rel="last"`).
+     */
+    private function nextPageUrl(?string $linkHeader): ?string
+    {
+        if ($linkHeader === null || $linkHeader === '') {
+            return null;
+        }
+        if (preg_match('/<([^>]+)>;\s*rel="next"/', $linkHeader, $m)) {
+            return $m[1];
         }
 
         return null;

--- a/app/Services/PullRequests/GithubPullRequestProvider.php
+++ b/app/Services/PullRequests/GithubPullRequestProvider.php
@@ -59,14 +59,22 @@ class GithubPullRequestProvider implements PullRequestProvider
         [$owner, $name] = $this->parseOwnerRepo($repo->url);
         $apiBase = rtrim((string) config('specify.github.api_base', 'https://api.github.com'), '/');
 
+        // GitHub's `head=user:branch` query-param filter is brittle:
+        // it's documented for fork PRs and silently returns empty for
+        // same-repo PRs whose head ref contains slashes (which all our
+        // `specify/<feature>/<story>` branches do). Smoke testing on a
+        // real repo confirmed the filtered request returned [] while the
+        // PR was open. The robust fix is to list open PRs (page 1, 100
+        // entries — a fresh retry adopts a recently-opened PR, which
+        // will always be on page 1 in any realistic queue) and match the
+        // head.ref client-side ourselves.
         $response = Http::withHeaders([
             'Accept' => 'application/vnd.github+json',
             'Authorization' => 'Bearer '.$repo->access_token,
             'X-GitHub-Api-Version' => '2022-11-28',
         ])->get("{$apiBase}/repos/{$owner}/{$name}/pulls", [
-            'head' => $owner.':'.$head,
             'state' => 'open',
-            'per_page' => 1,
+            'per_page' => 100,
         ]);
 
         if (! $response->successful()) {
@@ -78,13 +86,20 @@ class GithubPullRequestProvider implements PullRequestProvider
             return null;
         }
 
-        $pr = $data[0];
+        foreach ($data as $pr) {
+            if (! is_array($pr)) {
+                continue;
+            }
+            if (($pr['head']['ref'] ?? null) === $head) {
+                return [
+                    'url' => (string) ($pr['html_url'] ?? ''),
+                    'number' => $pr['number'] ?? 0,
+                    'id' => $pr['id'] ?? 0,
+                ];
+            }
+        }
 
-        return [
-            'url' => (string) ($pr['html_url'] ?? ''),
-            'number' => $pr['number'] ?? 0,
-            'id' => $pr['id'] ?? 0,
-        ];
+        return null;
     }
 
     /**

--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -10,6 +10,16 @@
 # and there's no faster proxy on this codebase.
 set -uo pipefail
 
+# When the parent shell's cwd has been deleted (e.g. by a prior
+# WorkspaceRunner test that tore down a tempdir we happened to be inside)
+# every subprocess inherits the broken cwd and PHP can't even resolve
+# `composer`. Detect that and reposition to the project root before
+# running anything. The script is invoked from .claude/hooks via
+# $CLAUDE_PROJECT_DIR, so we always know where to land.
+if ! pwd -P >/dev/null 2>&1; then
+  cd "${CLAUDE_PROJECT_DIR:-$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")}" || exit 1
+fi
+
 step() {
   local label="$1"; shift
   echo "→ $label"

--- a/tests/Feature/AgentRunPrRetryTest.php
+++ b/tests/Feature/AgentRunPrRetryTest.php
@@ -42,8 +42,13 @@ test('retryPullRequestOpen refuses runs that already have a PR url', function ()
 
 test('retryPullRequestOpen dispatches the OpenPullRequestJob end-to-end', function () {
     Http::fake([
-        'api.github.com/repos/*/pulls?head*' => Http::response([
-            ['html_url' => 'https://github.com/o/r/pull/77', 'number' => 77, 'id' => 7],
+        'api.github.com/*pulls*' => Http::response([
+            [
+                'html_url' => 'https://github.com/o/r/pull/77',
+                'number' => 77,
+                'id' => 7,
+                'head' => ['ref' => 'specify/feature/story'],
+            ],
         ], 200),
     ]);
 
@@ -144,14 +149,18 @@ test('OpenPullRequestJob records find() exceptions as pull_request_error instead
 });
 
 test('OpenPullRequestJob opens a fresh PR and stamps the run output', function () {
-    Http::fake([
-        'api.github.com/repos/*/pulls?head*' => Http::response([], 200),
-        'api.github.com/repos/*/pulls' => Http::response([
+    Http::fake(function ($request) {
+        // GET (find) → empty list; POST (create) → 201 with the new PR.
+        if ($request->method() === 'GET') {
+            return Http::response([], 200);
+        }
+
+        return Http::response([
             'html_url' => 'https://github.com/o/r/pull/42',
             'number' => 42,
             'id' => 999,
-        ], 201),
-    ]);
+        ], 201);
+    });
 
     $story = approvedStoryInProjectWithRepo();
     $repo = $story->feature->project->primaryRepo();
@@ -184,8 +193,13 @@ test('OpenPullRequestJob opens a fresh PR and stamps the run output', function (
 
 test('OpenPullRequestJob adopts an existing open PR rather than opening a duplicate', function () {
     Http::fake([
-        'api.github.com/repos/*/pulls?head*' => Http::response([
-            ['html_url' => 'https://github.com/o/r/pull/7', 'number' => 7, 'id' => 70],
+        'api.github.com/*pulls*' => Http::response([
+            [
+                'html_url' => 'https://github.com/o/r/pull/7',
+                'number' => 7,
+                'id' => 70,
+                'head' => ['ref' => 'specify/feature/story'],
+            ],
         ], 200),
     ]);
 

--- a/tests/Feature/AgentRunPrRetryTest.php
+++ b/tests/Feature/AgentRunPrRetryTest.php
@@ -47,7 +47,7 @@ test('retryPullRequestOpen dispatches the OpenPullRequestJob end-to-end', functi
                 'html_url' => 'https://github.com/o/r/pull/77',
                 'number' => 77,
                 'id' => 7,
-                'head' => ['ref' => 'specify/feature/story'],
+                'head' => ['ref' => 'specify/feature/story', 'repo' => ['full_name' => 'o/r']],
             ],
         ], 200),
     ]);
@@ -198,7 +198,7 @@ test('OpenPullRequestJob adopts an existing open PR rather than opening a duplic
                 'html_url' => 'https://github.com/o/r/pull/7',
                 'number' => 7,
                 'id' => 70,
-                'head' => ['ref' => 'specify/feature/story'],
+                'head' => ['ref' => 'specify/feature/story', 'repo' => ['full_name' => 'o/r']],
             ],
         ], 200),
     ]);
@@ -293,4 +293,109 @@ test('Run console exposes Retry PR on Succeeded runs with pull_request_error', f
     ])
         ->call('setTab', 'pr')
         ->assertSee('Retry PR open');
+});
+
+test('GithubPullRequestProvider::findOpenPullRequest skips fork PRs whose head.ref collides with a same-repo branch', function () {
+    // Same head.ref, different head repo — must be ignored. Otherwise a
+    // fork PR for the same branch name would be adopted and stamped on
+    // a Specify run that opened a PR on the destination repo, causing
+    // notifications to point at the wrong PR.
+    Http::fake(function ($request) {
+        if ($request->method() === 'GET') {
+            return Http::response([
+                [
+                    'html_url' => 'https://github.com/forker/r/pull/1',
+                    'number' => 1,
+                    'id' => 1,
+                    'head' => [
+                        'ref' => 'specify/feature/story',
+                        'repo' => ['full_name' => 'forker/r'],
+                    ],
+                ],
+            ], 200);
+        }
+
+        // POST = createPullRequest. Simulate GitHub's "PR already exists"
+        // 422 — a real test for "fork PR was not adopted" is that we
+        // actually attempted to create.
+        return Http::response([
+            'message' => 'Validation Failed',
+            'errors' => [['message' => 'A pull request already exists for o:specify/feature/story.']],
+        ], 422);
+    });
+
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        'url' => 'https://github.com/o/r',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'previous attempt blew up'],
+    ]);
+
+    (new OpenPullRequestJob($run->id))->handle();
+
+    $fresh = $run->fresh();
+    expect($fresh->output)->not->toHaveKey('pull_request_url');
+    expect($fresh->output['pull_request_error'])->toContain('422');
+});
+
+test('GithubPullRequestProvider::findOpenPullRequest follows Link rel="next" pagination to find a match on a later page', function () {
+    // First page: 1 unrelated PR + a Link header pointing to page 2.
+    // Second page: the matching PR. The provider must follow the Link
+    // header rather than giving up after page 1.
+    Http::fakeSequence('api.github.com/*pulls*')
+        ->push([
+            [
+                'html_url' => 'https://github.com/o/r/pull/1',
+                'number' => 1,
+                'id' => 1,
+                'head' => ['ref' => 'unrelated/branch', 'repo' => ['full_name' => 'o/r']],
+            ],
+        ], 200, [
+            'Link' => '<https://api.github.com/repositories/1/pulls?state=open&per_page=100&page=2>; rel="next"',
+        ])
+        ->push([
+            [
+                'html_url' => 'https://github.com/o/r/pull/2',
+                'number' => 2,
+                'id' => 2,
+                'head' => ['ref' => 'specify/feature/story', 'repo' => ['full_name' => 'o/r']],
+            ],
+        ], 200);
+
+    $story = approvedStoryInProjectWithRepo();
+    $repo = $story->feature->project->primaryRepo();
+    $repo->forceFill([
+        'provider' => RepoProvider::Github,
+        'access_token' => 'tok',
+        'url' => 'https://github.com/o/r',
+        'default_branch' => 'main',
+    ])->save();
+    $subtask = $story->tasks()->first()->subtasks()->first();
+
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'fake',
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_error' => 'previous attempt blew up'],
+    ]);
+
+    (new OpenPullRequestJob($run->id))->handle();
+
+    expect($run->fresh()->output['pull_request_url'])->toBe('https://github.com/o/r/pull/2');
 });


### PR DESCRIPTION
## Summary
- **GithubPullRequestProvider::findOpenPullRequest:** drop the brittle \`head=user:branch\` query filter (silently returns [] for same-repo PRs with slashed heads — every Specify branch is \`specify/<feature>/<story>\`). List open PRs page 1, match \`head.ref\` client-side. Verified end-to-end: Retry PR open now adopts the upstream PR instead of falling through to create() → 422.
- **scripts/harness-check.sh:** guard against a deleted-cwd state. Stop hook + harness-check run from whatever cwd the parent shell has; a prior test that deleted a tempdir we were inside leaves every subprocess unable to even resolve \`composer\`. \`pwd -P\` failure → \`cd \$CLAUDE_PROJECT_DIR\` (or fallback to script's project root).

## Why
Two follow-ups from the ADR-0010 PR #12 smoke that I noted but didn't fix in that PR's scope.

## Test plan
- [x] \`composer test\` — 320/320 (test fakes updated for the new GET method-based matching).
- [x] Live smoke: reset run #46 to PR-error state, click Retry PR open, confirm UI re-renders with the adopted PR URL and error callout gone.
- [x] \`bash scripts/harness-check.sh\` from a deleted-cwd state lands on the project root and runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)