### PR TITLE
feat(tasks): add task show page

### DIFF
--- a/resources/views/pages/tasks/⚡show.blade.php
+++ b/resources/views/pages/tasks/⚡show.blade.php
@@ -1,0 +1,151 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Models\Task;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+new #[Title('Task')] class extends Component {
+    public int $project_id;
+
+    public int $story_id;
+
+    public int $task_id;
+
+    public function mount(int $project, int $story, int $task): void
+    {
+        $this->project_id = (int) $project;
+        $this->story_id = (int) $story;
+        $this->task_id = (int) $task;
+
+        $loaded = $this->task;
+        abort_unless($loaded, 404);
+
+        $user = Auth::user();
+        if ((int) $user->current_project_id !== $this->project_id) {
+            $user->forceFill(['current_project_id' => $this->project_id])->save();
+        }
+    }
+
+    #[Computed]
+    public function task(): ?Task
+    {
+        return Task::query()
+            ->whereHas('story.feature', fn ($q) => $q
+                ->where('project_id', $this->project_id)
+                ->whereIn('project_id', Auth::user()->accessibleProjectIds())
+            )
+            ->whereHas('story', fn ($q) => $q->where('id', $this->story_id))
+            ->with([
+                'story.feature.project',
+                'acceptanceCriterion',
+                'dependencies',
+                'subtasks.agentRuns.repo',
+                'subtasks.proposedByRun',
+            ])
+            ->find($this->task_id);
+    }
+}; ?>
+
+<div class="flex p-6">
+    @if (! $this->task)
+        <flux:text class="text-zinc-500">{{ __('Task not found.') }}</flux:text>
+    @else
+        @php
+            $task = $this->task;
+            $story = $task->story;
+            $feature = $story->feature;
+            $project = $feature->project;
+            $ac = $task->acceptanceCriterion;
+            $rail = match ($task->status) {
+                TaskStatus::Done => 'run_complete',
+                TaskStatus::InProgress => 'running',
+                TaskStatus::Blocked => 'run_failed',
+                default => 'draft',
+            };
+            $deps = $task->dependencies->map(fn ($d) => '#'.$d->position);
+            $subtaskTotal = $task->subtasks->count();
+            $subtaskDone = $task->subtasks->filter(fn ($s) => $s->status === TaskStatus::Done)->count();
+        @endphp
+
+        <x-rail :state="$rail" class="mr-4" />
+
+        <div class="flex min-w-0 max-w-4xl flex-1 flex-col gap-6">
+            <nav aria-label="Breadcrumb" class="flex flex-wrap items-center gap-1 text-sm text-zinc-500" data-section="breadcrumb">
+                <a href="{{ route('projects.show', $project) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $project->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('features.show', ['project' => $project, 'feature' => $feature]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $feature->name }}</a>
+                <span aria-hidden="true">›</span>
+                <a href="{{ route('stories.show', ['project' => $project, 'story' => $story]) }}" wire:navigate class="hover:text-zinc-700 hover:underline dark:hover:text-zinc-300">{{ $story->name }}</a>
+                <span aria-hidden="true">›</span>
+                <span class="text-zinc-700 dark:text-zinc-300" aria-current="page">{{ $task->name }}</span>
+            </nav>
+
+            <div>
+                <div class="flex flex-wrap items-center gap-2 text-xs">
+                    <flux:badge variant="solid">{{ __('Task') }} #{{ $task->position }}</flux:badge>
+                    <x-state-pill :state="$rail" :label="$task->status->value" />
+                    @if ($subtaskTotal > 0)
+                        <flux:badge>{{ $subtaskDone }}/{{ $subtaskTotal }} {{ __('subtasks') }}</flux:badge>
+                    @endif
+                    @if ($deps->isNotEmpty())
+                        <flux:badge>{{ __('depends on') }} {{ $deps->implode(', ') }}</flux:badge>
+                    @endif
+                </div>
+                <flux:heading size="xl" class="mt-2">{{ $task->name }}</flux:heading>
+                @if ($task->description)
+                    <x-markdown :content="$task->description" class="mt-2" />
+                @endif
+                @if ($ac)
+                    <div class="mt-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
+                        <flux:text class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Acceptance criterion') }} #{{ $ac->position }}</flux:text>
+                        <flux:text class="mt-1 text-sm">{{ $ac->criterion }}</flux:text>
+                    </div>
+                @endif
+            </div>
+
+            <section class="flex flex-col gap-3" data-section="subtasks">
+                <flux:heading size="lg">{{ __('Subtasks') }}</flux:heading>
+                @forelse ($task->subtasks->sortBy('position') as $sub)
+                    @php
+                        $subRail = match ($sub->status) {
+                            TaskStatus::Done => 'run_complete',
+                            TaskStatus::InProgress => 'running',
+                            TaskStatus::Blocked => 'run_failed',
+                            default => 'draft',
+                        };
+                        $latestRun = $sub->agentRuns->sortByDesc('id')->first();
+                    @endphp
+                    <a
+                        href="{{ route('subtasks.show', ['project' => $project->id, 'story' => $story->id, 'subtask' => $sub->id]) }}"
+                        wire:navigate
+                        class="flex items-stretch gap-3 rounded-lg border border-zinc-200 p-3 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                        data-subtask-id="{{ $sub->id }}"
+                    >
+                        <x-rail :state="$subRail" class="!w-0.5" />
+                        <div class="min-w-0 flex-1">
+                            <div class="flex flex-wrap items-center gap-2 text-xs">
+                                <flux:badge variant="solid" size="sm">#{{ $sub->position }}</flux:badge>
+                                <x-state-pill :state="$subRail" :label="$sub->status->value" />
+                                @if ($latestRun)
+                                    <flux:badge size="sm">{{ __('run') }} #{{ $latestRun->id }}</flux:badge>
+                                @endif
+                                @if ($sub->updated_at)
+                                    <flux:text class="ml-auto text-xs text-zinc-500">{{ $sub->updated_at->diffForHumans(short: true) }}</flux:text>
+                                @endif
+                            </div>
+                            <flux:heading size="sm" class="mt-1">{{ $sub->name }}</flux:heading>
+                            @if ($sub->description)
+                                <x-markdown :content="$sub->description" class="mt-1 text-xs text-zinc-500" />
+                            @endif
+                        </div>
+                    </a>
+                @empty
+                    <flux:text class="text-zinc-500">{{ __('No subtasks yet.') }}</flux:text>
+                @endforelse
+            </section>
+        </div>
+    @endif
+</div>

