### PR TITLE
feat(adr-0011): streaming progress events (Phase A + B)

### DIFF
--- a/app/Http/Controllers/RunEventsController.php
+++ b/app/Http/Controllers/RunEventsController.php
@@ -6,6 +6,7 @@ use App\Models\AgentRun;
 use App\Models\AgentRunEvent;
 use App\Models\Story;
 use App\Models\Subtask;
+use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -49,7 +50,7 @@ class RunEventsController extends Controller
         ]);
     }
 
-    private function canSee($user, AgentRun $run): bool
+    private function canSee(User $user, AgentRun $run): bool
     {
         $accessible = $user->accessibleProjectIds();
 

--- a/app/Http/Controllers/RunEventsController.php
+++ b/app/Http/Controllers/RunEventsController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AgentRun;
+use App\Models\AgentRunEvent;
+use App\Models\Story;
+use App\Models\Subtask;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * ADR-0011 HTTP poll endpoint: clients advance a per-run cursor to fetch
+ * progress events written by `ProgressEmitter`. Reverb broadcast (Phase C)
+ * layers over the same rows; the poll is the always-available fallback.
+ */
+class RunEventsController extends Controller
+{
+    public function __invoke(Request $request, AgentRun $run): JsonResponse
+    {
+        $user = $request->user();
+        abort_if($user === null, 401);
+
+        if (! $this->canSee($user, $run)) {
+            abort(404);
+        }
+
+        $after = (int) $request->query('after', 0);
+        $limit = max(1, min(500, (int) $request->query('limit', 200)));
+
+        $events = AgentRunEvent::query()
+            ->where('agent_run_id', $run->getKey())
+            ->where('seq', '>', $after)
+            ->orderBy('seq')
+            ->limit($limit)
+            ->get(['id', 'seq', 'phase', 'type', 'payload', 'ts']);
+
+        return response()->json([
+            'run_id' => $run->getKey(),
+            'cursor' => $events->isEmpty() ? $after : (int) $events->last()->seq,
+            'status' => $run->status->value,
+            'events' => $events->map(fn (AgentRunEvent $e) => [
+                'seq' => $e->seq,
+                'phase' => $e->phase,
+                'type' => $e->type,
+                'payload' => $e->payload,
+                'ts' => optional($e->ts)->toIso8601String(),
+            ])->all(),
+        ]);
+    }
+
+    private function canSee($user, AgentRun $run): bool
+    {
+        $accessible = $user->accessibleProjectIds();
+
+        if ($run->runnable_type === Story::class) {
+            $story = Story::with('feature')->find($run->runnable_id);
+
+            return $story !== null
+                && in_array($story->feature->project_id, $accessible, true);
+        }
+
+        if ($run->runnable_type === Subtask::class) {
+            $subtask = Subtask::with('task.story.feature')->find($run->runnable_id);
+
+            return $subtask?->task?->story !== null
+                && in_array($subtask->task->story->feature->project_id, $accessible, true);
+        }
+
+        return false;
+    }
+}

--- a/app/Models/AgentRunEvent.php
+++ b/app/Models/AgentRunEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\AgentRunEventFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use RuntimeException;
+
+/**
+ * ADR-0011: append-only progress event for an AgentRun.
+ *
+ * Emitted by `ProgressEmitter` from inside cooperating Executors as work
+ * happens (stdout line, tool call, sentinel, etc). The HTTP-poll endpoint
+ * reads this table; Reverb broadcasts (Phase C) layer over the same writes.
+ *
+ * Append-only by contract — once written a row is never updated or deleted
+ * outside the cascade from `agent_runs` (which itself never deletes).
+ */
+#[Fillable([
+    'agent_run_id', 'seq', 'phase', 'type', 'payload', 'ts',
+])]
+class AgentRunEvent extends Model
+{
+    /** @use HasFactory<AgentRunEventFactory> */
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::deleting(fn () => throw new RuntimeException('Agent run events are immutable; deletion not allowed.'));
+        static::updating(fn () => throw new RuntimeException('Agent run events are immutable; updates not allowed.'));
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'seq' => 'integer',
+            'payload' => 'array',
+            'ts' => 'datetime',
+        ];
+    }
+
+    public function agentRun(): BelongsTo
+    {
+        return $this->belongsTo(AgentRun::class);
+    }
+}

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -4,6 +4,7 @@ namespace App\Services\Executors;
 
 use App\Models\Repo;
 use App\Models\Subtask;
+use App\Services\Progress\ProgressEmitter;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 
@@ -27,12 +28,17 @@ class CliExecutor implements Executor
         return true;
     }
 
