### PR TITLE
fix(dashboard): action-oriented layout, clickable runs

### DIFF
--- a/resources/views/pages/⚡dashboard.blade.php
+++ b/resources/views/pages/⚡dashboard.blade.php
@@ -64,6 +64,32 @@ new #[Title('Dashboard')] class extends Component {
     }
 
     #[Computed]
+    public function awaitingMyApproval()
+    {
+        $user = Auth::user();
+        $approvableProjectIds = collect($this->projectIds)
+            ->filter(function ($projectId) use ($user) {
+                $project = Project::find($projectId);
+
+                return $project && $user->canApproveInProject($project);
+            })
+            ->values()
+            ->all();
+
+        if ($approvableProjectIds === []) {
+            return collect();
+        }
+
+        return Story::query()
+            ->where('status', StoryStatus::PendingApproval)
+            ->whereHas('feature', fn ($q) => $q->whereIn('project_id', $approvableProjectIds))
+            ->with('feature.project', 'creator')
+            ->latest('updated_at')
+            ->limit(5)
+            ->get();
+    }
+
+    #[Computed]
     public function projects()
     {
         $ids = Auth::user()->accessibleProjectsInCurrentWorkspace()->pluck('id');
@@ -113,52 +139,92 @@ new #[Title('Dashboard')] class extends Component {
         </a>
     </div>
 
+    @if ($this->awaitingMyApproval->isNotEmpty())
+        <section class="flex flex-col gap-3">
+            <flux:heading size="lg">{{ __('Awaiting your approval') }}</flux:heading>
+            @foreach ($this->awaitingMyApproval as $story)
+                <a
+                    href="{{ route('stories.show', ['project' => $story->feature->project_id, 'story' => $story->id]) }}"
+                    wire:navigate
+                    class="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50/50 p-3 hover:bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/20 dark:hover:bg-amber-950/40"
+                >
+                    <flux:icon name="exclamation-triangle" class="size-5 shrink-0 text-amber-600 dark:text-amber-400" />
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2">
+                            <flux:text class="truncate font-medium">{{ $story->name }}</flux:text>
+                            <flux:badge size="sm">{{ __('rev') }} {{ $story->revision }}</flux:badge>
+                        </div>
+                        <flux:text class="text-xs text-zinc-500">
+                            {{ $story->feature->project->name }} · {{ $story->feature->name }}
+                            @if ($story->creator)
+                                · {{ __('by') }} {{ $story->creator->name }}
+                            @endif
+                        </flux:text>
+                    </div>
+                    <flux:text class="text-xs text-zinc-500">{{ $story->updated_at?->diffForHumans(short: true) }}</flux:text>
+                </a>
+            @endforeach
+        </section>
+    @endif
+
     <div class="grid gap-6 lg:grid-cols-2">
         <section class="flex flex-col gap-3">
-            <flux:heading size="lg">{{ __('Recent runs') }}</flux:heading>
+            <div class="flex items-baseline justify-between">
+                <flux:heading size="lg">{{ __('Recent runs') }}</flux:heading>
+                <a href="{{ $runsHref }}" wire:navigate class="text-xs text-zinc-500 hover:underline">{{ __('See all') }} &rarr;</a>
+            </div>
             @forelse ($this->recentRuns as $run)
-                <flux:card>
-                    <div class="flex flex-wrap items-center gap-2">
-                        <flux:badge variant="solid">#{{ $run->id }}</flux:badge>
-                        <flux:badge>{{ $run->status->value }}</flux:badge>
-                        @if ($run->repo)
-                            <flux:badge>{{ $run->repo->name }}</flux:badge>
-                        @endif
-                        @if ($run->finished_at)
-                            <flux:text class="ml-auto text-xs text-zinc-500">{{ $run->finished_at->diffForHumans() }}</flux:text>
-                        @endif
-                    </div>
-                    <flux:heading class="mt-2">
+                @php
+                    $runHref = $run->runnable && $run->runnable->task?->story
+                        ? route('runs.show', [
+                            'project' => $run->runnable->task->story->feature->project_id,
+                            'story' => $run->runnable->task->story->id,
+                            'subtask' => $run->runnable->id,
+                            'run' => $run->id,
+                        ])
+                        : null;
+                @endphp
+                <a
+                    @if ($runHref) href="{{ $runHref }}" wire:navigate @endif
+                    @class([
+                        'flex items-center gap-2 rounded-lg border border-zinc-200 p-3 dark:border-zinc-700',
+                        'hover:bg-zinc-50 dark:hover:bg-zinc-900' => $runHref,
+                    ])
+                >
+                    <flux:badge variant="solid" size="sm">#{{ $run->id }}</flux:badge>
+                    <flux:badge size="sm">{{ $run->status->value }}</flux:badge>
+                    <flux:text class="truncate text-sm">
                         @if ($run->runnable)
                             {{ $run->runnable->name }}
                         @else
                             {{ __('Run') }}
                         @endif
-                    </flux:heading>
-                    @if ($url = $run->output['pull_request_url'] ?? null)
-                        <flux:text class="mt-1">
-                            <a href="{{ $url }}" target="_blank" rel="noopener" class="underline">{{ $url }}</a>
-                        </flux:text>
+                    </flux:text>
+                    @if ($run->finished_at)
+                        <flux:text class="ml-auto shrink-0 text-xs text-zinc-500">{{ $run->finished_at->diffForHumans(short: true) }}</flux:text>
                     @endif
-                </flux:card>
+                </a>
             @empty
                 <flux:text class="text-zinc-500">{{ __('No runs yet.') }}</flux:text>
             @endforelse
-            <a href="{{ $runsHref }}" wire:navigate class="text-sm underline">{{ __('See all runs') }} &rarr;</a>
         </section>
 
         <section class="flex flex-col gap-3">
             <flux:heading size="lg">{{ __('Projects') }}</flux:heading>
             @forelse ($this->projects as $project)
-                <flux:card>
-                    <flux:heading>{{ $project->name }}</flux:heading>
-                    <flux:text class="mt-1 text-sm text-zinc-500">
-                        {{ $project->features_count }} {{ __('features') }} &middot; {{ $project->repos_count }} {{ __('repos') }}
-                    </flux:text>
-                    <div class="mt-2 flex flex-wrap gap-3 text-sm">
-                        <a href="{{ route('projects.show', $project) }}" wire:navigate class="underline">{{ __('Open') }}</a>
+                <a
+                    href="{{ route('projects.show', $project) }}"
+                    wire:navigate
+                    class="flex items-center justify-between gap-3 rounded-lg border border-zinc-200 p-3 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900"
+                >
+                    <div class="min-w-0">
+                        <flux:text class="truncate font-medium">{{ $project->name }}</flux:text>
+                        <flux:text class="text-xs text-zinc-500">
+                            {{ $project->features_count }} {{ __('features') }} &middot; {{ $project->repos_count }} {{ __('repos') }}
+                        </flux:text>
                     </div>
-                </flux:card>
+                    <flux:icon name="arrow-right" class="size-4 shrink-0 text-zinc-400" />
+                </a>
             @empty
                 <flux:text class="text-zinc-500">{{ __('No projects in your teams.') }}</flux:text>
             @endforelse

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -3,6 +3,7 @@
 use App\Enums\AgentRunStatus;
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
+use App\Enums\TeamRole;
 use App\Models\AgentRun;
 use App\Models\Feature;
 use App\Models\Project;
@@ -90,4 +91,76 @@ test('dashboard surfaces repos missing an access_token', function () {
     $this->actingAs($user);
 
     Livewire::test('pages::dashboard')->assertSet('reposNeedingToken', 1);
+});
+
+test('awaiting your approval lists pending stories the user can approve', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Admin);
+    $user->forceFill(['current_team_id' => $team->id])->save();
+
+    $project = Project::factory()->for($team)->create(['name' => 'Specify']);
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create([
+        'name' => 'Approve me',
+        'status' => StoryStatus::PendingApproval,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::dashboard')
+        ->assertSee('Awaiting your approval')
+        ->assertSee('Approve me')
+        ->assertSeeHtml(route('stories.show', ['project' => $project->id, 'story' => $story->id]));
+});
+
+test('awaiting your approval is hidden for non-approvers', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Member);
+    $user->forceFill(['current_team_id' => $team->id])->save();
+
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    Story::factory()->for($feature)->create([
+        'status' => StoryStatus::PendingApproval,
+        'name' => 'Hidden from me',
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::dashboard')
+        ->assertDontSee('Awaiting your approval')
+        ->assertDontSee('Hidden from me');
+});
+
+test('recent runs are clickable and link to the run console', function () {
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $user->forceFill(['current_team_id' => $team->id])->save();
+
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $task = Task::factory()->for($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::dashboard')
+        ->assertSeeHtml(route('runs.show', [
+            'project' => $project->id,
+            'story' => $story->id,
+            'subtask' => $subtask->id,
+            'run' => $run->id,
+        ]));
 });


### PR DESCRIPTION
## Summary

Tackles #19. The old dashboard was dominated by a Recent Runs panel whose rows weren't clickable — visual noise that pushed everything else off the page. Refocuses on what the user needs to **do**.

- **New "Awaiting your approval" section** at the top: up to five PendingApproval stories the user can approve in scope, each row a clickable card linking to the story console. Hidden for non-approvers (Member role).
- **Recent runs** panel kept but compacted into single-row tiles. Each row now wraps in an \`<a>\` linking to \`runs.show\`. "See all runs" moves to a small inline link in the panel header.
- **Projects** panel becomes arrow-row links instead of multi-line cards. Same info, less vertical real estate.

Closes #19.

## Test plan

- [ ] \`composer test\` (343 / 343 green locally).
- [ ] As an admin: PendingApproval stories appear in the new section; clicking a row lands on the story.
- [ ] As a member: section is absent.
- [ ] Recent runs: each row is hoverable + clickable; lands on the run console.
- [ ] Projects: each row links to the project show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)