### PR TITLE
fix(ui): feature card grid, story Delete affordance, label cleanup

### DIFF
--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -258,16 +258,29 @@ new #[Title('Feature')] class extends Component {
                     <a href="{{ route('stories.show', ['project' => $feature->project_id, 'story' => $story->id]) }}" wire:navigate class="flex items-stretch gap-3 rounded-lg border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50" data-story-row="{{ $story->id }}">
                         <x-rail :state="$rowState" class="!w-0.5" />
                         <div class="min-w-0 flex-1">
-                            <div class="flex flex-wrap items-center gap-2">
-                                <x-state-pill :state="$rowState" :label="$story->status->value" />
-                                <flux:badge size="sm">rev {{ $story->revision }}</flux:badge>
-                                @if ($story->creator)
-                                    <flux:badge size="sm">{{ __('by') }} {{ $story->creator->name }}</flux:badge>
-                                @endif
-                                @if ($tasksTotal > 0)
-                                    <flux:badge size="sm">{{ $tasksDone }}/{{ $tasksTotal }} {{ __('tasks') }}</flux:badge>
-                                @endif
-                                <flux:text class="ml-auto text-xs text-zinc-500">{{ $story->updated_at?->diffForHumans() }}</flux:text>
+                            <div class="flex items-center gap-2">
+                                <div class="w-24 flex-none">
+                                    <x-state-pill :state="$rowState" :label="$story->status->value" />
+                                </div>
+                                <div class="w-14 flex-none">
+                                    <flux:badge size="sm">{{ __('rev') }} {{ $story->revision }}</flux:badge>
+                                </div>
+                                <div class="w-16 flex-none">
+                                    @if ($tasksTotal > 0)
+                                        <flux:badge size="sm">{{ $tasksDone }}/{{ $tasksTotal }}</flux:badge>
+                                    @endif
+                                </div>
+                                <div class="ml-auto flex flex-none items-center gap-2">
+                                    @if ($story->creator)
+                                        <flux:avatar
+                                            size="xs"
+                                            :name="$story->creator->name"
+                                            :initials="$story->creator->initials()"
+                                            :tooltip="$story->creator->name"
+                                        />
+                                    @endif
+                                    <flux:text class="text-xs text-zinc-500 tabular-nums">{{ $story->updated_at?->diffForHumans(short: true) }}</flux:text>
+                                </div>
                             </div>
                             <flux:heading class="mt-2">{{ $story->name }}</flux:heading>
                             @if ($story->description)

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -191,6 +191,38 @@ new #[Title('Story')] class extends Component {
         return $this->canEdit($story);
     }
 