+    public function supportsProgressEvents(): bool
+    {
+        return true;
+    }
+
     /**
      * Pipe a prompt to the CLI, run it in `$workingDir`, and report changed files.
      *
      * @throws RuntimeException When `$workingDir` is null or the CLI exits non-zero.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
     {
         if ($workingDir === null) {
             throw new RuntimeException('CliExecutor requires a working directory.');
@@ -46,7 +52,12 @@ class CliExecutor implements Executor
         $process = new Process($this->command, $workingDir);
         $process->setTimeout($this->timeout);
         $process->setInput($prompt);
-        $process->run();
+
+        if ($emitter !== null) {
+            $this->runStreaming($process, $emitter);
+        } else {
+            $process->run();
+        }
 
         if (! $process->isSuccessful()) {
             throw new RuntimeException(sprintf(
@@ -71,6 +82,44 @@ class CliExecutor implements Executor
             alreadyComplete: $alreadyComplete,
             alreadyCompleteEvidence: $alreadyCompleteEvidence,
         );
+    }
+
+    /**
+     * Stream the process, emitting one stdout/stderr event per line and a
+     * `sentinel` event when the ADR-0007 already-complete block flushes.
+     *
+     * Symfony's Process callback can be invoked mid-line on partial reads, so
+     * we buffer per-stream until a newline arrives. Anything left in the
+     * buffer at exit is flushed as a final event.
+     */
+    private function runStreaming(Process $process, ProgressEmitter $emitter): void
+    {
+        $buffers = ['stdout' => '', 'stderr' => ''];
+        $sentinelSeen = false;
+
+        $process->run(function (string $type, string $chunk) use ($emitter, &$buffers, &$sentinelSeen) {
+            $stream = $type === Process::OUT ? 'stdout' : 'stderr';
+            $buffers[$stream] .= $chunk;
+
+            while (($nl = strpos($buffers[$stream], "\n")) !== false) {
+                $line = substr($buffers[$stream], 0, $nl);
+                $buffers[$stream] = substr($buffers[$stream], $nl + 1);
+                $line = rtrim($line, "\r");
+
+                $emitter->emit($stream, ['line' => $line]);
+
+                if (! $sentinelSeen && $stream === 'stdout' && str_contains($line, '<<<SPECIFY:already_complete>>>')) {
+                    $sentinelSeen = true;
+                    $emitter->emit('sentinel', ['name' => 'already_complete']);
+                }
+            }
+        });
+
+        foreach ($buffers as $stream => $rest) {
+            if ($rest !== '') {
+                $emitter->emit($stream, ['line' => rtrim($rest, "\r")]);
+            }
+        }
     }
 
     /**

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -97,27 +97,30 @@ class CliExecutor implements Executor
         $buffers = ['stdout' => '', 'stderr' => ''];
         $sentinelSeen = false;
 
-        $process->run(function (string $type, string $chunk) use ($emitter, &$buffers, &$sentinelSeen) {
+        $emit = function (string $stream, string $line) use ($emitter, &$sentinelSeen): void {
+            $emitter->emit($stream, ['line' => $line]);
+
+            if (! $sentinelSeen && $stream === 'stdout' && str_contains($line, '<<<SPECIFY:already_complete>>>')) {
+                $sentinelSeen = true;
+                $emitter->emit('sentinel', ['name' => 'already_complete']);
+            }
+        };
+
+        $process->run(function (string $type, string $chunk) use ($emit, &$buffers): void {
             $stream = $type === Process::OUT ? 'stdout' : 'stderr';
             $buffers[$stream] .= $chunk;
 
             while (($nl = strpos($buffers[$stream], "\n")) !== false) {
-                $line = substr($buffers[$stream], 0, $nl);
+                $line = rtrim(substr($buffers[$stream], 0, $nl), "\r");
                 $buffers[$stream] = substr($buffers[$stream], $nl + 1);
-                $line = rtrim($line, "\r");
 
-                $emitter->emit($stream, ['line' => $line]);
-
-                if (! $sentinelSeen && $stream === 'stdout' && str_contains($line, '<<<SPECIFY:already_complete>>>')) {
-                    $sentinelSeen = true;
-                    $emitter->emit('sentinel', ['name' => 'already_complete']);
-                }
+                $emit($stream, $line);
             }
         });
 
         foreach ($buffers as $stream => $rest) {
             if ($rest !== '') {
-                $emitter->emit($stream, ['line' => rtrim($rest, "\r")]);
+                $emit($stream, rtrim($rest, "\r"));
             }
         }
     }

--- a/app/Services/Executors/Executor.php
+++ b/app/Services/Executors/Executor.php
@@ -4,6 +4,7 @@ namespace App\Services\Executors;
 
 use App\Models\Repo;
 use App\Models\Subtask;
+use App\Services\Progress\ProgressEmitter;
 
 /**
  * Strategy that performs the engineering work for one Subtask.
@@ -22,6 +23,15 @@ interface Executor
     public function needsWorkingDirectory(): bool;
 
     /**
+     * Capability flag (ADR-0011). When true, the pipeline constructs a
+     * `ProgressEmitter` for the run and passes it to `execute()`; the
+     * driver emits typed events as work happens. Drivers that return
+     * false receive `null` and do nothing differently — backwards
+     * compatibility for existing impls.
+     */
+    public function supportsProgressEvents(): bool;
+
+    /**
      * Run the executor against a Subtask.
      *
      * `$contextBrief`, when non-null, is a markdown block produced by a
@@ -29,6 +39,11 @@ interface Executor
      * recent activity in the repo, and prior failed runs. Implementations
      * should prepend it to the user prompt so the model orients faster.
      * Defaults to null so existing tests and minimal drivers remain valid.
+     *
+     * `$emitter`, when non-null (only passed when `supportsProgressEvents()`
+     * is true — ADR-0011), is the per-run progress channel. Drivers call
+     * `$emitter->emit($type, $payload)` from within tool-call hooks /
+     * stdout handlers / sentinel parsers to surface live events.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult;
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult;
 }

--- a/app/Services/Executors/FakeExecutor.php
+++ b/app/Services/Executors/FakeExecutor.php
@@ -5,6 +5,7 @@ namespace App\Services\Executors;
 use App\Ai\Agents\SubtaskExecutor;
 use App\Models\Repo;
 use App\Models\Subtask;
+use App\Services\Progress\ProgressEmitter;
 
 /**
  * Test/no-op executor: invokes the agent (so SubtaskExecutor::fake() interception works)
@@ -18,7 +19,12 @@ class FakeExecutor implements Executor
         return false;
     }
 
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+    public function supportsProgressEvents(): bool
+    {
+        return false;
+    }
+
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
     {
         // Pass a real (but throwaway) directory so SubtaskExecutor::tools() can construct
         // a Sandbox during fake/test invocations. The tools are never actually called

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -5,6 +5,7 @@ namespace App\Services\Executors;
 use App\Ai\Agents\SubtaskExecutor;
 use App\Models\Repo;
 use App\Models\Subtask;
+use App\Services\Progress\ProgressEmitter;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
@@ -25,6 +26,11 @@ class LaravelAiExecutor implements Executor
         return true;
     }
 
+    public function supportsProgressEvents(): bool
+    {
+        return false;
+    }
+
     /**
      * Run the agent loop and translate its final output into an `ExecutionResult`.
      *
@@ -32,7 +38,7 @@ class LaravelAiExecutor implements Executor
      *                          or when the agent terminates without producing
      *                          summary/files/commit-message fields.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
     {
         $context = [
             'subtask_id' => $subtask->getKey(),

--- a/app/Services/Progress/ProgressEmitter.php
+++ b/app/Services/Progress/ProgressEmitter.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\Progress;
+
+use App\Models\AgentRun;
+use App\Models\AgentRunEvent;
+
+/**
+ * ADR-0011: writes one progress-event row per `emit()` call against an
+ * AgentRun. Keeps the per-run sequence counter in memory so the
+ * pipeline's typical "executor → emit → emit → emit" hot path doesn't
+ * round-trip to the DB for the next-seq lookup. The first emit on a run
+ * primes the counter from MAX(seq).
+ *
+ * Phase A scope: synchronous DB writes only. Reverb broadcast (Phase C)
+ * and 250ms batching (ADR-0011 mitigation for write amplification) layer
+ * on top of this surface; both wrap `emit()` rather than replace it.
+ */
+class ProgressEmitter
+{
+    private int $seq = 0;
+
+    private bool $primed = false;
+
+    private string $phase = 'execute';
+
+    public function __construct(public readonly AgentRun $agentRun) {}
+
+    /**
+     * Set the pipeline phase that subsequent events are tagged with.
+     * Called by SubtaskRunPipeline at phase boundaries; executors don't
+     * touch this directly.
+     */
+    public function setPhase(string $phase): void
+    {
+        $this->phase = $phase;
+    }
+
+    /**
+     * Persist one event. Returns the new AgentRunEvent so callers can
+     * inspect seq / id (used by the broadcast layer in Phase C).
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function emit(string $type, array $payload = []): AgentRunEvent
+    {
+        if (! $this->primed) {
+            $this->seq = (int) AgentRunEvent::query()
+                ->where('agent_run_id', $this->agentRun->getKey())
+                ->max('seq');
+            $this->primed = true;
+        }
+
+        $this->seq++;
+
+        return AgentRunEvent::create([
+            'agent_run_id' => $this->agentRun->getKey(),
+            'seq' => $this->seq,
+            'phase' => $this->phase,
+            'type' => $type,
+            'payload' => $payload,
+            'ts' => now(),
+        ]);
+    }
+}

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -8,6 +8,7 @@ use App\Models\Subtask;
 use App\Services\Context\ContextBuilder;
 use App\Services\Executors\Executor;
 use App\Services\Executors\ProposedSubtask;
+use App\Services\Progress\ProgressEmitter;
 use App\Services\PullRequests\PrPayloadBuilder;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
@@ -58,6 +59,8 @@ class SubtaskRunPipeline
             'executor_driver' => $agentRun->executor_driver,
         ]);
 
+        $emitter = $executor->supportsProgressEvents() ? new ProgressEmitter($agentRun) : null;
+
         if ($this->cancelObserved($agentRun, 'before_prepare', $logCtx)) {
             return SubtaskRunOutcome::cancelled();
         }
@@ -70,6 +73,7 @@ class SubtaskRunPipeline
                 throw new RuntimeException('Executor requires a repo, but none is bound to this AgentRun.');
             }
 
+            $emitter?->setPhase('prepare');
             $branch = $this->branchFor($agentRun);
             $workingDir = $this->workspace->prepare($repo, $agentRun);
             $this->workspace->checkoutBranch($workingDir, $branch, baseBranch: $repo->default_branch);
@@ -96,7 +100,8 @@ class SubtaskRunPipeline
             ])->save();
         }
 
-        $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null);
+        $emitter?->setPhase('execute');
+        $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null, $emitter);
 
         if ($this->cancelObserved($agentRun, 'after_execute', $logCtx)) {
             $this->discardLocalChangesIfPossible($workingDir, $agentRun, $repo, $logCtx);
@@ -118,6 +123,7 @@ class SubtaskRunPipeline
             return SubtaskRunOutcome::succeeded($output, $diff);
         }
 
+        $emitter?->setPhase('commit');
         $commitSha = $this->workspace->commit($workingDir, $result->commitMessage ?: 'specify: agent run');
         $diff = $this->workspace->diff($workingDir);
 
@@ -179,12 +185,14 @@ class SubtaskRunPipeline
                 return SubtaskRunOutcome::cancelled();
             }
 
+            $emitter?->setPhase('push');
             $branch = $this->branchFor($agentRun);
             $this->workspace->push($workingDir, $branch);
             $output['pushed'] = true;
             Log::info('specify.subtask.push', $logCtx);
 
             if (config('specify.workspace.open_pr_after_push', true) && $repo !== null) {
+                $emitter?->setPhase('open_pr');
                 $prResult = $this->openPullRequest($repo, $subtask, $branch, $output, $agentRun->executor_driver);
                 $output = array_merge($output, $prResult);
 

--- a/database/factories/AgentRunEventFactory.php
+++ b/database/factories/AgentRunEventFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AgentRun;
+use App\Models\AgentRunEvent;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AgentRunEvent>
+ */
+class AgentRunEventFactory extends Factory
+{
+    protected $model = AgentRunEvent::class;
+
+    public function definition(): array
+    {
+        return [
+            'agent_run_id' => AgentRun::factory(),
+            'seq' => 1,
+            'phase' => 'execute',
+            'type' => 'stdout',
+            'payload' => ['line' => 'fake'],
+            'ts' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_05_02_090000_create_agent_run_events_table.php
+++ b/database/migrations/2026_05_02_090000_create_agent_run_events_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR-0011: append-only stream of progress events from executors.
+ *
+ * Each row is one observable thing the run did at a point in time —
+ * stdout/stderr line, tool call, thinking marker, sentinel block. The
+ * HTTP-poll endpoint reads from this table; Reverb broadcasts (Phase C
+ * follow-up) layer over the same row writes for live latency.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_run_events', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('agent_run_id')->constrained('agent_runs')->cascadeOnDelete();
+
+            // Per-run monotonic sequence — the cursor the HTTP poll
+            // endpoint advances. The unique index on (run, seq) is the
+            // contract: clients refetching after=cursor get every event
+            // they haven't already seen, in order.
+            $t->unsignedInteger('seq');
+
+            // Pipeline phase the event was emitted in. Lets the future
+            // Timeline view filter by phase without reparsing payload.
+            $t->string('phase', 32)->nullable();
+
+            // tool_call | edit | shell | thinking | stdout | stderr |
+            // error | sentinel — the ADR-0011 type set; new types are
+            // additive (no enum cast — string keeps drivers free to
+            // emit ADR-driven types without a schema migration).
+            $t->string('type', 32);
+
+            $t->json('payload');
+            $t->timestamp('ts')->useCurrent();
+
+            $t->unique(['agent_run_id', 'seq']);
+            $t->index(['agent_run_id', 'ts']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_run_events');
+    }
+};

--- a/docs/adr/0011-streaming-progress-events-from-executors.md
+++ b/docs/adr/0011-streaming-progress-events-from-executors.md
@@ -1,7 +1,7 @@
 # 0011. Streaming progress events from executors
 
 Date: 2026-05-02
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -3,6 +3,7 @@
 use App\Enums\AgentRunKind;
 use App\Enums\AgentRunStatus;
 use App\Models\AgentRun;
+use App\Models\AgentRunEvent;
 use App\Models\Subtask;
 use App\Services\ExecutionService;
 use Illuminate\Support\Facades\Auth;
@@ -99,6 +100,22 @@ new #[Title('Run')] class extends Component {
             'subtask' => $this->subtask_id,
             'run' => $newRun->id,
         ]), navigate: true);
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, AgentRunEvent>
+     */
+    #[Computed]
+    public function events(): \Illuminate\Support\Collection
+    {
+        if (! $this->run) {
+            return collect();
+        }
+
+        return AgentRunEvent::query()
+            ->where('agent_run_id', $this->run->getKey())
+            ->orderBy('seq')
+            ->get();
     }
 
     #[Computed]
