### PR TITLE
fix(ui): current-project chrome consistency + project edit

### DIFF
--- a/resources/views/livewire/app-switcher.blade.php
+++ b/resources/views/livewire/app-switcher.blade.php
@@ -78,7 +78,12 @@ new class extends Component {
         }
 
         $this->user->switchProject($project);
-        $this->redirect(request()->header('Referer') ?? route('dashboard'), navigate: true);
+
+        $target = $project
+            ? route('projects.show', $project)
+            : route('projects.index');
+
+        $this->redirect($target, navigate: true);
     }
 
     public function createProject(): void

--- a/resources/views/pages/projects/⚡index.blade.php
+++ b/resources/views/pages/projects/⚡index.blade.php
@@ -37,7 +37,9 @@ new #[Title('Projects')] class extends Component {
                     &middot; {{ $project->repos_count }} {{ __('repos') }}
                 </flux:text>
                 <div class="mt-3 flex flex-wrap gap-2">
-                    <a href="{{ route('projects.show', $project) }}" wire:navigate class="text-sm underline">{{ __('Open project') }}</a>
+                    <a href="{{ route('projects.show', $project) }}" wire:navigate>
+                        <flux:button size="sm" variant="primary">{{ __('Open project') }}</flux:button>
+                    </a>
                 </div>
             </flux:card>
         @empty

--- a/resources/views/pages/projects/⚡show.blade.php
+++ b/resources/views/pages/projects/⚡show.blade.php
@@ -18,10 +18,24 @@ new #[Title('Project')] class extends Component {
     #[Validate('nullable|string')]
     public string $newFeatureDescription = '';
 
+    public bool $editing = false;
+
+    #[Validate('required|string|max:255')]
+    public string $editName = '';
+
+    #[Validate('nullable|string|max:1000')]
+    public string $editDescription = '';
+
     public function mount(int $project): void
     {
         $this->project_id = $project;
-        abort_unless($this->project, 404);
+        $loaded = $this->project;
+        abort_unless($loaded, 404);
+
+        $user = Auth::user();
+        if ((int) $user->current_project_id !== (int) $project) {
+            $user->switchProject($loaded);
+        }
     }
 
     #[Computed]
@@ -39,6 +53,52 @@ new #[Title('Project')] class extends Component {
         return $this->project
             ? $this->project->features()->withCount('stories')->orderBy('name')->get()
             : collect();
+    }
+
+    public function canEditProject(): bool
+    {
+        $project = $this->project;
+
+        return $project !== null && Auth::user()->canApproveInProject($project);
+    }
+
+    public function startEdit(): void
+    {
+        $project = $this->project;
+        abort_unless($project, 404);
+        abort_unless($this->canEditProject(), 403);
+
+        $this->editName = (string) $project->name;
+        $this->editDescription = (string) ($project->description ?? '');
+        $this->editing = true;
+    }
+
+    public function cancelEdit(): void
+    {
+        $this->editing = false;
+        $this->editName = '';
+        $this->editDescription = '';
+        $this->resetErrorBag();
+    }
+
+    public function saveEdit(): void
+    {
+        $project = $this->project;
+        abort_unless($project, 404);
+        abort_unless($this->canEditProject(), 403);
+
+        $this->validate([
+            'editName' => 'required|string|max:255',
+            'editDescription' => 'nullable|string|max:1000',
+        ]);
+
+        $project->update([
+            'name' => trim($this->editName),
+            'description' => $this->editDescription !== '' ? $this->editDescription : null,
+        ]);
+
+        $this->editing = false;
+        unset($this->project);
     }
 
     public function createFeature(): void
@@ -65,6 +125,27 @@ new #[Title('Project')] class extends Component {
     @if (! $this->project)
         <flux:text class="text-zinc-500">{{ __('Project not found.') }}</flux:text>
     @else
+        <section data-section="project-header" class="flex flex-col gap-2">
+            @if ($editing)
+                <flux:input wire:model="editName" :label="__('Name')" required />
+                <flux:textarea wire:model="editDescription" :label="__('Description')" rows="3" />
+                <div class="flex items-center gap-2">
+                    <flux:button wire:click="saveEdit" variant="primary">{{ __('Save') }}</flux:button>
+                    <flux:button wire:click="cancelEdit" variant="ghost">{{ __('Cancel') }}</flux:button>
+                </div>
+            @else
+                <div class="flex items-start justify-between gap-3">
+                    <flux:heading size="xl">{{ $this->project->name }}</flux:heading>
+                    @if ($this->canEditProject())
+                        <flux:button wire:click="startEdit" size="sm" icon="pencil-square">{{ __('Edit') }}</flux:button>
+                    @endif
+                </div>
+                @if ($this->project->description)
+                    <flux:text class="text-zinc-600 dark:text-zinc-400">{{ $this->project->description }}</flux:text>
+                @endif
+            @endif
+        </section>
+
         <section class="flex flex-col gap-3">
             <flux:heading size="xl">{{ __('Features') }}</flux:heading>
             @forelse ($this->features as $feature)

