### PR TITLE
fix(runs): readable card layout, markdown output, diff colours

### DIFF
--- a/resources/views/pages/runs/⚡index.blade.php
+++ b/resources/views/pages/runs/⚡index.blade.php
@@ -10,7 +10,7 @@ use Livewire\Attributes\Title;
 use Livewire\Component;
 use Livewire\WithPagination;
 
-new #[Title('Run history')] class extends Component {
+new #[Title('Runs')] class extends Component {
     use WithPagination;
 
     public int $project_id;
@@ -48,8 +48,38 @@ new #[Title('Run history')] class extends Component {
     }
 }; ?>
 
+@php
+    $formatDuration = function (?int $seconds): ?string {
+        if ($seconds === null) {
+            return null;
+        }
+        if ($seconds < 60) {
+            return $seconds.'s';
+        }
+        if ($seconds < 3600) {
+            return intdiv($seconds, 60).'m '.($seconds % 60).'s';
+        }
+        $hours = intdiv($seconds, 3600);
+        $mins = intdiv($seconds % 3600, 60);
+        return $hours.'h '.$mins.'m';
+    };
+    $prettyJsonOrText = function (?string $body): string {
+        if ($body === null || $body === '') {
+            return '';
+        }
+        $trimmed = ltrim($body);
+        if (str_starts_with($trimmed, '{') || str_starts_with($trimmed, '[')) {
+            $decoded = json_decode($body, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            }
+        }
+        return $body;
+    };
+@endphp
+
 <div class="flex flex-col gap-6 p-6">
-    <flux:heading size="xl">{{ __('Run history') }}</flux:heading>
+    <flux:heading size="xl">{{ __('Runs') }}</flux:heading>
 
     <div class="flex gap-2">
         <flux:select wire:model.live="status" :placeholder="__('All statuses')">
@@ -65,13 +95,19 @@ new #[Title('Run history')] class extends Component {
     <div class="flex flex-col gap-3">
         @forelse ($this->runs as $run)
             @php
-                $duration = $run->started_at && $run->finished_at
+                $durationSeconds = $run->started_at && $run->finished_at
                     ? $run->started_at->diffInSeconds($run->finished_at)
                     : null;
+                $duration = $formatDuration($durationSeconds);
                 $prMerged = $run->output['pull_request_merged'] ?? null;
                 $prAction = $run->output['pull_request_action'] ?? null;
                 $tokensIn = $run->tokens_input;
                 $tokensOut = $run->tokens_output;
+                $sha = $run->output['commit_sha'] ?? null;
+                $isFailed = $run->status->value === 'failed';
+                $errorBody = $run->error_message;
+                $prError = $run->output['pull_request_error'] ?? null;
+                $hasOutput = $errorBody || $prError;
             @endphp
             <flux:card>
                 <div class="flex flex-wrap items-center gap-2">
@@ -81,27 +117,30 @@ new #[Title('Run history')] class extends Component {
                         <flux:badge>{{ $run->repo->name }}</flux:badge>
                     @endif
                     @if ($run->working_branch)
-                        <flux:badge>{{ $run->working_branch }}</flux:badge>
-                    @endif
-                    @if ($sha = $run->output['commit_sha'] ?? null)
-                        <flux:badge>{{ substr($sha, 0, 7) }}</flux:badge>
+                        <flux:text class="font-mono text-xs text-zinc-400 truncate max-w-[24rem]" :title="$run->working_branch">{{ $run->working_branch }}</flux:text>
                     @endif
                     @if ($prMerged === true)
-                        <flux:badge>{{ __('PR merged') }}</flux:badge>
+                        <flux:badge color="emerald">{{ __('PR merged') }}</flux:badge>
                     @elseif ($prAction === 'closed' && $prMerged === false)
                         <flux:badge>{{ __('PR closed') }}</flux:badge>
                     @elseif ($prAction !== null)
                         <flux:badge>{{ __('PR') }} {{ $prAction }}</flux:badge>
                     @endif
-                    @if ($duration !== null)
-                        <flux:badge>{{ $duration }}s</flux:badge>
-                    @endif
-                    @if ($tokensIn || $tokensOut)
-                        <flux:badge>{{ $tokensIn ?? 0 }}/{{ $tokensOut ?? 0 }} {{ __('tok') }}</flux:badge>
-                    @endif
-                    @if ($run->finished_at)
-                        <flux:text class="ml-auto text-xs text-zinc-500">{{ $run->finished_at->diffForHumans() }}</flux:text>
-                    @endif
+
+                    <div class="ml-auto flex items-center gap-3 text-xs text-zinc-500">
+                        @if ($sha)
+                            <span class="font-mono">{{ substr($sha, 0, 7) }}</span>
+                        @endif
+                        @if ($duration)
+                            <span class="tabular-nums">{{ $duration }}</span>
+                        @endif
+                        @if ($tokensIn || $tokensOut)
+                            <span class="tabular-nums" title="{{ __('tokens in / out') }}">{{ $tokensIn ?? 0 }}↓ {{ $tokensOut ?? 0 }}↑</span>
+                        @endif
+                        @if ($run->finished_at)
+                            <span>{{ $run->finished_at->diffForHumans(short: true) }}</span>
+                        @endif
+                    </div>
                 </div>
 
                 <flux:heading class="mt-2">
@@ -124,30 +163,45 @@ new #[Title('Run history')] class extends Component {
                 @endif
 
                 @if ($url = $run->output['pull_request_url'] ?? null)
-                    <flux:text class="mt-1">
-                        <a href="{{ $url }}" target="_blank" rel="noopener" class="underline">{{ $url }}</a>
-                    </flux:text>
+                    <a href="{{ $url }}" target="_blank" rel="noopener" class="mt-1 inline-flex">
+                        <flux:badge size="sm" color="zinc" icon="arrow-top-right-on-square">{{ __('Pull request') }}</flux:badge>
+                    </a>
                 @endif
 
