### PR TITLE
fix(ui): distinguish approved from done; drop redundant AC 'met' pill

### DIFF
--- a/resources/views/components/rail.blade.php
+++ b/resources/views/components/rail.blade.php
@@ -4,7 +4,7 @@
     $colors = [
         'draft' => 'bg-zinc-300 dark:bg-zinc-700',
         'pending' => 'bg-amber-500',
-        'approved' => 'bg-emerald-500',
+        'approved' => 'bg-indigo-500',
         'changes_requested' => 'bg-rose-500',
         'rejected' => 'bg-zinc-500',
         'running' => 'bg-sky-500 animate-pulse motion-reduce:animate-none',

--- a/resources/views/components/state-pill.blade.php
+++ b/resources/views/components/state-pill.blade.php
@@ -4,7 +4,7 @@
     $palette = [
         'draft' => 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300',
         'pending' => 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
-        'approved' => 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+        'approved' => 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200',
         'changes_requested' => 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200',
         'rejected' => 'bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300',
         'running' => 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -823,9 +823,6 @@ new #[Title('Story')] class extends Component {
                                 <span class="text-zinc-400 transition-transform group-open:rotate-90" aria-hidden="true">▸</span>
                                 <flux:badge>{{ __('AC') }} #{{ $loop->iteration }}</flux:badge>
                                 <span class="font-medium">{{ $ac->criterion }}</span>
-                                @if ($ac->met)
-                                    <flux:badge class="ml-1">{{ __('met') }}</flux:badge>
-                                @endif
                             </summary>
 
                             @if ($acTasks->isEmpty())


### PR DESCRIPTION
## Summary

Two related visual fixes flagged in #21 and #22:

- **\`approved\` and \`done\` no longer look identical.** Both used the same emerald palette in \`<x-state-pill>\` and \`<x-rail>\`. \`approved\` (story ready to run) now uses indigo; \`done\` / \`run_complete\` stays emerald. They're different concepts and should look different at a glance.
- **Drop the \`met\` badge from each AC summary on the story show page.** Tasks under an AC already carry their own \`done\`/\`running\`/\`failed\` status — the extra AC-level "met" pill was the loudest source of "too many slightly different labels for the same thing" on the page (#22).

Partially closes #21 (colour clash) and partially #22 (label redundancy). Card-layout / header-action / numbering pieces of those issues are scoped to the next PR.

## Test plan

- [ ] \`composer test\` (338 / 338 green locally).
- [ ] Feature show page: \`approved\` story pill is visibly different from \`done\`.
- [ ] Story show page: AC summaries no longer carry a \`met\` badge.
- [ ] Rail colour for \`approved\` reads as blue/indigo, distinct from \`run_complete\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)