### PR TITLE
fix(ui): standardise hierarchy numbering across views

### DIFF
--- a/resources/views/pages/runs/⚡index.blade.php
+++ b/resources/views/pages/runs/⚡index.blade.php
@@ -157,8 +157,8 @@ new #[Title('Runs')] class extends Component {
                     <flux:text class="mt-1 text-xs text-zinc-500">
                         {{ $run->runnable->task->story->feature?->project?->name }}
                         &middot; {{ $run->runnable->task->story->name }}
-                        &middot; {{ __('task') }} #{{ $run->runnable->task->position }} {{ $run->runnable->task->name }}
-                        &middot; {{ __('subtask') }} #{{ $run->runnable->position }}
+                        &middot; T{{ $run->runnable->task->position }} {{ $run->runnable->task->name }}
+                        &middot; T{{ $run->runnable->task->position }}.{{ $run->runnable->position }}
                     </flux:text>
                 @endif
 

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -662,7 +662,7 @@ new #[Title('Story')] class extends Component {
                         <flux:label>{{ __('Acceptance criteria') }}</flux:label>
                         @foreach ($editCriteria as $i => $row)
                             <div wire:key="ac-{{ $i }}" class="flex items-start gap-2">
-                                <flux:badge class="mt-2">{{ __('AC') }} #{{ $i + 1 }}</flux:badge>
+                                <flux:badge class="mt-2" size="sm">AC{{ $i + 1 }}</flux:badge>
                                 <flux:textarea wire:model="editCriteria.{{ $i }}.criterion" rows="2" class="flex-1" />
                                 <flux:button wire:click="removeCriterion({{ $i }})" variant="ghost" size="sm" class="mt-1">{{ __('Remove') }}</flux:button>
                             </div>
@@ -881,7 +881,7 @@ new #[Title('Story')] class extends Component {
                         >
                             <summary class="flex cursor-pointer list-none flex-wrap items-baseline gap-2 text-sm [&::-webkit-details-marker]:hidden">
                                 <span class="text-zinc-400 transition-transform group-open:rotate-90" aria-hidden="true">▸</span>
-                                <flux:badge>{{ __('AC') }} #{{ $loop->iteration }}</flux:badge>
+                                <flux:badge size="sm">AC{{ $loop->iteration }}</flux:badge>
                                 <span class="font-medium">{{ $ac->criterion }}</span>
                             </summary>
 

--- a/resources/views/pages/subtasks/⚡show.blade.php
+++ b/resources/views/pages/subtasks/⚡show.blade.php
@@ -96,11 +96,11 @@ new #[Title('Subtask')] class extends Component {
 
             <div>
                 <div class="flex flex-wrap items-center gap-2 text-xs">
-                    <flux:badge variant="solid">{{ __('Subtask') }} #{{ $subtask->position }}</flux:badge>
-                    <flux:badge>{{ $subtask->status->value }}</flux:badge>
-                    <flux:badge>{{ __('Task') }} #{{ $task->position }}: {{ $task->name }}</flux:badge>
+                    <flux:badge size="sm">T{{ $task->position }}.{{ $subtask->position }}</flux:badge>
+                    <flux:badge size="sm">{{ $subtask->status->value }}</flux:badge>
+                    <flux:badge size="sm">T{{ $task->position }}: {{ $task->name }}</flux:badge>
                     @if ($subtask->proposed_by_run_id)
-                        <flux:badge color="amber" title="{{ __('Appended mid-run by') }} #{{ $subtask->proposed_by_run_id }} (ADR-0005)">{{ __('appended') }}</flux:badge>
+                        <flux:badge color="amber" size="sm" title="{{ __('Appended mid-run by') }} #{{ $subtask->proposed_by_run_id }} (ADR-0005)">{{ __('appended') }}</flux:badge>
                     @endif
                 </div>
                 <flux:heading size="xl" class="mt-2">{{ $subtask->name }}</flux:heading>

--- a/resources/views/pages/tasks/⚡show.blade.php
+++ b/resources/views/pages/tasks/⚡show.blade.php
@@ -65,7 +65,7 @@ new #[Title('Task')] class extends Component {
                 TaskStatus::Blocked => 'run_failed',
                 default => 'draft',
             };
-            $deps = $task->dependencies->map(fn ($d) => '#'.$d->position);
+            $deps = $task->dependencies->map(fn ($d) => 'T'.$d->position);
             $subtaskTotal = $task->subtasks->count();
             $subtaskDone = $task->subtasks->filter(fn ($s) => $s->status === TaskStatus::Done)->count();
         @endphp
@@ -85,13 +85,13 @@ new #[Title('Task')] class extends Component {
 
             <div>
                 <div class="flex flex-wrap items-center gap-2 text-xs">
-                    <flux:badge variant="solid">{{ __('Task') }} #{{ $task->position }}</flux:badge>
+                    <flux:badge size="sm">T{{ $task->position }}</flux:badge>
                     <x-state-pill :state="$rail" :label="$task->status->value" />
                     @if ($subtaskTotal > 0)
                         <flux:badge>{{ $subtaskDone }}/{{ $subtaskTotal }} {{ __('subtasks') }}</flux:badge>
                     @endif
                     @if ($deps->isNotEmpty())