-                @if ($run->error_message)
-                    <flux:text class="mt-1 text-red-600">{{ $run->error_message }}</flux:text>
-                @endif
-
-                @if ($prError = $run->output['pull_request_error'] ?? null)
-                    <flux:text class="mt-1 text-amber-600">{{ __('PR error') }}: {{ $prError }}</flux:text>
+                @if ($hasOutput)
+                    <details class="mt-3" {{ $isFailed ? 'open' : '' }}>
+                        <summary class="cursor-pointer text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Output') }}</summary>
+                        @if ($errorBody)
+                            <div class="mt-2 rounded-md border border-rose-200 bg-rose-50 p-3 dark:border-rose-900/40 dark:bg-rose-950/30">
+                                <x-markdown :content="$errorBody" class="text-rose-900 dark:text-rose-200" />
+                            </div>
+                        @endif
+                        @if ($prError)
+                            <div class="mt-2">
+                                <div class="mb-1 text-xs uppercase tracking-wide text-amber-700 dark:text-amber-400">{{ __('PR error') }}</div>
+                                <pre class="max-h-72 overflow-auto rounded bg-amber-50 p-3 font-mono text-xs leading-snug text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">{{ $prettyJsonOrText($prError) }}</pre>
+                            </div>
+                        @endif
+                    </details>
                 @endif
 
                 @if ($run->diff)
-                    <details class="mt-3">
-                        <summary class="cursor-pointer text-sm text-zinc-500">{{ __('Diff') }}</summary>
-                        <pre class="mt-2 max-h-96 overflow-auto rounded bg-zinc-100 p-3 text-xs dark:bg-zinc-900">{{ $run->diff }}</pre>
+                    <details class="mt-2">
+                        <summary class="cursor-pointer text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Diff') }}</summary>
+                        <pre class="mt-2 max-h-96 overflow-auto rounded bg-zinc-100 p-3 font-mono text-xs leading-snug dark:bg-zinc-900"><code>@foreach (preg_split("/\r?\n/", (string) $run->diff) as $line)<span @class([
+                            'text-emerald-700 dark:text-emerald-300' => str_starts_with($line, '+') && ! str_starts_with($line, '+++'),
+                            'text-rose-700 dark:text-rose-300' => str_starts_with($line, '-') && ! str_starts_with($line, '---'),
+                            'text-sky-700 dark:text-sky-300 font-semibold' => str_starts_with($line, '@@'),
+                            'text-zinc-500 dark:text-zinc-400 font-semibold' => str_starts_with($line, 'diff ') || str_starts_with($line, '+++') || str_starts_with($line, '---'),
+                        ])>{{ $line }}</span>
+@endforeach</code></pre>
                     </details>
                 @endif
 
                 @if ($run->input)
                     <details class="mt-2">
-                        <summary class="cursor-pointer text-sm text-zinc-500">{{ __('Prompt') }}</summary>
-                        <pre class="mt-2 max-h-96 overflow-auto rounded bg-zinc-100 p-3 text-xs dark:bg-zinc-900">{{ json_encode($run->input, JSON_PRETTY_PRINT) }}</pre>
+                        <summary class="cursor-pointer text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">{{ __('Prompt') }}</summary>
+                        <pre class="mt-2 max-h-96 overflow-auto rounded bg-zinc-100 p-3 font-mono text-xs leading-snug dark:bg-zinc-900">{{ json_encode($run->input, JSON_PRETTY_PRINT) }}</pre>
                     </details>
                 @endif
             </flux:card>

--- a/tests/Feature/RunHistoryTest.php
+++ b/tests/Feature/RunHistoryTest.php
@@ -114,7 +114,7 @@ test('shows repo name and tokens on the run card', function () {
 
     Livewire::test('pages::runs.index', ['project' => $project->id])
         ->assertSee('backend')
-        ->assertSee('1234/567 tok');
+        ->assertSee('1234↓ 567↑');
 });
 
 test('status filter narrows the list', function () {


### PR DESCRIPTION
## Summary

Tackles #24 — runs index was a wall of unrendered text.

- **Title fix.** Page header now reads \`Runs\` (matches the sidebar).
- **Card metadata grid.** Action badges (status, repo, branch, PR) on the left; commit hash + duration + tokens + age in a fixed right slot rendered as plain text. Branch is monospace zinc-400 with truncation. No more "wall of digits" next to the commit hash.
- **Duration formatting.** \`145s\` -> \`2m 25s\`, \`91s\` -> \`1m 31s\`, > 1h shown as \`1h 5m\`.
- **Output rendering.** \`error_message\` now goes through \`<x-markdown>\` inside a rose callout — agent summaries with code spans, file links, and lists actually format. PR error blobs are pretty-printed if they parse as JSON, otherwise plain text. Both live in one \`Output\` disclosure that defaults to expanded for failed runs and collapsed otherwise.
- **Diff colours.** Per-line classes: \`+\` green, \`-\` rose, \`@@\` sky, file headers zinc. Block-level monospace preserved.
- **PR URL.** Bare full-length link collapsed to a small clickable badge with an external-link icon.

Closes #24.

## Test plan

- [ ] \`composer test\` (338 / 338 green locally).
- [ ] Sidebar item and page heading both read \`Runs\`.
- [ ] A failing run with a markdown agent summary renders code/links/lists correctly.
- [ ] A run with a JSON \`pull_request_error\` shows pretty-printed JSON in the amber pane.
- [ ] Duration on cards reads \`Xm Ys\` instead of \`Ns\`.
- [ ] Diff disclosure shows green / rose / sky line colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)