### PR TITLE
fix(runs): close stuck-AgentRun gap with failed() handler + reaper

### DIFF
--- a/app/Console/Commands/ReapStuckRunsCommand.php
+++ b/app/Console/Commands/ReapStuckRunsCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Services\ExecutionService;
+use Illuminate\Console\Command;
+
+/**
+ * Operator safety net: find AgentRuns whose status is still active but whose
+ * `started_at` is older than the threshold, and mark them Failed.
+ *
+ * The queue's `failed()` callback (see ExecuteSubtaskJob) handles the common
+ * path where a worker dies; this command catches the residual where the
+ * failure callback itself didn't fire (worker process never returned, the
+ * row predates the failed() handler, or the job was dispatched on a queue
+ * driver that doesn't deliver failed callbacks).
+ */
+class ReapStuckRunsCommand extends Command
+{
+    protected $signature = 'runs:reap-stuck
+        {--minutes=60 : Mark runs Failed if started_at is older than this many minutes}
+        {--dry-run : List candidates without modifying any rows}';
+
+    protected $description = 'Mark long-running AgentRuns as Failed when their started_at exceeds the staleness threshold';
+
+    public function handle(ExecutionService $execution): int
+    {
+        $minutes = max(1, (int) $this->option('minutes'));
+        $cutoff = now()->subMinutes($minutes);
+        $dryRun = (bool) $this->option('dry-run');
+
+        $stuck = AgentRun::query()
+            ->whereIn('status', [AgentRunStatus::Queued->value, AgentRunStatus::Running->value])
+            ->whereNotNull('started_at')
+            ->where('started_at', '<', $cutoff)
+            ->orderBy('id')
+            ->get();
+
+        if ($stuck->isEmpty()) {
+            $this->info('No stuck runs found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->line(sprintf('Found %d stuck run(s) (started_at older than %d min):', $stuck->count(), $minutes));
+        foreach ($stuck as $run) {
+            $this->line(sprintf(
+                '  run #%d  status=%s  started_at=%s  runnable=%s#%s',
+                $run->getKey(),
+                $run->status->value,
+                optional($run->started_at)->toIso8601String() ?? '?',
+                class_basename($run->runnable_type ?? '?'),
+                $run->runnable_id ?? '?',
+            ));
+        }
+
+        if ($dryRun) {
+            $this->warn('Dry run — no rows modified.');
+
+            return self::SUCCESS;
+        }
+
+        $reason = sprintf('Reaped after %d minutes without progress.', $minutes);
+        foreach ($stuck as $run) {
+            $execution->markFailed($run, $reason);
+        }
+
+        $this->info(sprintf('Reaped %d run(s).', $stuck->count()));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Jobs/ExecuteSubtaskJob.php
+++ b/app/Jobs/ExecuteSubtaskJob.php
@@ -89,6 +89,32 @@ class ExecuteSubtaskJob implements ShouldQueue
     }
 
     /**
+     * Queue failure callback — fires when the worker dies, the job exceeds
+     * `tries`/`timeout`, or the framework otherwise decides this attempt is
+     * dead. The catch block in `handle()` covers exceptions thrown inside
+     * the pipeline; this covers the rest (worker SIGKILL, OOM, retry
+     * exhaustion). `markFailed` is idempotent so a double-mark is harmless.
+     */
+    public function failed(?Throwable $e): void
+    {
+        $run = AgentRun::find($this->agentRunId);
+        if ($run === null || $run->isTerminal()) {
+            return;
+        }
+
+        Log::error('specify.subtask.run.job_failed', [
+            'run_id' => $run->getKey(),
+            'subtask_id' => $run->runnable_id,
+            'exception' => $e?->getMessage(),
+        ]);
+
+        app(ExecutionService::class)->markFailed(
+            $run,
+            $e?->getMessage() ?: 'Job failed without surfacing an exception (worker died or retries exhausted).',
+        );
+    }
+
+    /**
      * Fire the ADR-conformance review job after the AgentRun has been
      * persisted by markSucceeded. Dispatched here (not from the pipeline)
      * so the queued job sees `output.pull_request_number` and `diff`

--- a/app/Jobs/GenerateTasksJob.php
+++ b/app/Jobs/GenerateTasksJob.php
@@ -9,6 +9,7 @@ use App\Services\ExecutionService;
 use App\Services\PlanWriter;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 /**
@@ -56,6 +57,30 @@ class GenerateTasksJob implements ShouldQueue
 
             throw $e;
         }
+    }
+
+    /**
+     * Queue failure callback — covers worker death / retry exhaustion that
+     * the catch block in `handle()` can't see. `markFailed` is idempotent so
+     * a double-mark with the catch block is harmless.
+     */
+    public function failed(?Throwable $e): void
+    {
+        $run = AgentRun::find($this->agentRunId);
+        if ($run === null || $run->isTerminal()) {
+            return;
+        }
+
+        Log::error('specify.tasks.generate.job_failed', [
+            'run_id' => $run->getKey(),
+            'story_id' => $run->runnable_id,
+            'exception' => $e?->getMessage(),
+        ]);
+
+        app(ExecutionService::class)->markFailed(
+            $run,
+            $e?->getMessage() ?: 'Job failed without surfacing an exception (worker died or retries exhausted).',
+        );
     }
 
     /**

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -286,14 +286,35 @@ class ExecutionService
      * Persist a failed AgentRun. Subtask status is *not* flipped to Blocked
      * here — `finalizeSubtaskFromRun` decides Done vs Blocked once every
      * racing sibling has terminated.
+     *
+     * Idempotent: the UPDATE is conditional on a non-terminal status. A late
+     * caller (e.g. the queue's `failed()` callback after the catch block has
+     * already marked the row Failed, or after a cooperative Cancelled) sees
+     * zero rows affected and bails — terminal stays terminal.
      */
     public function markFailed(AgentRun $run, string $error): void
     {
+        $affected = AgentRun::query()
+            ->whereKey($run->getKey())
+            ->whereIn('status', [
+                AgentRunStatus::Queued->value,
+                AgentRunStatus::Running->value,
+            ])
+            ->update([
+                'status' => AgentRunStatus::Failed->value,
+                'error_message' => $error,
+                'finished_at' => now(),
+            ]);
+
+        if ($affected === 0) {
+            return;
+        }
+
         $run->forceFill([
             'status' => AgentRunStatus::Failed->value,
             'error_message' => $error,
             'finished_at' => now(),
-        ])->save();
+        ])->syncOriginal();
 
         if ($run->runnable_type === Subtask::class) {
             $this->finalizeSubtaskFromRun($run);

--- a/tests/Feature/ReapStuckRunsTest.php
+++ b/tests/Feature/ReapStuckRunsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Jobs\ExecuteSubtaskJob;
+use App\Jobs\GenerateTasksJob;
+use App\Models\AgentRun;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Services\ExecutionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('markFailed is idempotent — terminal status is preserved', function () {
+    $run = AgentRun::factory()->create([
+        'status' => AgentRunStatus::Succeeded->value,
+        'finished_at' => now(),
+    ]);
+
+    app(ExecutionService::class)->markFailed($run, 'late callback');
+
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Succeeded)
+        ->and($run->fresh()->error_message)->toBeNull();
+});
+
+test('markFailed flips an active run to Failed', function () {
+    $run = AgentRun::factory()->create([
+        'status' => AgentRunStatus::Running->value,
+        'started_at' => now()->subMinutes(5),
+    ]);
+
+    app(ExecutionService::class)->markFailed($run, 'boom');
+
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Failed)
+        ->and($run->fresh()->error_message)->toBe('boom');
+});
+
+test('ExecuteSubtaskJob::failed() marks a still-active run Failed', function () {
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => 999_999,
+        'status' => AgentRunStatus::Running->value,
+        'started_at' => now()->subMinutes(2),
+    ]);
+
+    (new ExecuteSubtaskJob($run->getKey()))->failed(new RuntimeException('worker died'));
+
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Failed)
+        ->and($run->fresh()->error_message)->toContain('worker died');
+});
+
+test('ExecuteSubtaskJob::failed() is a no-op for terminal runs', function () {
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => 999_999,
+        'status' => AgentRunStatus::Failed->value,
+        'error_message' => 'original failure',
+        'finished_at' => now(),
+    ]);
+
+    (new ExecuteSubtaskJob($run->getKey()))->failed(new RuntimeException('late callback'));
+
+    expect($run->fresh()->error_message)->toBe('original failure');
+});
+
+test('GenerateTasksJob::failed() marks a still-active task-gen run Failed', function () {
+    $story = Story::factory()->create();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Story::class,
+        'runnable_id' => $story->getKey(),
+        'status' => AgentRunStatus::Running->value,
+        'started_at' => now()->subMinutes(2),
+    ]);
+
+    (new GenerateTasksJob($run->getKey()))->failed(new RuntimeException('worker oom'));
+
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Failed)
+        ->and($run->fresh()->error_message)->toContain('worker oom');
+});
+
+test('runs:reap-stuck marks stale active runs Failed', function () {
+    $stale = AgentRun::factory()->create([
+        'status' => AgentRunStatus::Running->value,
+        'started_at' => now()->subHours(3),
+    ]);
+    $fresh = AgentRun::factory()->create([
+        'status' => AgentRunStatus::Running->value,
+        'started_at' => now()->subMinutes(5),
+    ]);
+    $done = AgentRun::factory()->create([
+        'status' => AgentRunStatus::Succeeded->value,
+        'started_at' => now()->subHours(3),
+        'finished_at' => now()->subHours(2),
+    ]);
+
+    $this->artisan('runs:reap-stuck', ['--minutes' => 60])
+        ->assertExitCode(0);
+
+    expect($stale->fresh()->status)->toBe(AgentRunStatus::Failed)
+        ->and($stale->fresh()->error_message)->toContain('Reaped')
+        ->and($fresh->fresh()->status)->toBe(AgentRunStatus::Running)
+        ->and($done->fresh()->status)->toBe(AgentRunStatus::Succeeded);
+});
+
+test('runs:reap-stuck --dry-run lists candidates without modifying rows', function () {
+    $stale = AgentRun::factory()->create([
+        'status' => AgentRunStatus::Running->value,
+        'started_at' => now()->subHours(3),
+    ]);
+
+    $this->artisan('runs:reap-stuck', ['--minutes' => 60, '--dry-run' => true])
+        ->assertExitCode(0);
+
+    expect($stale->fresh()->status)->toBe(AgentRunStatus::Running);
+});