--- a/resources/views/partials/story-task.blade.php
+++ b/resources/views/partials/story-task.blade.php
@@ -12,7 +12,13 @@
         @endif
     </div>
 
-    <flux:heading class="mt-1" size="sm">{{ $task->name }}</flux:heading>
+    <flux:heading class="mt-1" size="sm">
+        <a
+            href="{{ route('tasks.show', ['project' => $task->story->feature->project_id, 'story' => $task->story_id, 'task' => $task->id]) }}"
+            wire:navigate
+            class="hover:underline"
+        >{{ $task->name }}</a>
+    </flux:heading>
 
     @if ($task->description)
         <x-markdown :content="$task->description" class="mt-1 text-sm text-zinc-600 dark:text-zinc-400" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('projects/{project}/runs', 'pages::runs.index')->name('runs.index');
     Route::livewire('projects/{project}/repos', 'pages::repos.index')->name('repos.index');
     Route::livewire('projects/{project}/stories/{story}', 'pages::stories.show')->name('stories.show');
+    Route::livewire('projects/{project}/stories/{story}/tasks/{task}', 'pages::tasks.show')->name('tasks.show');
     Route::livewire('projects/{project}/stories/{story}/subtasks/{subtask}', 'pages::subtasks.show')->name('subtasks.show');
     Route::livewire('projects/{project}/stories/{story}/subtasks/{subtask}/runs/{run}', 'pages::runs.show')->name('runs.show');
 

