### PR TITLE
feat: surface the PR at the Story level (primacy fix)

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\AgentRunKind;
 use App\Enums\StoryStatus;
 use App\Models\Concerns\HasSlug;
 use App\Services\ApprovalService;
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 
 /**
@@ -117,6 +119,103 @@ class Story extends Model
     public function agentRuns(): MorphMany
     {
         return $this->morphMany(AgentRun::class, 'runnable');
+    }
+
+    /**
+     * Pull requests associated with this Story — the PR is a Story-level
+     * artefact (every Subtask AgentRun on a single-driver story commits to
+     * the same `specify/<feature>/<story>` branch; the first run opens the
+     * PR, the rest add commits). Race mode (ADR-0006) opens N PRs, one per
+     * driver branch — each is a separate entry in the returned collection.
+     *
+     * Pulled from each Execute-kind Subtask AgentRun whose output carries
+     * a `pull_request_url`. RespondToReview runs (ADR-0008) are excluded
+     * because they push commits to an already-open PR; their
+     * `pull_request_number` is just a back-pointer, not a new PR.
+     *
+     * Each entry: `{ url, number, driver, branch, run_id, merged, action,
+     * opened_at }`. Ordered by most recent first; the merged one (if any)
+     * is hoisted to the top.
+     *
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function pullRequests(): Collection
+    {
+        $subtaskIds = $this->tasks()
+            ->with('subtasks:id,task_id')
+            ->get()
+            ->flatMap(fn ($t) => $t->subtasks->pluck('id'))
+            ->all();
+
+        if ($subtaskIds === []) {
+            return collect();
+        }
+
+        $entries = AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->whereIn('runnable_id', $subtaskIds)
+            ->where('kind', AgentRunKind::Execute->value)
+            ->whereJsonContainsKey('output->pull_request_url')
+            ->orderByDesc('id')
+            ->get(['id', 'executor_driver', 'working_branch', 'output', 'finished_at'])
+            ->map(function (AgentRun $run) {
+                $o = (array) $run->output;
+                $url = (string) ($o['pull_request_url'] ?? '');
+                if ($url === '') {
+                    return null;
+                }
+
+                return [
+                    'url' => $url,
+                    'number' => $o['pull_request_number'] ?? null,
+                    'driver' => $run->executor_driver,
+                    'branch' => $run->working_branch,
+                    'run_id' => $run->getKey(),
+                    'merged' => $o['pull_request_merged'] ?? null,
+                    'action' => $o['pull_request_action'] ?? null,
+                    'opened_at' => $run->finished_at,
+                ];
+            })
+            ->filter()
+            ->values();
+
+        // Deduplicate on URL: when a PR retry adopts an already-open PR
+        // every retried run records the same URL. Keep the freshest one
+        // (the most recent run wins because we ordered by id desc).
+        $entries = $entries
+            ->groupBy('url')
+            ->map(fn (Collection $g) => $g->first())
+            ->values();
+
+        // Hoist merged PRs to the top.
+        return $entries
+            ->sortBy(fn ($pr) => $pr['merged'] === true ? 0 : 1)
+            ->values();
+    }
+
+    /**
+     * The single canonical PR for this Story, if there is one. Returns
+     * the merged PR if any sibling has been merged; otherwise the sole
+     * entry in single-driver mode; otherwise null in pre-merge race mode
+     * where the candidates are still equally valid.
+     *
+     * Use `pullRequests()` when you want to render every candidate.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function primaryPullRequest(): ?array
+    {
+        $prs = $this->pullRequests();
+        if ($prs->isEmpty()) {
+            return null;
+        }
+
+        $merged = $prs->first(fn ($pr) => $pr['merged'] === true);
+        if ($merged !== null) {
+            return $merged;
+        }
+
+        return $prs->count() === 1 ? $prs->first() : null;
     }
 
     public function effectivePolicy(): ApprovalPolicy

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -134,8 +134,10 @@ class Story extends Model
      * `pull_request_number` is just a back-pointer, not a new PR.
      *
      * Each entry: `{ url, number, driver, branch, run_id, merged, action,
-     * opened_at }`. Ordered by most recent first; the merged one (if any)
-     * is hoisted to the top.
+     * run_finished_at }`. `run_finished_at` is the terminal timestamp of
+     * the AgentRun that recorded the PR, *not* the PR's upstream open
+     * time — we don't fetch that. Ordered by most recent run first; any
+     * merged PR is hoisted to the top.
      *
      * @return Collection<int, array<string, mixed>>
      */