+    public function canDeleteStory(): bool
+    {
+        $story = $this->story;
+        if (! $story) {
+            return false;
+        }
+        if (! in_array($story->status, [
+            StoryStatus::Draft,
+            StoryStatus::ProposedByAI,
+            StoryStatus::Cancelled,
+            StoryStatus::Rejected,
+        ], true)) {
+            return false;
+        }
+
+        return $this->canEdit($story);
+    }
+
+    public function deleteStory(): void
+    {
+        $story = $this->story;
+        abort_unless($story, 404);
+        abort_unless($this->canDeleteStory(), 403);
+
+        $featureId = $story->feature_id;
+        $projectId = $story->feature->project_id;
+
+        $story->delete();
+
+        $this->redirectRoute('features.show', ['project' => $projectId, 'feature' => $featureId], navigate: true);
+    }
+
     public function submit(): void
     {
         $story = $this->story;
@@ -655,17 +687,44 @@ new #[Title('Story')] class extends Component {
             @else
                 <div class="mt-2 flex items-start justify-between gap-3">
                     <flux:heading size="xl">{{ $story->name }}</flux:heading>
-                    @if ($this->canEditStory())
-                        <flux:button wire:click="startEdit" size="sm" icon="pencil-square">{{ __('Edit') }}</flux:button>
-                    @endif
+                    <div class="flex items-center gap-2">
+                        @if ($this->canEditStory())
+                            <flux:button wire:click="startEdit" size="sm" icon="pencil-square">{{ __('Edit') }}</flux:button>
+                        @endif
+                        @if ($this->canDeleteStory())
+                            <flux:modal.trigger name="delete-story-modal">
+                                <flux:button size="sm" variant="danger" icon="trash">{{ __('Delete') }}</flux:button>
+                            </flux:modal.trigger>
+                        @endif
+                    </div>
                 </div>
                 <div class="mt-2 flex flex-wrap items-center gap-2">
                     <x-state-pill :state="$pill['state']" :tally="$pill['tally']" :label="$pill['label']" />
-                    <flux:badge>v{{ $story->revision }}</flux:badge>
+                    <flux:badge>{{ __('rev') }} {{ $story->revision }}</flux:badge>
                     @if ($story->creator)
-                        <flux:badge>{{ __('by') }} {{ $story->creator->name }}</flux:badge>
+                        <flux:avatar
+                            size="xs"
+                            :name="$story->creator->name"
+                            :initials="$story->creator->initials()"
+                            :tooltip="$story->creator->name"
+                        />
                     @endif
                 </div>
+
+                @if ($this->canDeleteStory())
+                    <flux:modal name="delete-story-modal" class="md:w-96">
+                        <div class="flex flex-col gap-4">
+                            <flux:heading size="lg">{{ __('Delete story?') }}</flux:heading>
+                            <flux:text>{{ __('This permanently removes the story and its acceptance criteria. Cannot be undone.') }}</flux:text>
+                            <div class="flex justify-end gap-2">
+                                <flux:modal.close>
+                                    <flux:button variant="ghost">{{ __('Cancel') }}</flux:button>
+                                </flux:modal.close>
+                                <flux:button wire:click="deleteStory" variant="danger" icon="trash">{{ __('Delete') }}</flux:button>
+                            </div>
+                        </div>
+                    </flux:modal>
+                @endif
 
                 @php $storyPrs = $story->pullRequests(); @endphp
                 @if ($storyPrs->isNotEmpty())
@@ -683,24 +742,25 @@ new #[Title('Story')] class extends Component {
                         <div class="flex flex-col gap-1">
                             @foreach ($storyPrs as $pr)
                                 <div class="flex flex-wrap items-center gap-2 text-sm">
-                                    <flux:badge size="sm" :color="$pr['merged'] === true ? 'emerald' : 'zinc'">
-                                        @if ($pr['merged'] === true)
-                                            {{ __('merged') }}
-                                        @elseif ($pr['merged'] === false)
-                                            {{ __('open') }}
-                                        @else
-                                            {{ __('PR') }}
-                                        @endif
-                                        @if ($pr['number'])
-                                            #{{ $pr['number'] }}
-                                        @endif
-                                    </flux:badge>
                                     <a
                                         href="{{ $pr['url'] }}"
                                         target="_blank"
                                         rel="noopener"
-                                        class="truncate text-zinc-700 underline decoration-dotted hover:decoration-solid dark:text-zinc-300"
-                                    >{{ $pr['url'] }}</a>
+                                        class="inline-flex"
+                                    >
+                                        <flux:badge size="sm" :color="$pr['merged'] === true ? 'emerald' : 'zinc'" icon="arrow-top-right-on-square">
+                                            @if ($pr['merged'] === true)
+                                                {{ __('merged') }}
+                                            @elseif ($pr['merged'] === false)
+                                                {{ __('open') }}
+                                            @else
+                                                {{ __('PR') }}
+                                            @endif
+                                            @if ($pr['number'])
+                                                #{{ $pr['number'] }}
+                                            @endif
+                                        </flux:badge>
+                                    </a>
                                     @if ($pr['driver'])
                                         <flux:badge size="sm" icon="cpu-chip">{{ $pr['driver'] }}</flux:badge>
                                     @endif
@@ -766,19 +826,19 @@ new #[Title('Story')] class extends Component {
                     <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
                         <flux:heading size="lg">{{ __('Plan') }}</flux:heading>
                         <flux:text class="text-xs text-zinc-500">
-                            {{ $acs->count() }} {{ __('ACs') }} · {{ $subtaskCount }} {{ __('subtasks') }} · v{{ $story->revision }}
+                            {{ $acs->count() }} {{ __('ACs') }} · {{ $subtaskCount }} {{ __('subtasks') }}
                         </flux:text>
                         @if ($repo)
                             <flux:badge size="sm" icon="folder">{{ $repo->name }}</flux:badge>
                         @endif
                         @if ($branch)
-                            <flux:badge size="sm" icon="code-bracket">{{ $branch }}</flux:badge>
+                            <flux:text class="font-mono text-xs text-zinc-400 truncate max-w-[24rem]" :title="$branch">{{ $branch }}</flux:text>
                         @endif
                     </div>
 
                     <div class="flex items-center gap-2">
                         @if ($acs->isNotEmpty() || $unmappedTasks->isNotEmpty())
-                            <div class="inline-flex rounded-md border border-zinc-200 p-0.5 text-xs dark:border-zinc-700" role="tablist" data-toggle="plan-mode">
+                            <div class="inline-flex rounded-md border border-zinc-200 p-0.5 text-xs dark:border-zinc-700" role="tablist" data-toggle="plan-mode" aria-label="{{ __('Plan view density') }}">
                                 <button
                                     type="button"
                                     role="tab"
@@ -786,7 +846,7 @@ new #[Title('Story')] class extends Component {
                                     :aria-selected="!planRunMode ? 'true' : 'false'"
                                     :class="!planRunMode ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900' : 'text-zinc-600 dark:text-zinc-300'"
                                     class="rounded px-2 py-0.5"
-                                >{{ __('Grooming') }}</button>
+                                >{{ __('Compact') }}</button>
                                 <button
                                     type="button"
                                     role="tab"
@@ -794,7 +854,7 @@ new #[Title('Story')] class extends Component {
                                     :aria-selected="planRunMode ? 'true' : 'false'"
                                     :class="planRunMode ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900' : 'text-zinc-600 dark:text-zinc-300'"
                                     class="rounded px-2 py-0.5"
-                                >{{ __('Run') }}</button>
+                                >{{ __('Expanded') }}</button>
                             </div>
                         @endif
 

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -316,7 +316,7 @@ test('reset-approval banner does not render when nothing changes during edit', f
         ->assertDontSee('Save & request re-approval');
 });
 
