### PR TITLE
refactor(runs): centralize active/terminal status rules

### DIFF
--- a/app/Enums/AgentRunStatus.php
+++ b/app/Enums/AgentRunStatus.php
@@ -25,11 +25,27 @@ enum AgentRunStatus: string
         };
     }
 
+    public function isActive(): bool
+    {
+        return ! $this->isTerminal();
+    }
+
     public function isFailure(): bool
     {
         return match ($this) {
             self::Failed, self::Aborted, self::Cancelled => true,
             default => false,
         };
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function activeValues(): array
+    {
+        return array_values(array_map(
+            fn (self $s) => $s->value,
+            array_filter(self::cases(), fn (self $s) => $s->isActive()),
+        ));
     }
 }

--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -6,6 +6,7 @@ use App\Enums\AgentRunKind;
 use App\Enums\AgentRunStatus;
 use Database\Factories\AgentRunFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -78,6 +79,16 @@ class AgentRun extends Model
     public function isTerminal(): bool
     {
         return $this->status->isTerminal();
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status->isActive();
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereIn('status', AgentRunStatus::activeValues());
     }
 
     public function retryOf(): BelongsTo

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -114,6 +114,22 @@ class Story extends Model
         return $this->hasMany(Task::class)->orderBy('position');
     }
 
+    /**
+     * True if any subtask under this story has an AgentRun that is still
+     * active (queued or running). Single source of truth for "this story
+     * is mid-execution" — UI gates and rail roll-ups read this.
+     */
+    public function hasActiveSubtaskRun(): bool
+    {
+        return AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->whereIn('runnable_id', Subtask::query()
+                ->whereIn('task_id', Task::query()->where('story_id', $this->getKey())->select('id'))
+                ->select('id'))
+            ->active()
+            ->exists();
+    }
+
     public function creator(): BelongsTo
     {
         return $this->belongsTo(User::class, 'created_by_id');

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -199,9 +199,7 @@ class ExecutionService
 
         DB::transaction(function () use ($story, $approval) {
             foreach ($this->nextActionableSubtasks($story) as $subtask) {
-                $hasOpenRun = $subtask->agentRuns()
-                    ->whereIn('status', [AgentRunStatus::Queued->value, AgentRunStatus::Running->value])
-                    ->exists();
+                $hasOpenRun = $subtask->agentRuns()->active()->exists();
                 if ($hasOpenRun) {
                     continue;
                 }
@@ -454,9 +452,7 @@ class ExecutionService
     public function cancelSubtask(Subtask $subtask, ?string $reason = null): int
     {
         $changed = 0;
-        foreach ($subtask->agentRuns()
-            ->whereIn('status', [AgentRunStatus::Queued->value, AgentRunStatus::Running->value])
-            ->get() as $run) {
+        foreach ($subtask->agentRuns()->active()->get() as $run) {
             if ($this->cancelRun($run, $reason)) {
                 $changed++;
             }
@@ -505,12 +501,7 @@ class ExecutionService
                 ->where('kind', AgentRunKind::Execute->value)
                 ->get();
 
-            $stillOpen = $siblings->contains(fn (AgentRun $r) => in_array(
-                $r->status,
-                [AgentRunStatus::Queued, AgentRunStatus::Running],
-                true,
-            ));
-            if ($stillOpen) {
+            if ($siblings->contains(fn (AgentRun $r) => $r->isActive())) {
                 return;
             }
 
@@ -558,10 +549,7 @@ class ExecutionService
         $approval = $authorizingApproval instanceof StoryApproval ? $authorizingApproval : null;
 
         foreach ($this->nextActionableSubtasks($story->fresh()) as $next) {
-            $hasOpenRun = $next->agentRuns()
-                ->whereIn('status', [AgentRunStatus::Queued->value, AgentRunStatus::Running->value])
-                ->exists();
-            if ($hasOpenRun) {
+            if ($next->agentRuns()->active()->exists()) {
                 continue;
             }
             $this->dispatchSubtaskExecution($next, $approval);

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -282,7 +282,7 @@ new #[Title('Story')] class extends Component {
 
         AgentRun::where('runnable_type', Subtask::class)
             ->whereIn('runnable_id', $subtaskIds)
-            ->whereIn('status', [AgentRunStatus::Queued, AgentRunStatus::Running])
+            ->active()
             ->update([
                 'status' => AgentRunStatus::Aborted->value,
                 'error_message' => 'Aborted on resume.',
@@ -377,17 +377,7 @@ new #[Title('Story')] class extends Component {
     #[Computed]
     public function hasActiveSubtaskRun(): bool
     {
-        $story = $this->story;
-        if (! $story) {
-            return false;
-        }
-
-        return $story->tasks->flatMap->subtasks->flatMap->agentRuns
-            ->contains(fn (AgentRun $run) => in_array(
-                $run->status,
-                [AgentRunStatus::Queued, AgentRunStatus::Running],
-                true,
-            ));
+        return (bool) $this->story?->hasActiveSubtaskRun();
     }
 
     /**
@@ -473,7 +463,7 @@ new #[Title('Story')] class extends Component {
         return AgentRun::query()
             ->where('runnable_type', Story::class)
             ->where('runnable_id', $this->story_id)
-            ->whereIn('status', [AgentRunStatus::Queued, AgentRunStatus::Running])
+            ->active()
             ->latest('id')
             ->first();
     }


### PR DESCRIPTION
## Summary
- The \"is this AgentRun still active\" rule was duplicated at six call sites — \`whereIn('status', [Queued, Running])\` in queries and \`in_array(\$run->status, [Queued, Running], true)\` in collections. A future status drift had to be patched in every location, and a Livewire component shouldn't encode domain rules.
- \`AgentRunStatus::isActive()\` / \`activeValues()\` — single source of truth (negation of \`isTerminal\`).
- \`AgentRun::isActive()\` instance helper + \`active()\` query scope so callers say \`->active()\`.
- \`Story::hasActiveSubtaskRun()\` — domain method on the aggregate root. The story show component now delegates instead of computing it inline.

Six call sites converged: \`ExecutionService\` (×4), \`stories/⚡show.blade.php\` (\`pendingPlanRun\` + resume cleanup + the inline computed), and the \`hasActiveSubtaskRun\` rollup.

## Test plan
- [x] \`./scripts/harness-check.sh\` (354 tests pass)
- [ ] Story show page renders the \"running\" rail when a subtask has an active run, and the \"done\" rail when none do.
- [ ] Resume on a story with stale Queued/Running runs aborts them as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)