@@ -282,10 +299,26 @@ new #[Title('Run')] class extends Component {
 
                 @if ($tab === 'logs')
                     @php
+                        $events = $this->events;
                         $stdout = $run->output['stdout'] ?? null;
                         $stderr = $run->output['stderr'] ?? null;
                     @endphp
-                    @if ($stdout || $stderr)
+                    @if ($events->isNotEmpty())
+                        <div
+                            class="max-h-[40rem] overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 font-mono text-xs leading-snug dark:border-zinc-700 dark:bg-zinc-900"
+                            data-section="run-events"
+                            @if (! $run->isTerminal()) wire:poll.2s @endif
+                        >
+                            @foreach ($events as $event)
+                                <div class="flex gap-2" data-event-seq="{{ $event->seq }}" data-event-type="{{ $event->type }}">
+                                    <span class="w-12 shrink-0 text-right text-zinc-400">{{ $event->seq }}</span>
+                                    <span class="w-16 shrink-0 truncate text-zinc-500">{{ $event->phase }}</span>
+                                    <span class="w-16 shrink-0 truncate {{ $event->type === 'stderr' || $event->type === 'error' ? 'text-rose-600 dark:text-rose-400' : ($event->type === 'sentinel' ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500') }}">{{ $event->type }}</span>
+                                    <span class="min-w-0 flex-1 whitespace-pre-wrap break-words">{{ $event->payload['line'] ?? json_encode($event->payload) }}</span>
+                                </div>
+                            @endforeach
+                        </div>
+                    @elseif ($stdout || $stderr)
                         @if ($stdout)
                             <div>
                                 <div class="mb-1 text-xs uppercase tracking-wide text-zinc-500">{{ __('stdout') }}</div>