-                        <flux:badge>{{ __('depends on') }} {{ $deps->implode(', ') }}</flux:badge>
+                        <flux:badge size="sm">{{ __('depends on') }} {{ $deps->implode(', ') }}</flux:badge>
                     @endif
                 </div>
                 <flux:heading size="xl" class="mt-2">{{ $task->name }}</flux:heading>
@@ -100,7 +100,7 @@ new #[Title('Task')] class extends Component {
                 @endif
                 @if ($ac)
                     <div class="mt-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
-                        <flux:text class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Acceptance criterion') }} #{{ $ac->position }}</flux:text>
+                        <flux:text class="text-xs uppercase tracking-wide text-zinc-500">{{ __('Acceptance criterion') }} AC{{ $ac->position }}</flux:text>
                         <flux:text class="mt-1 text-sm">{{ $ac->criterion }}</flux:text>
                     </div>
                 @endif
@@ -127,7 +127,7 @@ new #[Title('Task')] class extends Component {
                         <x-rail :state="$subRail" class="!w-0.5" />
                         <div class="min-w-0 flex-1">
                             <div class="flex flex-wrap items-center gap-2 text-xs">
-                                <flux:badge variant="solid" size="sm">#{{ $sub->position }}</flux:badge>
+                                <flux:badge size="sm">T{{ $task->position }}.{{ $sub->position }}</flux:badge>
                                 <x-state-pill :state="$subRail" :label="$sub->status->value" />
                                 @if ($latestRun)
                                     <flux:badge size="sm">{{ __('run') }} #{{ $latestRun->id }}</flux:badge>

--- a/resources/views/partials/story-task.blade.php
+++ b/resources/views/partials/story-task.blade.php
@@ -1,11 +1,11 @@
 @php
     /** @var \App\Models\Task $task */
-    $deps = $task->dependencies->map(fn ($d) => '#'.$d->position);
+    $deps = $task->dependencies->map(fn ($d) => 'T'.$d->position);
 @endphp
 
 <div class="mt-4 border-l-2 border-zinc-100 pl-3 dark:border-zinc-800" data-task-id="{{ $task->id }}">
     <div class="flex flex-wrap items-center gap-2 text-xs">
-        <flux:badge variant="solid" size="sm">#{{ $task->position }}</flux:badge>
+        <flux:badge size="sm">T{{ $task->position }}</flux:badge>
         <flux:badge size="sm">{{ $task->status->value }}</flux:badge>
         @if ($deps->isNotEmpty())
             <flux:badge size="sm">{{ __('depends on') }} {{ $deps->implode(', ') }}</flux:badge>
@@ -25,7 +25,7 @@
     @endif
 
     @if ($task->subtasks->isNotEmpty())
-        <ol class="mt-3 flex list-decimal flex-col gap-3 pl-5 text-sm marker:text-zinc-400">
+        <div class="mt-3 flex flex-col gap-3 text-sm">
             @foreach ($task->subtasks->sortBy('position') as $sub)
                 @php
                     $runs = $sub->agentRuns->sortByDesc('id')->values();
@@ -34,8 +34,9 @@
                     $appended = ! is_null($sub->proposed_by_run_id ?? null);
                     $hasError = $latestRun && $latestRun->error_message;
                 @endphp
-                <li data-subtask-id="{{ $sub->id }}">
+                <div data-subtask-id="{{ $sub->id }}">
                     <div class="flex flex-wrap items-center gap-2">
+                        <flux:badge size="sm">T{{ $task->position }}.{{ $sub->position }}</flux:badge>
                         <a
                             href="{{ route('subtasks.show', ['project' => $task->story->feature->project_id, 'story' => $task->story_id, 'subtask' => $sub->id]) }}"
                             wire:navigate
@@ -134,8 +135,8 @@
                             @endif
                         </div>
                     @endif
-                </li>
+                </div>
             @endforeach
-        </ol>
+        </div>
     @endif
 </div>


### PR DESCRIPTION
## Summary
- Use **AC{n}** / **T{n}** / **T{n}.{m}** consistently for acceptance criteria, tasks, and subtasks across the story / task / subtask / runs views.
- Uniform `flux:badge size=\"sm\"` treatment (no more mixed `variant=\"solid\"` blocks).
- Story-task partial drops the `<ol class=\"list-decimal\">` markers in favour of explicit `T{n}.{m}` badges so the numbers match across pages instead of resetting per task.

Follow-up to #22.

## Test plan
- [x] `./scripts/harness-check.sh` (350 tests pass)
- [ ] Story show: AC sidebar shows `AC1, AC2, ...`; tasks/subtasks render `T1`, `T1.1`, `T1.2`, `T2`, ...
- [ ] Task show: header pill is `T{n}`; subtask rows show `T{n}.{m}`
- [ ] Subtask show: hero pill is `T{n}.{m}`; parent task pill is `T{n}: …`
- [ ] Runs index: subtitle reads `T{n} {task name} · T{n}.{m}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)