--- a/resources/views/pages/stories/⚡index.blade.php
+++ b/resources/views/pages/stories/⚡index.blade.php
@@ -63,7 +63,6 @@ new #[Title('Stories')] class extends Component {
             <a href="{{ route('stories.show', ['project' => $story->feature->project_id, 'story' => $story->id]) }}" wire:navigate>
                 <flux:card class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
                     <div class="flex flex-wrap items-center gap-2">
-                        <flux:badge variant="solid">{{ $story->feature->project->name }}</flux:badge>
                         <flux:badge>{{ $story->status->value }}</flux:badge>
                         <flux:badge>rev {{ $story->revision }}</flux:badge>
                         @if ($story->creator)

--- a/tests/Feature/ProjectShowTest.php
+++ b/tests/Feature/ProjectShowTest.php
@@ -64,3 +64,39 @@ test('lists existing features with story counts', function () {
     Livewire::test('pages::projects.show', ['project' => $project->id])
         ->assertSee('Visible Feature');
 });
+
+test('mounting a project show page sets the user current_project_id to that project', function () {
+    ['user' => $user, 'project' => $project] = projectShowScene();
+    $other = Project::factory()->for($project->team)->create();
+    $user->forceFill(['current_project_id' => $other->id])->save();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::projects.show', ['project' => $project->id]);
+
+    expect($user->fresh()->current_project_id)->toBe($project->id);
+});
+
+test('admin can edit project name and description', function () {
+    ['user' => $user, 'project' => $project] = projectShowScene();
+    $this->actingAs($user);
+
+    Livewire::test('pages::projects.show', ['project' => $project->id])
+        ->call('startEdit')
+        ->set('editName', 'Renamed')
+        ->set('editDescription', 'New description')
+        ->call('saveEdit');
+
+    $project->refresh();
+    expect($project->name)->toBe('Renamed');
+    expect($project->description)->toBe('New description');
+});
+
+test('member cannot edit project', function () {
+    ['user' => $user, 'project' => $project] = projectShowScene(TeamRole::Member);
+    $this->actingAs($user);
+
+    Livewire::test('pages::projects.show', ['project' => $project->id])
+        ->call('startEdit')
+        ->assertStatus(403);
+});

--- a/tests/Feature/SwitcherTest.php
+++ b/tests/Feature/SwitcherTest.php
@@ -121,10 +121,12 @@ test('app-switcher component sets and clears the project pin', function () {
     $this->actingAs($user);
 
     Livewire::test('app-switcher')
-        ->call('switchProject', $projects[0][0]->id);
+        ->call('switchProject', $projects[0][0]->id)
+        ->assertRedirect(route('projects.show', $projects[0][0]));
     expect($user->fresh()->current_project_id)->toBe($projects[0][0]->id);
 
     Livewire::test('app-switcher')
-        ->call('switchProject', null);
+        ->call('switchProject', null)
+        ->assertRedirect(route('projects.index'));
     expect($user->fresh()->current_project_id)->toBeNull();
 });


### PR DESCRIPTION
## Summary

Fixes #17, #20, and #26 — the "current project" experience now coheres across the chrome, projects index, and project show page.

**Switcher** (#26)

- \`switchProject()\` previously redirected to \`request()->header('Referer')\`. On project-scoped pages (\`stories.index\`, \`runs.index\`, \`repos.index\`), the destination's \`mount()\` re-asserted the old project's id from the URL, silently undoing the switch.
- Now redirects to the new project's \`projects.show\` (or \`projects.index\` for the "All projects" entry).

**Project show** (#17, #20)

- \`mount()\` calls \`$user->switchProject()\` so opening a project from the index, or via any deep-link, syncs the chrome.
- Adds an Edit affordance (header pencil button → inline name/description form), gated on \`canApproveInProject\`.

**Projects index** (#20)

- "Open project" is now a Flux primary button (consistent with the action-button pattern elsewhere).

**Stories index** (#26)

- Drop the redundant project-name badge per story row. The page is project-scoped, so every row carried the same badge. Global pages (triage, dashboard) keep the badge — that's where it actually disambiguates.

## Test plan

- [ ] \`composer test\` (341 / 341 green locally).
- [ ] Switcher → choose a different project → land on that project's show page; chrome agrees.
- [ ] Switcher → "All projects" → land on \`projects.index\`; chrome shows null project.
- [ ] Open a project from the index → chrome's switcher follows.
- [ ] Project show: pencil → edit name + description → save → reflects on the page.
- [ ] Stories index: rows no longer carry a project badge; page heading is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)