@@ -298,8 +331,10 @@ new #[Title('Run')] class extends Component {
                                 <pre class="max-h-[32rem] overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-3 font-mono text-xs leading-snug dark:border-zinc-700 dark:bg-zinc-900">{{ $stderr }}</pre>
                             </div>
                         @endif
+                    @elseif (! $run->isTerminal())
+                        <flux:text class="text-zinc-500" wire:poll.2s>{{ __('Waiting for the executor to emit events…') }}</flux:text>
                     @else
-                        <flux:text class="text-zinc-500">{{ __('No log output captured for this run. (ADR-0011 streaming events land here once implemented.)') }}</flux:text>
+                        <flux:text class="text-zinc-500">{{ __('No log output captured for this run.') }}</flux:text>
                     @endif
                 @elseif ($tab === 'diff')
                     @if ($diff)

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\SocialiteController;
+use App\Http\Controllers\RunEventsController;
 use App\Http\Controllers\Webhooks\GithubWebhookController;
 use App\Models\AgentRun;
 use App\Models\Story;
@@ -19,6 +20,8 @@ Route::get('auth/{provider}/callback', [SocialiteController::class, 'callback'])
     ->name('socialite.callback');
 
 Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('runs/{run}/events', RunEventsController::class)->name('runs.events');
+
     Route::livewire('dashboard', 'pages::dashboard')->name('dashboard');
     Route::livewire('triage', 'pages::triage')->name('triage');
     Route::livewire('activity', 'pages::activity.index')->name('activity.index');