@@ -173,7 +175,13 @@ class Story extends Model
                     'run_id' => $run->getKey(),
                     'merged' => $o['pull_request_merged'] ?? null,
                     'action' => $o['pull_request_action'] ?? null,
-                    'opened_at' => $run->finished_at,
+                    // The run's terminal timestamp — *not* the PR's open
+                    // time. We don't fetch the upstream PR's created_at;
+                    // this is the closest proxy for "when did Specify
+                    // first know about this PR" without an extra API
+                    // call. Rename the key so callers don't think it's
+                    // an authoritative PR timestamp.
+                    'run_finished_at' => $run->finished_at,
                 ];
             })
             ->filter()
@@ -187,9 +195,15 @@ class Story extends Model
             ->map(fn (Collection $g) => $g->first())
             ->values();
 
-        // Hoist merged PRs to the top.
+        // Hoist merged PRs to the top while preserving the id-desc order
+        // within each partition. A compound sort key (merged-bit, then
+        // -run_id) is order-stable across PHP / Laravel versions and
+        // doesn't depend on Collection::sortBy's stability semantics.
         return $entries
-            ->sortBy(fn ($pr) => $pr['merged'] === true ? 0 : 1)
+            ->sortBy(fn ($pr) => [
+                $pr['merged'] === true ? 0 : 1,
+                -1 * (int) $pr['run_id'],
+            ])
             ->values();
     }
 

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -666,6 +666,49 @@ new #[Title('Story')] class extends Component {
                         <flux:badge>{{ __('by') }} {{ $story->creator->name }}</flux:badge>
                     @endif
                 </div>
+
+                @php $storyPrs = $story->pullRequests(); @endphp
+                @if ($storyPrs->isNotEmpty())
+                    <div class="mt-3 flex flex-col gap-1.5" data-section="story-prs">
+                        <div class="flex items-baseline gap-2">
+                            <flux:text class="text-xs uppercase tracking-wide text-zinc-500">
+                                {{ trans_choice('Pull request|Pull requests', $storyPrs->count()) }}
+                            </flux:text>
+                            @if ($storyPrs->count() > 1)
+                                <flux:text class="text-xs text-zinc-400">
+                                    {{ __('race candidates — reviewer picks the winner by merging it') }}
+                                </flux:text>
+                            @endif
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            @foreach ($storyPrs as $pr)
+                                <div class="flex flex-wrap items-center gap-2 text-sm">
+                                    <flux:badge size="sm" :color="$pr['merged'] === true ? 'emerald' : 'zinc'">
+                                        @if ($pr['merged'] === true)
+                                            {{ __('merged') }}
+                                        @elseif ($pr['merged'] === false)
+                                            {{ __('open') }}
+                                        @else
+                                            {{ __('PR') }}
+                                        @endif
+                                        @if ($pr['number'])
+                                            #{{ $pr['number'] }}
+                                        @endif
+                                    </flux:badge>
+                                    <a
+                                        href="{{ $pr['url'] }}"
+                                        target="_blank"
+                                        rel="noopener"
+                                        class="truncate text-zinc-700 underline decoration-dotted hover:decoration-solid dark:text-zinc-300"
+                                    >{{ $pr['url'] }}</a>
+                                    @if ($pr['driver'])
+                                        <flux:badge size="sm" icon="cpu-chip">{{ $pr['driver'] }}</flux:badge>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
             @endif
         </div>
 

--- a/tests/Feature/StoryPullRequestsTest.php
+++ b/tests/Feature/StoryPullRequestsTest.php
@@ -143,6 +143,61 @@ test('primaryPullRequest hoists the merged sibling and pullRequests sorts it fir
     expect($primary['url'])->toBe('https://github.com/o/r/pull/101');
 });
 