### PR DESCRIPTION
## Summary

Defensive fix for the upstream cause of run #34 (stuck `running` for days with `error_message` set, requiring tinker to clear). The catch block in `ExecuteSubtaskJob` covers exceptions thrown inside the pipeline, but nothing covered worker death, OOM, or retry exhaustion — so a row could end up persistently active.

- `ExecuteSubtaskJob::failed()` and `GenerateTasksJob::failed()` — Laravel's queue failure callbacks. Fire after worker death / retry exhaustion and call `markFailed` if the row is still non-terminal.
- `ExecutionService::markFailed` is now idempotent — the UPDATE is guarded on a non-terminal status (mirroring `markRunning`). A late `failed()` callback after the catch block already terminated the row sees zero rows affected and bails.
- `php artisan runs:reap-stuck` (`--minutes`, `--dry-run`) — operator safety net for runs that escape both surfaces.

## Note on PR #42

PR #42 centralizes "what is active" via an `AgentRunStatus::activeValues()` helper and an `AgentRun::scopeActive`. To keep this PR independent, the new code uses raw `whereIn('status', [Queued, Running])` directly. Once #42 lands, a small follow-up sweep can switch `markFailed` and `ReapStuckRunsCommand` to use the centralized helpers.

## Test plan

- [x] `composer test` (361 passing, 7 new)
- [x] `./scripts/harness-check.sh`
- [x] `markFailed` idempotency on terminal rows
- [x] `ExecuteSubtaskJob::failed()` marks active → Failed; no-op on terminal
- [x] `GenerateTasksJob::failed()` marks active → Failed
- [x] `runs:reap-stuck` flips stale runs Failed; `--dry-run` is read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)