--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -20,6 +20,19 @@ if ! pwd -P >/dev/null 2>&1; then
   cd "${CLAUDE_PROJECT_DIR:-$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")}" || exit 1
 fi
 
+# Disable Laravel Pao's pest output capture. Pao detects the agent
+# environment and swaps verbose pest output for a single JSON summary
+# line, which is great for protocol callers but useless here:
+#   - Multi-failure runs produce a JSON line longer than the Bash tool's
+#     output buffer and arrive truncated.
+#   - Fatals during pest's *test collection phase* (e.g. an anonymous
+#     class not satisfying a changed interface) abort before any result
+#     exists, so Pao's shutdown handler emits nothing at all — exit=2
+#     with zero output.
+# Both modes drop us into a silent retry loop. Verbose pest output is
+# what we actually want when the gate fails.
+export PAO_DISABLE=1
+
 step() {
   local label="$1"; shift
   echo "→ $label"

--- a/tests/Feature/ProgressEventsTest.php
+++ b/tests/Feature/ProgressEventsTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Enums\StoryStatus;
+use App\Models\AcceptanceCriterion;
+use App\Models\AgentRun;
+use App\Models\AgentRunEvent;
+use App\Models\ApprovalPolicy;
+use App\Models\Repo;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\ExecutionService;
+use App\Services\Executors\CliExecutor;
+use App\Services\Executors\Executor;
+use App\Services\Executors\FakeExecutor;
+use App\Services\Executors\LaravelAiExecutor;
+use App\Services\Progress\ProgressEmitter;
+use App\Services\WorkspaceRunner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+
+uses(RefreshDatabase::class);
+
+afterEach(function () {
+    foreach (glob(sys_get_temp_dir().'/specify-*') as $path) {
+        is_file($path) ? @unlink($path) : File::deleteDirectory($path);
+    }
+});
+
+test('ProgressEmitter persists rows with monotonic seq scoped to the run', function () {
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->getKey(),
+        'status' => AgentRunStatus::Running->value,
+    ]);
+
+    $emitter = new ProgressEmitter($run);
+    $emitter->emit('stdout', ['line' => 'first']);
+    $emitter->emit('stdout', ['line' => 'second']);
+    $emitter->setPhase('commit');
+    $emitter->emit('stderr', ['line' => 'oops']);
+
+    $events = AgentRunEvent::where('agent_run_id', $run->getKey())->orderBy('seq')->get();
+
+    expect($events)->toHaveCount(3);
+    expect($events->pluck('seq')->all())->toBe([1, 2, 3]);
+    expect($events->pluck('phase')->all())->toBe(['execute', 'execute', 'commit']);
+    expect($events->pluck('type')->all())->toBe(['stdout', 'stdout', 'stderr']);
+    expect($events[0]->payload)->toBe(['line' => 'first']);
+});
+
+test('ProgressEmitter primes seq from the highest existing row', function () {
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create()->getKey(),
+        'status' => AgentRunStatus::Running->value,
+    ]);
+
+    AgentRunEvent::create([
+        'agent_run_id' => $run->getKey(),
+        'seq' => 7,
+        'phase' => 'execute',
+        'type' => 'stdout',
+        'payload' => ['line' => 'pre-existing'],
+        'ts' => now(),
+    ]);
+
+    (new ProgressEmitter($run))->emit('stdout', ['line' => 'next']);
+
+    expect(AgentRunEvent::where('agent_run_id', $run->getKey())->max('seq'))->toBe(8);
+});
+
+test('AgentRunEvent rows are immutable — update and delete throw', function () {
+    $event = AgentRunEvent::factory()->create();
+
+    expect(fn () => $event->update(['type' => 'changed']))
+        ->toThrow(RuntimeException::class, 'immutable');
+
+    expect(fn () => $event->delete())
+        ->toThrow(RuntimeException::class, 'immutable');
+});
+
+test('CliExecutor emits stdout / stderr / sentinel events when an emitter is passed', function () {
+    $bin = sys_get_temp_dir().'/specify-fake-agent-'.uniqid().'.sh';
+    File::put($bin, "#!/usr/bin/env bash\nset -e\ncat > /dev/null\necho 'hello'\necho 'oops' >&2\necho '<<<SPECIFY:already_complete>>>abc<<<END>>>'\n");
+    chmod($bin, 0o755);
+
+    $workingDir = sys_get_temp_dir().'/specify-cwd-'.uniqid();
+    File::ensureDirectoryExists($workingDir);
+    new Process(['git', '-c', 'init.defaultBranch=main', 'init'], $workingDir)->mustRun();
+    new Process(['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], $workingDir)->mustRun();
+
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => Subtask::factory()->create(['name' => 'x'])->getKey(),
+        'status' => AgentRunStatus::Running->value,
+    ]);
+
+    $emitter = new ProgressEmitter($run);
+    $emitter->setPhase('execute');
+
+    (new CliExecutor([$bin]))
+        ->execute($run->runnable, $workingDir, null, null, null, $emitter);
+
+    $events = AgentRunEvent::where('agent_run_id', $run->getKey())->orderBy('seq')->get();
+    $types = $events->pluck('type')->all();
+
+    expect($types)->toContain('stdout', 'stderr', 'sentinel');
+    $stdoutLines = $events->where('type', 'stdout')->pluck('payload.line')->all();
+    expect($stdoutLines)->toContain('hello');
+    expect($events->where('type', 'stderr')->pluck('payload.line')->all())->toContain('oops');
+    expect($events->where('type', 'sentinel')->first()->payload)->toBe(['name' => 'already_complete']);
+});
+
+test('CliExecutor.supportsProgressEvents()=true; LaravelAi/Fake=false', function () {
+    expect((new CliExecutor(['/bin/true']))->supportsProgressEvents())->toBeTrue();
+    expect((new LaravelAiExecutor)->supportsProgressEvents())->toBeFalse();
+    expect((new FakeExecutor)->supportsProgressEvents())->toBeFalse();
+});
+
+test('SubtaskRunPipeline tags events with the current phase and writes them under the run', function () {
+    config(['queue.default' => 'sync']);
+    config(['specify.executor.default' => 'cli']);
+    config(['specify.workspace.open_pr_after_push' => false]);
+
+    $bare = sys_get_temp_dir().'/specify-src-'.uniqid().'.git';
+    new Process(['git', 'init', '--bare', '--initial-branch=main', $bare])->mustRun();
+    $seed = sys_get_temp_dir().'/specify-seed-'.uniqid();
+    File::ensureDirectoryExists($seed);
+    new Process(['git', 'init', '--initial-branch=main', $seed])->mustRun();
+    File::put($seed.'/README.md', "# hi\n");
+    new Process(['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'add', 'README.md'], $seed)->mustRun();
+    new Process(['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', 'initial'], $seed)->mustRun();
+    new Process(['git', 'remote', 'add', 'origin', 'file://'.$bare], $seed)->mustRun();
+    new Process(['git', 'push', 'origin', 'main'], $seed)->mustRun();
+    File::deleteDirectory($seed);
+
+    $bin = sys_get_temp_dir().'/specify-fake-agent-'.uniqid().'.sh';
+    File::put($bin, "#!/usr/bin/env bash\nset -e\ncat > /dev/null\necho 'edited' >> README.md\necho 'agent ok'\n");
+    chmod($bin, 0o755);
+    config(['specify.executor.drivers.cli.command' => [$bin]]);
+    config(['specify.runs_path' => sys_get_temp_dir().'/specify-runs-'.uniqid()]);
+    app()->forgetInstance(WorkspaceRunner::class);
+    app()->forgetInstance(Executor::class);
+
+    $story = makeStory();
+    $project = $story->feature->project;
+    $repo = Repo::factory()->for($project->team->workspace)->create([
+        'url' => 'file://'.$bare,
+        'default_branch' => 'main',
+    ]);
+    $project->attachRepo($repo);
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_PROJECT,
+        'scope_id' => $project->id,
+        'required_approvals' => 0,
+    ]);
+    $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
+    $task = Task::factory()->for($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $subtask = Subtask::factory()->for($task)->create(['name' => 'append', 'position' => 0]);
+    $story->forceFill(['status' => StoryStatus::Draft->value])->save();
+    $story->fresh()->submitForApproval();
+    app(ExecutionService::class)->startStoryExecution($story->fresh());
+
+    $run = AgentRun::where('runnable_id', $subtask->id)
+        ->where('runnable_type', Subtask::class)
+        ->latest('id')->firstOrFail();
+
+    expect($run->status)->toBe(AgentRunStatus::Succeeded);
+
+    $events = AgentRunEvent::where('agent_run_id', $run->getKey())->orderBy('seq')->get();
+    expect($events)->not->toBeEmpty();
+    $phases = $events->pluck('phase')->unique()->values()->all();
+    expect($phases)->toContain('execute');
+    expect($events->pluck('seq')->all())->toBe(range(1, $events->count()));
+});
+
+test('GET /runs/{run}/events returns events scoped + after a cursor', function () {
+    $story = makeStory();
+    $project = $story->feature->project;
+    $user = User::factory()->create();
+    $project->team->addMember($user);
+
+    $task = Task::factory()->for($story)->create(['position' => 0]);
+    $subtask = Subtask::factory()->for($task)->create(['position' => 0]);
+
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->getKey(),
+        'status' => AgentRunStatus::Running->value,
+    ]);
+
+    foreach (range(1, 5) as $i) {
+        AgentRunEvent::create([
+            'agent_run_id' => $run->getKey(),
+            'seq' => $i,
+            'phase' => 'execute',
+            'type' => 'stdout',
+            'payload' => ['line' => "line $i"],
+            'ts' => now(),
+        ]);
+    }
+
+    $body = $this->actingAs($user)->getJson(route('runs.events', ['run' => $run->id]))
+        ->assertOk()
+        ->json();
+
+    expect($body['cursor'])->toBe(5);
+    expect($body['events'])->toHaveCount(5);
+    expect($body['events'][0]['payload'])->toBe(['line' => 'line 1']);
+
+    $body = $this->actingAs($user)->getJson(route('runs.events', ['run' => $run->id, 'after' => 3]))
+        ->assertOk()
+        ->json();
+
+    expect($body['events'])->toHaveCount(2);
+    expect(array_column($body['events'], 'seq'))->toBe([4, 5]);
+});
+
+test('GET /runs/{run}/events 404s when the user has no project access', function () {
+    $outsider = User::factory()->create();
+    Workspace::factory()->for($outsider, 'owner')->create();
+
+    $story = makeStory();
+    $task = Task::factory()->for($story)->create(['position' => 0]);
+    $subtask = Subtask::factory()->for($task)->create(['position' => 0]);
+    $run = AgentRun::create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->getKey(),
+        'status' => AgentRunStatus::Running->value,
+    ]);
+
+    $this->actingAs($outsider->fresh())->getJson(route('runs.events', ['run' => $run->id]))
+        ->assertNotFound();
+});

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -17,6 +17,7 @@ use App\Services\Executors\Executor;
 use App\Services\Executors\ExecutorClarification;
 use App\Services\Executors\ProposedSubtask;
 use App\Services\PlanWriter;