+test('pullRequests preserves run-id-desc order within the unmerged partition when hoisting a merged PR', function () {
+    // Compound sort key: (merged, -run_id). Without it the order of
+    // non-merged candidates can drift across PHP/Laravel versions —
+    // reviewers reading the candidate list would see entries shuffle.
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+
+    foreach ([
+        ['driver' => 'a', 'number' => 1, 'merged' => null],
+        ['driver' => 'b', 'number' => 2, 'merged' => true],
+        ['driver' => 'c', 'number' => 3, 'merged' => null],
+        ['driver' => 'd', 'number' => 4, 'merged' => null],
+    ] as $row) {
+        AgentRun::factory()->create([
+            'runnable_type' => Subtask::class,
+            'runnable_id' => $subtask->id,
+            'status' => AgentRunStatus::Succeeded,
+            'kind' => AgentRunKind::Execute,
+            'executor_driver' => $row['driver'],
+            'output' => [
+                'pull_request_url' => 'https://github.com/o/r/pull/'.$row['number'],
+                'pull_request_number' => $row['number'],
+                'pull_request_merged' => $row['merged'],
+            ],
+        ]);
+    }
+
+    $prs = $story->pullRequests();
+
+    // Merged hoisted; remaining are run-id desc (insertion order: a,b,c,d
+    // → ids 1,2,3,4 → desc among non-merged is d,c,a, with merged b on top).
+    expect($prs->pluck('driver')->all())->toMatchArray(['b', 'd', 'c', 'a']);
+});
+
+test('pullRequests entries expose run_finished_at, not opened_at', function () {
+    // Renamed in review feedback: opened_at implied an authoritative PR
+    // open timestamp; we only have the AgentRun's terminal time.
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+        'kind' => AgentRunKind::Execute,
+        'finished_at' => now(),
+        'output' => ['pull_request_url' => 'https://github.com/o/r/pull/1'],
+    ]);
+
+    $entry = $story->pullRequests()->first();
+    expect($entry)->toHaveKey('run_finished_at');
+    expect($entry)->not->toHaveKey('opened_at');
+});
+
 test('pullRequests excludes RespondToReview-kind runs (those just push commits, not PRs)', function () {
     $story = Story::factory()->create();
     $task = Task::factory()->for($story)->create();

--- a/tests/Feature/StoryPullRequestsTest.php
+++ b/tests/Feature/StoryPullRequestsTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use App\Enums\AgentRunKind;
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function storyWithSubtaskAndRun(array $output, array $runOverrides = []): array
+{
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+    $run = AgentRun::factory()->create(array_merge([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+        'kind' => AgentRunKind::Execute,
+        'output' => $output,
+    ], $runOverrides));
+
+    return ['story' => $story, 'subtask' => $subtask, 'run' => $run];
+}
+
+test('pullRequests returns empty when no run has opened a PR', function () {
+    $s = storyWithSubtaskAndRun(['summary' => 'noop']);
+
+    expect($s['story']->pullRequests())->toBeEmpty();
+    expect($s['story']->primaryPullRequest())->toBeNull();
+});
+
+test('pullRequests surfaces a single-driver PR as primary', function () {
+    $s = storyWithSubtaskAndRun([
+        'pull_request_url' => 'https://github.com/o/r/pull/42',
+        'pull_request_number' => 42,
+    ], ['executor_driver' => 'cli']);
+
+    $prs = $s['story']->pullRequests();
+    expect($prs)->toHaveCount(1);
+    expect($prs->first()['url'])->toBe('https://github.com/o/r/pull/42');
+    expect($prs->first()['driver'])->toBe('cli');
+
+    $primary = $s['story']->primaryPullRequest();
+    expect($primary)->not->toBeNull();
+    expect($primary['url'])->toBe('https://github.com/o/r/pull/42');
+});
+
+test('pullRequests deduplicates retries that adopted the same upstream PR', function () {
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+
+    // Two AgentRuns on the same Subtask both adopting the same PR — e.g.
+    // the original run's PR-open failed and a later retry adopted it via
+    // findOpenPullRequest. The dedup keeps only the most recent.
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'kind' => AgentRunKind::Execute,
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_url' => 'https://github.com/o/r/pull/9'],
+    ]);
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'kind' => AgentRunKind::Execute,
+        'status' => AgentRunStatus::Succeeded,
+        'output' => ['pull_request_url' => 'https://github.com/o/r/pull/9'],
+    ]);
+
+    expect($story->pullRequests())->toHaveCount(1);
+});
+
+test('pullRequests in race mode surfaces every sibling and primary is null until merge', function () {
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+
+    foreach (['cli' => 21, 'specify' => 22, 'codex' => 23] as $driver => $number) {
+        AgentRun::factory()->create([
+            'runnable_type' => Subtask::class,
+            'runnable_id' => $subtask->id,
+            'status' => AgentRunStatus::Succeeded,
+            'kind' => AgentRunKind::Execute,
+            'executor_driver' => $driver,
+            'working_branch' => 'specify/feature/story-by-'.$driver,
+            'output' => [
+                'pull_request_url' => 'https://github.com/o/r/pull/'.$number,
+                'pull_request_number' => $number,
+            ],
+        ]);
+    }
+
+    $prs = $story->pullRequests();
+    expect($prs)->toHaveCount(3);
+    // Ordered most-recent first (sorted by run id desc); insertion order
+    // was cli, specify, codex so the freshest run comes back first.
+    expect($prs->pluck('driver')->all())->toMatchArray(['codex', 'specify', 'cli']);
+
+    // Pre-merge race mode: no canonical PR.
+    expect($story->primaryPullRequest())->toBeNull();
+});
+
+test('primaryPullRequest hoists the merged sibling and pullRequests sorts it first', function () {
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+        'kind' => AgentRunKind::Execute,
+        'executor_driver' => 'cli',
+        'output' => [
+            'pull_request_url' => 'https://github.com/o/r/pull/100',
+            'pull_request_number' => 100,
+            'pull_request_merged' => false,
+        ],
+    ]);
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+        'kind' => AgentRunKind::Execute,
+        'executor_driver' => 'specify',
+        'output' => [
+            'pull_request_url' => 'https://github.com/o/r/pull/101',
+            'pull_request_number' => 101,
+            'pull_request_merged' => true,
+        ],
+    ]);
+
+    $prs = $story->pullRequests();
+    expect($prs->first()['merged'])->toBeTrue();
+    expect($prs->first()['number'])->toBe(101);
+
+    $primary = $story->primaryPullRequest();
+    expect($primary['url'])->toBe('https://github.com/o/r/pull/101');
+});
+
+test('pullRequests excludes RespondToReview-kind runs (those just push commits, not PRs)', function () {
+    $story = Story::factory()->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+        'kind' => AgentRunKind::RespondToReview,
+        'output' => [
+            'pull_request_url' => 'https://github.com/o/r/pull/55',
+            'pull_request_number' => 55,
+        ],
+    ]);
+
+    expect($story->pullRequests())->toBeEmpty();
+});


### PR DESCRIPTION
## Summary
- The PR is a Story-level artefact (per-Story branch, all Subtask runs commit to it). Until now it was only surfaced on the originating Subtask's run page; reviewers had to drill three levels down. This PR gives it primacy at the Story document.
- Adds \`Story::pullRequests()\` (collection) and \`Story::primaryPullRequest()\` (single canonical entry, or null when race mode is still pre-merge).
- Renders right under the Story header: \`PR #N\` + URL + driver badge per entry. Race mode (ADR-0006) shows all N candidates; once one merges via webhook it hoists to the top.
- Excludes RespondToReview-kind runs (ADR-0008) — those push commits to an already-open PR, not a new PR.

## Resolution model for race mode
Doesn't try to pick a single canonical PR pre-merge. Each driver's PR is rendered as a candidate; reviewer picks the winner by merging one (matches ADR-0006). \`primaryPullRequest()\` returns null in that state — callers that need a single answer can fall back to \`pullRequests()->first()\`.

## Test plan
- [x] \`composer test\` — 326/326 (6 new).
- [x] Live smoke on Story #11: PR card renders at the top of the document with the adopted PR URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)