--- a/tests/Feature/TaskShowTest.php
+++ b/tests/Feature/TaskShowTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Enums\TeamRole;
+use App\Models\AcceptanceCriterion;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Livewire\Livewire;
+
+function taskShowScene(): array
+{
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Admin);
+    $project = Project::factory()->for($team)->create(['name' => 'Specify']);
+    $feature = Feature::factory()->for($project)->create(['name' => 'Authoring']);
+    $story = Story::factory()->for($feature)->create(['name' => 'Manage stories']);
+    $ac = AcceptanceCriterion::create([
+        'story_id' => $story->id,
+        'position' => 1,
+        'criterion' => 'Users can edit a story.',
+    ]);
+    $task = Task::factory()->for($story)->create([
+        'name' => 'Add edit form',
+        'position' => 1,
+        'status' => TaskStatus::InProgress,
+        'acceptance_criterion_id' => $ac->id,
+    ]);
+    $subtask = Subtask::factory()->for($task)->create([
+        'name' => 'Wire input fields',
+        'position' => 1,
+    ]);
+
+    return compact('user', 'project', 'feature', 'story', 'ac', 'task', 'subtask');
+}
+
+test('task show page renders task name, AC, and subtask', function () {
+    ['user' => $user, 'project' => $project, 'story' => $story, 'task' => $task] = taskShowScene();
+    $this->actingAs($user);
+
+    Livewire::test('pages::tasks.show', [
+        'project' => $project->id,
+        'story' => $story->id,
+        'task' => $task->id,
+    ])
+        ->assertSee('Add edit form')
+        ->assertSee('Users can edit a story.')
+        ->assertSee('Wire input fields');
+});
+
+test('task show 404s when task is outside the user accessible projects', function () {
+    ['user' => $user] = taskShowScene();
+
+    $other = Workspace::factory()->create();
+    $otherTeam = Team::factory()->for($other)->create();
+    $otherProject = Project::factory()->for($otherTeam)->create();
+    $otherFeature = Feature::factory()->for($otherProject)->create();
+    $otherStory = Story::factory()->for($otherFeature)->create();
+    $otherTask = Task::factory()->for($otherStory)->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::tasks.show', [
+        'project' => $otherProject->id,
+        'story' => $otherStory->id,
+        'task' => $otherTask->id,
+    ])->assertStatus(404);
+});
+
+test('task show mount syncs current_project_id', function () {
+    ['user' => $user, 'project' => $project, 'story' => $story, 'task' => $task] = taskShowScene();
+    $other = Project::factory()->for($project->team)->create();
+    $user->forceFill(['current_project_id' => $other->id])->save();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::tasks.show', [
+        'project' => $project->id,
+        'story' => $story->id,
+        'task' => $task->id,
+    ]);
+
+    expect($user->fresh()->current_project_id)->toBe($project->id);
+});
+
+test('story show page links task names to the task show page', function () {
+    ['user' => $user, 'project' => $project, 'story' => $story, 'task' => $task] = taskShowScene();
+    $this->actingAs($user);
+
+    Livewire::test('pages::stories.show', ['story' => $story->id])
+        ->assertSeeHtml(route('tasks.show', [
+            'project' => $project->id,
+            'story' => $story->id,
+            'task' => $task->id,
+        ]));
+});


### PR DESCRIPTION
## Summary

Tackles #23, picking direction 1: every node in the hierarchy gets its own show page.

- New route \`projects/{p}/stories/{s}/tasks/{t}\` (\`tasks.show\`), mirroring the \`/subtasks/{u}\` URL shape.
- Volt SFC at \`resources/views/pages/tasks/⚡show.blade.php\`. Authz mirrors \`subtasks.show\` (404 outside accessible projects, mount syncs \`current_project_id\`).
- Header: task #, status pill, subtask counter, deps badge, and a card showing the linked acceptance criterion.
- Body: subtask list with their status pills and rail colour, each row a click-through to the subtask show.
- Story show page now wraps task names in a link to the new route, so clicking a task lands on its own surface instead of doing nothing.

Closes #23.

## Test plan

- [ ] \`composer test\` (347 / 347 green locally).
- [ ] Open a story → click any task name → land on the task show page.
- [ ] Page shows the task header + AC card + subtask list.
- [ ] Subtasks click through to the subtask page.
- [ ] Out-of-scope task URL 404s (covered by test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)