+use App\Services\Progress\ProgressEmitter;
 use App\Services\PullRequests\PrPayloadBuilder;
 use App\Services\SubtaskRunOutcome;
 use App\Services\SubtaskRunPipeline;
@@ -154,7 +155,12 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
             return true;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        public function supportsProgressEvents(): bool
+        {
+            return false;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'I tried but produced no diff',
@@ -218,7 +224,12 @@ test('alreadyComplete returns the Succeeded-class outcome when evidence SHAs are
             return true;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        public function supportsProgressEvents(): bool
+        {
+            return false;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'Confirmed already done by abc1234',
@@ -286,7 +297,12 @@ test('alreadyComplete falls through to noDiff when evidence is empty (ADR-0007 s
             return true;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        public function supportsProgressEvents(): bool
+        {
+            return false;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'I swear it is already done',
@@ -350,7 +366,12 @@ test('alreadyComplete falls through to noDiff when ANY cited SHA is unreachable,
             return true;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        public function supportsProgressEvents(): bool
+        {
+            return false;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'One real, one made up',
@@ -416,7 +437,12 @@ test('alreadyComplete falls through to noDiff when none of the cited SHAs are re
             return true;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        public function supportsProgressEvents(): bool
+        {
+            return false;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'Done in commit deadbeef',
@@ -503,7 +529,12 @@ test('context_brief is persisted on AgentRun.output even when the run ends in no
             return true;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null): ExecutionResult
+        public function supportsProgressEvents(): bool
+        {
+            return false;
+        }
+
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
         {
             return new ExecutionResult(summary: '', filesChanged: [], commitMessage: 'noop');
         }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -24,7 +24,7 @@ pest()->extend(TestCase::class)
 // the cwd to the project root before every test so the suite is order-
 // independent regardless of what a prior test did.
 beforeEach(function () {
-    @chdir(base_path());
+    chdir(base_path());
 });
 
 /*

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,6 +18,15 @@ pest()->extend(TestCase::class)
     ->use(RefreshDatabase::class)
     ->in('Feature');
 
+// WorkspaceRunner / CliExecutor tests cd into temp directories and tear
+// them down. If a later test inherits a deleted cwd, every git/process
+// invocation fails with `getcwd: cannot access parent directories`. Reset
+// the cwd to the project root before every test so the suite is order-
+// independent regardless of what a prior test did.
+beforeEach(function () {
+    @chdir(base_path());
+});
+
 /*
 |--------------------------------------------------------------------------
 | Expectations


### PR DESCRIPTION
## Summary

- Append-only `agent_run_events` table + `ProgressEmitter` writing one row per `emit()`, keyed on a per-run monotonic `seq`. Phase A.
- `Executor::supportsProgressEvents()` capability flag — pipeline constructs an emitter only for cooperating drivers, sets phase at `prepare`/`execute`/`commit`/`push`/`open_pr` boundaries, and passes it to `execute()`.
- **Phase B**: `CliExecutor` opts in. Streams stdout/stderr line-buffered and emits a `sentinel` event when the ADR-0007 already-complete block flushes. `LaravelAiExecutor` and `FakeExecutor` stay opted out (Phase D flips LaravelAi).
- HTTP poll endpoint `GET /runs/{run}/events?after={cursor}` (authed; 404s on out-of-scope projects).
- Run console renders events with `wire:poll.2s` while the run is non-terminal, falling back to the legacy `stdout`/`stderr` block when no events exist.

Reverb broadcast (Phase C) and LaravelAi tool-call events (Phase D) follow as separate PRs.

Bonus: `tests/Pest.php` now `chdir(base_path())` before every test so WorkspaceRunner's chdir+rmdir hygiene can't poison later tests with a deleted parent dir (the `getcwd: cannot access parent directories` flake we kept hitting in the Stop hook).

ADR-0011 promoted from Proposed → Accepted.

## Test plan
- [x] `composer test` — 338 passed (8 new)
- [x] Three consecutive `composer test` runs — no flake
- [ ] Smoke a CLI run in the dev app and watch the run-console events tab populate live
- [ ] Hit `GET /runs/{run}/events` while a run is in flight and confirm the cursor advances