### PR TITLE
feat(features): drag-and-drop story reordering

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -24,7 +24,7 @@ use InvalidArgumentException;
  * on plan replacement), and the only approval gate in the system
  * (see ADR-0001). Tasks attach directly to the Story (ADR-0002).
  */
-#[Fillable(['feature_id', 'created_by_id', 'name', 'slug', 'description', 'notes', 'status', 'revision'])]
+#[Fillable(['feature_id', 'created_by_id', 'name', 'slug', 'description', 'notes', 'status', 'revision', 'position'])]
 class Story extends Model
 {
     /** @use HasFactory<StoryFactory> */
@@ -55,6 +55,13 @@ class Story extends Model
 
     protected static function booted(): void
     {
+        static::creating(function (self $story) {
+            if (empty($story->position)) {
+                $max = static::where('feature_id', $story->feature_id)->max('position') ?? 0;
+                $story->position = $max + 1;
+            }
+        });
+
         static::updating(function (self $story) {
             if (self::$suppressRevisionBump) {
                 return;
@@ -93,6 +100,7 @@ class Story extends Model
         return [
             'status' => StoryStatus::class,
             'revision' => 'integer',
+            'position' => 'integer',
         ];
     }
 

--- a/database/migrations/2026_05_03_053325_add_position_to_stories_table.php
+++ b/database/migrations/2026_05_03_053325_add_position_to_stories_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            $table->unsignedInteger('position')->default(0)->after('feature_id');
+        });
+
+        DB::table('stories')
+            ->select('id', 'feature_id')
+            ->orderBy('feature_id')
+            ->orderBy('id')
+            ->get()
+            ->groupBy('feature_id')
+            ->each(function ($rows) {
+                $rows->values()->each(function ($row, $i) {
+                    DB::table('stories')->where('id', $row->id)->update(['position' => $i + 1]);
+                });
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            $table->dropColumn('position');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
                 "autoprefixer": "^10.4.20",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^3.0.0",
+                "sortablejs": "^1.15.7",
                 "tailwindcss": "^4.0.7",
                 "vite": "^8.0.0"
             },
@@ -1403,6 +1404,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/sortablejs": {
+            "version": "1.15.7",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+            "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+            "license": "MIT"
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.0.0",
+        "sortablejs": "^1.15.7",
         "tailwindcss": "^4.0.7",
         "vite": "^8.0.0"
     },

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,0 +1,17 @@
+import Sortable from 'sortablejs';
+
+document.addEventListener('alpine:init', () => {
+    window.Alpine.directive('sortable', (el, { expression }, { evaluate }) => {
+        Sortable.create(el, {
+            handle: '[data-sortable-handle]',
+            animation: 150,
+            ghostClass: 'opacity-50',
+            onEnd: () => {
+                const ids = Array.from(el.querySelectorAll('[data-sortable-id]'))
+                    .map((node) => parseInt(node.dataset.sortableId, 10))
+                    .filter((id) => !Number.isNaN(id));
+                evaluate(`${expression}(${JSON.stringify(ids)})`);
+            },
+        });
+    });
+});

--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -4,6 +4,7 @@ use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Models\Feature;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Attributes\Validate;
@@ -92,8 +93,40 @@ new #[Title('Feature')] class extends Component {
     public function stories()
     {
         return $this->feature
-            ? $this->feature->stories()->with('creator', 'tasks:id,story_id,status')->latest('updated_at')->get()
+            ? $this->feature->stories()
+                ->with('creator', 'tasks:id,story_id,status')
+                ->orderBy('position')
+                ->orderBy('id')
+                ->get()
             : collect();
+    }
+
+    /**
+     * @param  array<int, int>  $orderedIds  Story IDs in the new visual order.
+     */
+    public function reorderStories(array $orderedIds): void
+    {
+        $feature = $this->feature;
+        abort_unless($feature, 404);
+        abort_unless(Auth::user()->canApproveInProject($feature->project), 403);
+
+        $owned = $feature->stories()->pluck('id')->all();
+        $clean = array_values(array_filter(
+            array_map('intval', $orderedIds),
+            fn (int $id) => in_array($id, $owned, true),
+        ));
+
+        if (count($clean) !== count($owned)) {
+            return;
+        }
+
+        DB::transaction(function () use ($clean) {
+            foreach ($clean as $i => $id) {
+                DB::table('stories')->where('id', $id)->update(['position' => $i + 1]);
+            }
+        });
+
+        unset($this->stories);
     }
 
     /**
@@ -241,56 +274,85 @@ new #[Title('Feature')] class extends Component {
 
             <section class="flex flex-col gap-3" data-section="stories">
                 <flux:heading size="lg">{{ __('Stories') }}</flux:heading>
-                @forelse ($this->stories as $story)
-                    @php
-                        $rowState = match ($story->status->value) {
-                            StoryStatus::Draft->value, StoryStatus::ProposedByAI->value => 'draft',
-                            StoryStatus::PendingApproval->value => 'pending',
-                            StoryStatus::Approved->value => 'approved',
-                            StoryStatus::ChangesRequested->value => 'changes_requested',
-                            StoryStatus::Rejected->value, StoryStatus::Cancelled->value => 'rejected',
-                            StoryStatus::Done->value => 'run_complete',
-                            default => 'draft',
-                        };
-                        $tasksTotal = $story->tasks->count();
-                        $tasksDone = $story->tasks->filter(fn ($t) => $t->status === TaskStatus::Done)->count();
-                    @endphp
-                    <a href="{{ route('stories.show', ['project' => $feature->project_id, 'story' => $story->id]) }}" wire:navigate class="flex items-stretch gap-3 rounded-lg border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50" data-story-row="{{ $story->id }}">
-                        <x-rail :state="$rowState" class="!w-0.5" />
-                        <div class="min-w-0 flex-1">
-                            <div class="flex items-center gap-2">
-                                <div class="w-24 flex-none">
-                                    <x-state-pill :state="$rowState" :label="$story->status->value" />
-                                </div>
-                                <div class="w-14 flex-none">
-                                    <flux:badge size="sm">{{ __('rev') }} {{ $story->revision }}</flux:badge>
-                                </div>
-                                <div class="w-16 flex-none">
-                                    @if ($tasksTotal > 0)
-                                        <flux:badge size="sm">{{ $tasksDone }}/{{ $tasksTotal }}</flux:badge>
-                                    @endif
-                                </div>
-                                <div class="ml-auto flex flex-none items-center gap-2">
-                                    @if ($story->creator)
-                                        <flux:avatar
-                                            size="xs"
-                                            :name="$story->creator->name"
-                                            :initials="$story->creator->initials()"
-                                            :tooltip="$story->creator->name"
-                                        />
-                                    @endif
-                                    <flux:text class="text-xs text-zinc-500 tabular-nums">{{ $story->updated_at?->diffForHumans(short: true) }}</flux:text>
-                                </div>
-                            </div>
-                            <flux:heading class="mt-2">{{ $story->name }}</flux:heading>
-                            @if ($story->description)
-                                <x-markdown :content="$story->description" class="mt-1 text-sm text-zinc-600 dark:text-zinc-400" />
+                @php $canReorder = $this->canEditFeature() && $this->stories->count() > 1; @endphp
+                <div
+                    class="flex flex-col gap-3"
+                    @if ($canReorder)
+                        x-data
+                        x-sortable="$wire.reorderStories"
+                    @endif
+                    data-stories-list
+                >
+                    @forelse ($this->stories as $story)
+                        @php
+                            $rowState = match ($story->status->value) {
+                                StoryStatus::Draft->value, StoryStatus::ProposedByAI->value => 'draft',
+                                StoryStatus::PendingApproval->value => 'pending',
+                                StoryStatus::Approved->value => 'approved',
+                                StoryStatus::ChangesRequested->value => 'changes_requested',
+                                StoryStatus::Rejected->value, StoryStatus::Cancelled->value => 'rejected',
+                                StoryStatus::Done->value => 'run_complete',
+                                default => 'draft',
+                            };
+                            $tasksTotal = $story->tasks->count();
+                            $tasksDone = $story->tasks->filter(fn ($t) => $t->status === TaskStatus::Done)->count();
+                            $storyUrl = route('stories.show', ['project' => $feature->project_id, 'story' => $story->id]);
+                        @endphp
+                        <div
+                            class="relative flex items-stretch gap-3 rounded-lg border border-zinc-200 p-4 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                            data-story-row="{{ $story->id }}"
+                            data-sortable-id="{{ $story->id }}"
+                            wire:key="story-{{ $story->id }}"
+                        >
+                            <x-rail :state="$rowState" class="!w-0.5" />
+                            @if ($canReorder)
+                                <button
+                                    type="button"
+                                    data-sortable-handle
+                                    class="relative z-10 flex flex-none cursor-grab items-center text-zinc-400 hover:text-zinc-600 active:cursor-grabbing dark:hover:text-zinc-300"
+                                    aria-label="{{ __('Drag to reorder') }}"
+                                    title="{{ __('Drag to reorder') }}"
+                                >
+                                    <flux:icon.bars-3 class="size-5" />
+                                </button>
                             @endif
+                            <div class="min-w-0 flex-1">
+                                <div class="flex items-center gap-2">
+                                    <div class="w-24 flex-none">
+                                        <x-state-pill :state="$rowState" :label="$story->status->value" />
+                                    </div>
+                                    <div class="w-14 flex-none">
+                                        <flux:badge size="sm">{{ __('rev') }} {{ $story->revision }}</flux:badge>
+                                    </div>
+                                    <div class="w-16 flex-none">
+                                        @if ($tasksTotal > 0)
+                                            <flux:badge size="sm">{{ $tasksDone }}/{{ $tasksTotal }}</flux:badge>
+                                        @endif
+                                    </div>
+                                    <div class="ml-auto flex flex-none items-center gap-2">
+                                        @if ($story->creator)
+                                            <flux:avatar
+                                                size="xs"
+                                                :name="$story->creator->name"
+                                                :initials="$story->creator->initials()"
+                                                :tooltip="$story->creator->name"
+                                            />
+                                        @endif
+                                        <flux:text class="text-xs text-zinc-500 tabular-nums">{{ $story->updated_at?->diffForHumans(short: true) }}</flux:text>
+                                    </div>
+                                </div>
+                                <flux:heading class="mt-2">
+                                    <a href="{{ $storyUrl }}" wire:navigate class="before:absolute before:inset-0 before:content-['']">{{ $story->name }}</a>
+                                </flux:heading>
+                                @if ($story->description)
+                                    <x-markdown :content="$story->description" class="relative z-10 mt-1 text-sm text-zinc-600 dark:text-zinc-400" />
+                                @endif
+                            </div>
                         </div>
-                    </a>
-                @empty
-                    <flux:text class="text-zinc-500">{{ __('No stories yet for this feature.') }}</flux:text>
-                @endforelse
+                    @empty
+                        <flux:text class="text-zinc-500">{{ __('No stories yet for this feature.') }}</flux:text>
+                    @endforelse
+                </div>
             </section>
         </div>
     @endif

--- a/tests/Feature/FeatureShowTest.php
+++ b/tests/Feature/FeatureShowTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\TeamRole;
 use App\Models\Feature;
 use App\Models\Project;
 use App\Models\Story;
@@ -8,12 +9,12 @@ use App\Models\User;
 use App\Models\Workspace;
 use Livewire\Livewire;
 
-function featureShowScene(): array
+function featureShowScene(TeamRole $role = TeamRole::Admin): array
 {
     $ws = Workspace::factory()->create();
     $team = Team::factory()->for($ws)->create();
     $user = User::factory()->create();
-    $team->addMember($user);
+    $team->addMember($user, $role);
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create(['name' => 'Approval inbox']);
 
@@ -29,6 +30,63 @@ test('feature page lists its stories and links to a feature-prefilled create', f
     Livewire::test('pages::features.show', ['project' => $project->id, 'feature' => $feature->id])
         ->assertSee('Approval inbox')
         ->assertSee('Inline-listed-story');
+});
+
+test('new stories receive monotonic per-feature positions', function () {
+    ['feature' => $feature] = featureShowScene();
+    $a = Story::factory()->for($feature)->create();
+    $b = Story::factory()->for($feature)->create();
+    $c = Story::factory()->for($feature)->create();
+
+    expect([$a->fresh()->position, $b->fresh()->position, $c->fresh()->position])->toBe([1, 2, 3]);
+});
+
+test('reorderStories rewrites positions and survives a refresh', function () {
+    ['user' => $user, 'project' => $project, 'feature' => $feature] = featureShowScene();
+    $a = Story::factory()->for($feature)->create(['name' => 'Alpha']);
+    $b = Story::factory()->for($feature)->create(['name' => 'Bravo']);
+    $c = Story::factory()->for($feature)->create(['name' => 'Charlie']);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::features.show', ['project' => $project->id, 'feature' => $feature->id])
+        ->call('reorderStories', [$c->id, $a->id, $b->id]);
+
+    expect($c->fresh()->position)->toBe(1);
+    expect($a->fresh()->position)->toBe(2);
+    expect($b->fresh()->position)->toBe(3);
+});
+
+test('reorderStories ignores foreign ids and noops on incomplete payload', function () {
+    ['user' => $user, 'project' => $project, 'feature' => $feature] = featureShowScene();
+    $a = Story::factory()->for($feature)->create();
+    $b = Story::factory()->for($feature)->create();
+    $c = Story::factory()->for($feature)->create();
+
+    $otherFeature = Feature::factory()->for($project)->create();
+    $foreign = Story::factory()->for($otherFeature)->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::features.show', ['project' => $project->id, 'feature' => $feature->id])
+        ->call('reorderStories', [$b->id, $foreign->id, $a->id]);
+
+    expect($a->fresh()->position)->toBe(1);
+    expect($b->fresh()->position)->toBe(2);
+    expect($c->fresh()->position)->toBe(3);
+    expect($foreign->fresh()->position)->toBe(1);
+});
+
+test('Member cannot reorder stories', function () {
+    ['user' => $user, 'project' => $project, 'feature' => $feature] = featureShowScene(TeamRole::Member);
+    $a = Story::factory()->for($feature)->create();
+    $b = Story::factory()->for($feature)->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::features.show', ['project' => $project->id, 'feature' => $feature->id])
+        ->call('reorderStories', [$b->id, $a->id])
+        ->assertStatus(403);
 });
 
 test('out-of-scope feature 404s', function () {


### PR DESCRIPTION
## Summary
- New `stories.position` column with a per-feature monotonic seed (existing rows backfilled in id order).
- SortableJS-backed Alpine directive (`x-sortable`) wired to a Livewire `reorderStories(ids[])` action gated on `canApproveInProject`.
- Drag handles render only for users with reorder permission and only when the feature has 2+ stories.
- Story rows now use a stretched-link pattern (`::before` overlay on the heading) so the entire card stays clickable while the handle sits above it on `z-10`.

Closes the drag-and-drop follow-up from #21.

## Test plan
- [x] `./scripts/harness-check.sh` (354 tests pass)
- [x] `npm run build`
- [ ] Browser: drag a story handle in a feature show; confirm the new order persists after a refresh.
- [ ] Browser: as a Member, confirm no handles render and the row remains a normal clickable card.
- [ ] Browser: feature with one story shows no drag affordance.

> JS-side drag is exercised manually; Pest covers the `reorderStories` server method, the per-feature filter, and the Member 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)