-test('plan section renders with grooming/run toggle controls', function () {
+test('plan section renders with compact/expanded toggle controls', function () {
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);
     AcceptanceCriterion::create([
@@ -327,8 +327,8 @@ test('plan section renders with grooming/run toggle controls', function () {
 
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertSeeHtml('data-toggle="plan-mode"')
-        ->assertSee('Grooming')
-        ->assertSee('Run');
+        ->assertSee('Compact')
+        ->assertSee('Expanded');
 });
 
 test('plan toggle is hidden when story has no ACs and no unmapped tasks', function () {
@@ -339,4 +339,36 @@ test('plan toggle is hidden when story has no ACs and no unmapped tasks', functi
 
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertDontSeeHtml('data-toggle="plan-mode"');
+});
+
+test('Draft story exposes a Delete button that removes the story and redirects to the feature', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft]);
+    attachPolicy($s['ws'], required: 1);
+
+    $this->actingAs($s['user']);
+
+    $component = Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSee('Delete')
+        ->call('deleteStory');
+
+    $component->assertRedirect(route('features.show', [
+        'project' => $s['project']->id,
+        'feature' => $s['feature']->id,
+    ]));
+
+    expect(Story::find($s['story']->id))->toBeNull();
+});
+
+test('Approved story does not expose a Delete button and deleteStory is forbidden', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertDontSeeHtml('wire:click="deleteStory"')
+        ->call('deleteStory')
+        ->assertForbidden();
+
+    expect(Story::find($s['story']->id))->not->toBeNull();
 });


### PR DESCRIPTION
## Summary

Tackles the layout, redundancy, and missing-affordance pieces of #21 and #22.

**Feature show page**
- Story cards now use a fixed metadata grid: status / rev / tasks pin to the left; creator avatar + updated-age pin to the right. Eyes can scan a column instead of re-finding labels each row.
- Replace \`by datashaman\` text badge with the creator's avatar (tooltip on hover).
- Use \`rev N\` (consistent with the story show page) and short-form age.

**Story show page**
- Add Delete behind a Flux modal confirmation (Draft / ProposedByAI / Cancelled / Rejected only). Approved/Done stories don't expose the button, and \`deleteStory()\` returns 403 if called regardless.
- \`v6\` -> \`rev 6\` in the header; creator's \`by datashaman\` badge replaced with an avatar.
- Drop duplicate \`· v6\` in the Plan header (already in page header).
- Demote the giant branch-name badge to a subtle monospace zinc-400 text with truncation + title attribute.
- PR row: collapse "badge + bare URL" to a single clickable badge with external-link icon.
- Rename plan-density toggle from \`Grooming / Run\` to \`Compact / Expanded\`. \`Run\` is an active verb and implied execution.

Out of scope (deferred to follow-ups so this PR stays reviewable):
- AC / Task / Subtask numbering style sweep (#22).
- Drag-and-drop story reorder + per-story kebab on the feature page (#21 follow-up).
- Default-collapsed plan tree (interacts with run-mode logic; deserves its own PR).

Closes parts of #21 and #22.

## Test plan

- [ ] \`composer test\` (340 / 340 green locally).
- [ ] Feature show page: story rows align column-by-column; avatar visible with name on hover.
- [ ] Story show page (Draft): Delete button visible; modal confirms; on confirm, redirects to feature page and the story is gone.
- [ ] Story show page (Approved): no Delete button; \`deleteStory()\` direct call returns 403 (covered by test).
- [ ] Plan header: only one \`rev\` reference visible.
- [ ] PR row: badge is clickable; opens GitHub in a new tab.
- [ ] Plan-density toggle reads \`Compact / Expanded\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)