### PR TITLE
feat(stories): merge-conflict resolution with configured executor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,7 @@ VITE_APP_NAME="${APP_NAME}"
 # Laravel AI (Specify) — Anthropic for in-app agents. Uses SPECIFY_* so ANTHROPIC_API_KEY can stay for CLI tools.
 SPECIFY_ANTHROPIC_API_KEY=
 # SPECIFY_ANTHROPIC_URL=https://api.anthropic.com/v1
+# SPECIFY_CONFLICT_RESOLUTION_MAX_CYCLES=3
 
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
 
+# Laravel AI (Specify) — Anthropic for in-app agents. Uses SPECIFY_* so ANTHROPIC_API_KEY can stay for CLI tools.
+SPECIFY_ANTHROPIC_API_KEY=
+# SPECIFY_ANTHROPIC_URL=https://api.anthropic.com/v1
+
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_REDIRECT_URI="${APP_URL}/auth/github/callback"

--- a/app/Enums/AgentRunKind.php
+++ b/app/Enums/AgentRunKind.php
@@ -16,9 +16,15 @@ namespace App\Enums;
  * the same branch. The cascade gate **ignores** RespondToReview runs —
  * review responses don't change Subtask status. The cap on cycles per PR
  * lives on the `repos` row.
+ *
+ * `ResolveConflicts` is a human-triggered merge-conflict repair on the
+ * Story's primary PR: merge `origin/{default_branch}` with `--no-ff`, resolve
+ * conflicts with AI, push one commit. The cascade gate ignores these runs
+ * (same as RespondToReview).
  */
 enum AgentRunKind: string
 {
     case Execute = 'execute';
     case RespondToReview = 'respond_to_review';
+    case ResolveConflicts = 'resolve_conflicts';
 }

--- a/app/Jobs/ResolveConflictsJob.php
+++ b/app/Jobs/ResolveConflictsJob.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\AgentRunKind;
+use App\Models\AgentRun;
+use App\Models\Subtask;
+use App\Services\ConflictResolutionPrompt;
+use App\Services\ExecutionService;
+use App\Services\Executors\ExecutorFactory;
+use App\Services\Progress\ProgressEmitter;
+use App\Services\PullRequests\GithubPullRequestProbe;
+use App\Services\WorkspaceRunner;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Queue job for a `ResolveConflicts` AgentRun — merge-conflict repair on the Story's primary PR.
+ *
+ * Uses the same executor driver as recorded on the AgentRun (`executor_driver` from the
+ * originating Execute run), resolved via {@see ExecutorFactory} and `config/specify.php`.
+ *
+ * Serialised per repo+branch like {@see RespondToPrReviewJob} to avoid concurrent git corruption.
+ */
+class ResolveConflictsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public int $agentRunId) {}
+
+    public function handle(
+        ExecutionService $execution,
+        WorkspaceRunner $workspace,
+        GithubPullRequestProbe $github,
+        ExecutorFactory $executors,
+    ): void {
+        $run = AgentRun::findOrFail($this->agentRunId);
+
+        if ($run->kind !== AgentRunKind::ResolveConflicts) {
+            $execution->markFailed($run, 'ResolveConflictsJob dispatched for a non-conflict-resolution AgentRun.');
+
+            return;
+        }
+
+        $subtask = $run->runnable;
+        $repo = $run->repo;
+        $prNumber = (int) ($run->output['pull_request_number'] ?? 0);
+        $branch = $run->working_branch;
+        $base = $repo?->default_branch ?? 'main';
+
+        if (! $subtask instanceof Subtask || $repo === null || $prNumber === 0 || $branch === null || $branch === '') {
+            $execution->markFailed($run, 'ResolveConflictsJob: incomplete run state (subtask/repo/PR number/branch missing).');
+
+            return;
+        }
+
+        if (! $execution->markRunning($run)) {
+            return;
+        }
+
+        $driver = $run->executor_driver !== null && $run->executor_driver !== ''
+            ? (string) $run->executor_driver
+            : $executors->defaultDriver();
+        $executor = $executors->make($driver);
+
+        if (! $executor->needsWorkingDirectory()) {
+            $execution->markFailed($run, 'Conflict resolution requires an executor with a working directory (configure a cli or laravel-ai driver in specify.executor).');
+
+            return;
+        }
+
+        $logCtx = [
+            'run_id' => $run->getKey(),
+            'subtask_id' => $subtask->getKey(),
+            'pull_request_number' => $prNumber,
+            'branch' => $branch,
+            'executor_driver' => $driver,
+        ];
+
+        $lockKey = sprintf('specify:resolve-conflicts:%d:%s', $repo->getKey(), $branch);
+        $workingDir = '';
+
+        try {
+            Cache::lock($lockKey, 1800)->block(300, function () use ($run, $repo, $branch, $base, $prNumber, $subtask, $execution, $workspace, $github, $executor, $driver, $logCtx, &$workingDir) {
+                $workingDir = $workspace->prepare($repo, $run);
+                $workspace->checkoutBranch($workingDir, $branch, baseBranch: $base);
+                $workspace->fetchOriginBranch($workingDir, $base);
+
+                Log::info('specify.resolve_conflicts.workspace.ready', $logCtx + ['working_dir' => $workingDir]);
+
+                $headBefore = $workspace->currentHeadSha($workingDir);
+                $mergeExit = $workspace->mergeNoFfFromOrigin($workingDir, $base);
+
+                if ($mergeExit === 0) {
+                    $headAfter = $workspace->currentHeadSha($workingDir);
+                    if ($headBefore === $headAfter) {
+                        Log::info('specify.resolve_conflicts.merge_up_to_date', $logCtx);
+                    } else {
+                        $workspace->resetHardToOriginBranch($workingDir, $branch);
+                    }
+
+                    $execution->markSucceeded($run, [
+                        'pull_request_number' => $prNumber,
+                        'origin_run_id' => (int) ($run->output['origin_run_id'] ?? 0),
+                        'stale_mergeability' => true,
+                        'message' => 'Merge completed without conflicts (GitHub mergeability was stale or branch already matched base).',
+                    ], null);
+
+                    return;
+                }
+
+                if (! $workspace->hasUnmergedPaths($workingDir)) {
+                    $workspace->mergeAbort($workingDir);
+                    $execution->markFailed($run, 'Merge failed but git did not report unmerged paths; aborting.');
+
+                    return;
+                }
+
+                $unmerged = $workspace->unmergedPaths($workingDir);
+
+                $prompt = ConflictResolutionPrompt::forExecutorContext(
+                    $subtask,
+                    $repo,
+                    $branch,
+                    $base,
+                    $prNumber,
+                    $unmerged,
+                );
+
+                $emitter = $executor->supportsProgressEvents() ? tap(new ProgressEmitter($run), fn (ProgressEmitter $e) => $e->setPhase('execute')) : null;
+
+                $result = $executor->execute($subtask, $workingDir, $repo, $branch, null, $emitter, $prompt);
+
+                if ($workspace->hasUnmergedPaths($workingDir)) {
+                    throw new RuntimeException('Unmerged paths remain after the executor finished.');
+                }
+
+                $commitMessage = "fix: resolve merge conflict with {$base} (PR #{$prNumber})";
+
+                $commitSha = $workspace->commit($workingDir, $commitMessage);
+                if ($commitSha === null) {
+                    throw new RuntimeException('No commit was created after resolving conflicts.');
+                }
+
+                $diff = $workspace->diff($workingDir);
+
+                $workspace->push($workingDir, $branch);
+
+                $summary = trim($result->summary);
+                $commentBody = "Specify **conflict resolution** (run #{$run->getKey()}, executor `{$driver}`)\n\n{$summary}\n\nCommit: `{$commitSha}`";
+                $github->postIssueComment($repo, $prNumber, $commentBody);
+
+                $payload = [
+                    'pull_request_number' => $prNumber,
+                    'origin_run_id' => (int) ($run->output['origin_run_id'] ?? 0),
+                    'summary' => $summary,
+                    'files_changed' => $result->filesChanged,
+                    'conflict_resolutions' => [],
+                    'commit_message' => $commitMessage,
+                    'commit_sha' => $commitSha,
+                    'pushed' => true,
+                    'executor_driver' => $driver,
+                ];
+                if ($result->executorLog !== null && $result->executorLog !== '') {
+                    $payload['executor_log'] = $result->executorLog;
+                }
+
+                Log::info('specify.resolve_conflicts.pushed', $logCtx + ['commit_sha' => $commitSha]);
+                $execution->markSucceeded($run, $payload, $diff);
+            });
+        } catch (Throwable $e) {
+            if ($workingDir !== '') {
+                try {
+                    if ($workspace->hasUnmergedPaths($workingDir)) {
+                        $workspace->mergeAbort($workingDir);
+                    }
+                    $workspace->discardLocalChanges($workingDir, $branch, $base);
+                } catch (Throwable) {
+                    // best-effort cleanup
+                }
+            }
+
+            Log::error('specify.resolve_conflicts.failed', $logCtx + [
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+            $execution->markFailed($run, $e->getMessage());
+
+            throw $e instanceof RuntimeException ? $e : new RuntimeException($e->getMessage(), 0, $e);
+        }
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $run = AgentRun::find($this->agentRunId);
+        if ($run === null || $run->isTerminal()) {
+            return;
+        }
+
+        app(ExecutionService::class)->markFailed(
+            $run,
+            $exception?->getMessage() ?? 'ResolveConflictsJob failed.',
+        );
+    }
+}

--- a/app/Jobs/RespondToPrReviewJob.php
+++ b/app/Jobs/RespondToPrReviewJob.php
@@ -104,7 +104,8 @@ class RespondToPrReviewJob implements ShouldQueue
                     workingDir: $workingDir,
                 );
 
-                $output = $agent->run()->structured();
+                $response = $agent->prompt($agent->buildPrompt());
+                $output = $response->toArray();
 
                 $clarifications = (array) ($output['clarifications'] ?? []);
                 $summary = trim((string) ($output['summary'] ?? ''));

--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -23,8 +23,9 @@ use RuntimeException;
  *
  * `kind` distinguishes the historical `Execute` run (produces the Subtask
  * diff and opens a PR) from `RespondToReview` (ADR-0008 — pushes a
- * `fix(review):` commit on the originating Subtask's open PR). The cascade
- * gate ignores RespondToReview runs.
+ * `fix(review):` commit on the originating Subtask's open PR) and
+ * `ResolveConflicts` (human-triggered merge-conflict repair on the primary
+ * PR). The cascade gate ignores RespondToReview and ResolveConflicts runs.
  */
 #[Fillable([
     'runnable_type', 'runnable_id',

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -3,9 +3,11 @@
 namespace App\Models;
 
 use App\Enums\AgentRunKind;
+use App\Enums\RepoProvider;
 use App\Enums\StoryStatus;
 use App\Models\Concerns\HasSlug;
 use App\Services\ApprovalService;
+use App\Services\PullRequests\GithubPullRequestProbe;
 use Database\Factories\StoryFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -130,6 +132,23 @@ class Story extends Model
             ->exists();
     }
 
+    /**
+     * Latest in-flight `ResolveConflicts` run for any subtask under this story.
+     */
+    public function activeConflictResolutionAgentRun(): ?AgentRun
+    {
+        return AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->whereIn('runnable_id', Subtask::query()
+                ->whereIn('task_id', Task::query()->where('story_id', $this->getKey())->select('id'))
+                ->select('id'))
+            ->where('kind', AgentRunKind::ResolveConflicts->value)
+            ->active()
+            ->with('runnable')
+            ->latest('id')
+            ->first();
+    }
+
     public function creator(): BelongsTo
     {
         return $this->belongsTo(User::class, 'created_by_id');
@@ -158,10 +177,12 @@ class Story extends Model
      * `pull_request_number` is just a back-pointer, not a new PR.
      *
      * Each entry: `{ url, number, driver, branch, run_id, merged, action,
-     * run_finished_at }`. `run_finished_at` is the terminal timestamp of
-     * the AgentRun that recorded the PR, *not* the PR's upstream open
-     * time — we don't fetch that. Ordered by most recent run first; any
-     * merged PR is hoisted to the top.
+     * run_finished_at, mergeable, mergeable_state }`. `mergeable` and
+     * `mergeable_state` come from a best-effort GitHub API probe (null when
+     * unknown, non-GitHub repos, or API errors). `run_finished_at` is the
+     * terminal timestamp of the AgentRun that recorded the PR, *not* the PR's
+     * upstream open time — we don't fetch that. Ordered by most recent run
+     * first; any merged PR is hoisted to the top.
      *
      * @return Collection<int, array<string, mixed>>
      */
@@ -183,7 +204,7 @@ class Story extends Model
             ->where('kind', AgentRunKind::Execute->value)
             ->whereJsonContainsKey('output->pull_request_url')
             ->orderByDesc('id')
-            ->get(['id', 'executor_driver', 'working_branch', 'output', 'finished_at'])
+            ->get(['id', 'repo_id', 'executor_driver', 'working_branch', 'output', 'finished_at'])
             ->map(function (AgentRun $run) {
                 $o = (array) $run->output;
                 $url = (string) ($o['pull_request_url'] ?? '');
@@ -197,6 +218,7 @@ class Story extends Model
                     'driver' => $run->executor_driver,
                     'branch' => $run->working_branch,
                     'run_id' => $run->getKey(),
+                    'repo_id' => $run->repo_id,
                     'merged' => $o['pull_request_merged'] ?? null,
                     'action' => $o['pull_request_action'] ?? null,
                     // The run's terminal timestamp — *not* the PR's open
@@ -219,11 +241,35 @@ class Story extends Model
             ->map(fn (Collection $g) => $g->first())
             ->values();
 
+        $repoIds = $entries->pluck('repo_id')->filter()->unique()->values();
+        $reposById = Repo::query()->whereIn('id', $repoIds)->get()->keyBy('id');
+        $probe = app(GithubPullRequestProbe::class);
+
         // Hoist merged PRs to the top while preserving the id-desc order
         // within each partition. A compound sort key (merged-bit, then
         // -run_id) is order-stable across PHP / Laravel versions and
         // doesn't depend on Collection::sortBy's stability semantics.
         return $entries
+            ->map(function (array $pr) use ($probe, $reposById) {
+                $repoId = $pr['repo_id'] ?? null;
+                unset($pr['repo_id']);
+                $pr['mergeable'] = null;
+                $pr['mergeable_state'] = null;
+
+                $number = $pr['number'] ?? null;
+                if ($repoId && is_numeric($number)) {
+                    $repo = $reposById->get($repoId);
+                    if ($repo && $repo->provider === RepoProvider::Github) {
+                        $result = $probe->probeMergeable($repo, (int) $number);
+                        if ($result !== null) {
+                            $pr['mergeable'] = $result['mergeable'];
+                            $pr['mergeable_state'] = $result['mergeable_state'];
+                        }
+                    }
+                }
+
+                return $pr;
+            })
             ->sortBy(fn ($pr) => [
                 $pr['merged'] === true ? 0 : 1,
                 -1 * (int) $pr['run_id'],

--- a/app/Services/ConflictResolutionPrompt.php
+++ b/app/Services/ConflictResolutionPrompt.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Repo;
+use App\Models\Subtask;
+use App\Services\Prompts\PromptLoader;
+
+/**
+ * Builds the prompt passed to the configured executor for ResolveConflicts runs.
+ */
+final class ConflictResolutionPrompt
+{
+    /**
+     * @param  list<string>  $unmergedPaths
+     */
+    public static function forExecutorContext(
+        Subtask $subtask,
+        Repo $repo,
+        string $workingBranch,
+        string $baseBranch,
+        int $pullRequestNumber,
+        array $unmergedPaths,
+    ): string {
+        $subtask->loadMissing('task.story', 'task.acceptanceCriterion');
+        $task = $subtask->task;
+        $story = $task?->story;
+        $criterion = $task?->acceptanceCriterion?->criterion;
+
+        $criterionBlock = $criterion ? "Acceptance Criterion: {$criterion}\n\n" : '';
+        $taskBlock = $task ? "Parent Task #{$task->position}: {$task->name}\n" : '';
+
+        $files = $unmergedPaths === []
+            ? '(unknown — inspect git status)'
+            : implode("\n", array_map(fn (string $p) => '- '.$p, $unmergedPaths));
+
+        $repoLine = "Repository: {$repo->url} (working branch: {$workingBranch}, base: {$baseBranch})";
+
+        $preamble = app(PromptLoader::class)->load('conflict-resolver-executor');
+
+        $detail = implode("\n", array_filter([
+            $story ? "Story: {$story->name}" : null,
+            '',
+            'Description:',
+            $story ? (string) $story->description : '',
+            '',
+            $criterionBlock.$taskBlock.'Subtask #'.$subtask->position.': '.$subtask->name,
+            '',
+            'Subtask description:',
+            (string) $subtask->description,
+            '',
+            $repoLine,
+            '',
+            "Open Pull Request: #{$pullRequestNumber}",
+            '',
+            "A merge of `origin/{$baseBranch}` into `{$workingBranch}` (`git merge --no-ff`) is in progress and has conflicts.",
+            '',
+            'Unmerged paths reported by git:',
+            $files,
+            '',
+            'Resolve every conflict so `git` no longer reports unmerged paths.',
+        ]));
+
+        return $preamble."\n\n---\n\n".$detail;
+    }
+}

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -10,6 +10,7 @@ use App\Enums\TaskStatus;
 use App\Jobs\ExecuteSubtaskJob;
 use App\Jobs\GenerateTasksJob;
 use App\Jobs\OpenPullRequestJob;
+use App\Jobs\ResolveConflictsJob;
 use App\Jobs\RespondToPrReviewJob;
 use App\Models\AgentRun;
 use App\Models\Repo;
@@ -139,6 +140,69 @@ class ExecutionService
             ]);
 
             RespondToPrReviewJob::dispatch($run->getKey());
+
+            return ['status' => 'dispatched', 'run' => $run, 'cycle' => $cycles + 1];
+        });
+    }
+
+    /**
+     * Queue a `ResolveConflicts` AgentRun for the Story's primary GitHub PR when
+     * mergeability is false, subject to a per-PR attempt cap.
+     *
+     * @return array{status: string, run?: AgentRun, cycle?: int, cycles?: int}
+     */
+    public function dispatchConflictResolution(Story $story): array
+    {
+        $pr = $story->primaryPullRequest();
+        if ($pr === null || ($pr['mergeable'] ?? null) !== false) {
+            return ['status' => 'not_applicable'];
+        }
+
+        $executeRun = AgentRun::query()->with('repo')->find($pr['run_id'] ?? 0);
+        if (! $executeRun instanceof AgentRun || $executeRun->kind !== AgentRunKind::Execute) {
+            return ['status' => 'missing_origin_run'];
+        }
+
+        $repo = $executeRun->repo;
+        if ($repo === null) {
+            return ['status' => 'missing_repo'];
+        }
+
+        $prNumber = (int) ($pr['number'] ?? 0);
+        if ($prNumber === 0) {
+            return ['status' => 'missing_pr_number'];
+        }
+
+        $max = (int) config('specify.conflict_resolution.max_cycles_per_pr', 3);
+
+        return DB::transaction(function () use ($repo, $executeRun, $prNumber, $max) {
+            $repo = Repo::query()->whereKey($repo->getKey())->lockForUpdate()->first() ?? $repo;
+
+            $cycles = AgentRun::query()
+                ->where('repo_id', $repo->getKey())
+                ->where('kind', AgentRunKind::ResolveConflicts->value)
+                ->whereJsonContains('output->pull_request_number', $prNumber)
+                ->count();
+
+            if ($cycles >= $max) {
+                return ['status' => 'max_cycles_reached', 'cycles' => $cycles];
+            }
+
+            $run = AgentRun::create([
+                'runnable_type' => $executeRun->runnable_type,
+                'runnable_id' => $executeRun->runnable_id,
+                'repo_id' => $repo->getKey(),
+                'working_branch' => $executeRun->working_branch,
+                'executor_driver' => $executeRun->executor_driver,
+                'kind' => AgentRunKind::ResolveConflicts->value,
+                'status' => AgentRunStatus::Queued,
+                'output' => [
+                    'pull_request_number' => $prNumber,
+                    'origin_run_id' => $executeRun->getKey(),
+                ],
+            ]);
+
+            ResolveConflictsJob::dispatch($run->getKey());
 
             return ['status' => 'dispatched', 'run' => $run, 'cycle' => $cycles + 1];
         });
@@ -287,6 +351,11 @@ class ExecutionService
      */
     public function markFailed(AgentRun $run, string $error): void
     {
+        $run->refresh();
+        if ($run->isTerminal()) {
+            return;
+        }
+
         $run->forceFill([
             'status' => AgentRunStatus::Failed->value,
             'error_message' => $error,
@@ -382,6 +451,9 @@ class ExecutionService
         }
         if ($fromRun->kind === AgentRunKind::RespondToReview) {
             throw new RuntimeException('Review-response runs are not retryable; new review events re-fire automatically.');
+        }
+        if ($fromRun->kind === AgentRunKind::ResolveConflicts) {
+            throw new RuntimeException('Conflict-resolution runs are not retryable from the run console.');
         }
         if (! $fromRun->isTerminal()) {
             throw new RuntimeException('Cannot retry a run that is still in flight.');
@@ -485,7 +557,7 @@ class ExecutionService
         // RespondToReview run only pushes a `fix(review):` commit on its
         // open PR. Returning here keeps the cascade gate purely about
         // Execute-kind run terminations.
-        if ($run->kind === AgentRunKind::RespondToReview) {
+        if (in_array($run->kind, [AgentRunKind::RespondToReview, AgentRunKind::ResolveConflicts], true)) {
             return;
         }
 

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -38,15 +38,22 @@ class CliExecutor implements Executor
      *
      * @throws RuntimeException When `$workingDir` is null or the CLI exits non-zero.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
     {
         if ($workingDir === null) {
             throw new RuntimeException('CliExecutor requires a working directory.');
         }
 
-        $prompt = $this->buildPrompt($subtask, $repo, $workingBranch);
-        if ($contextBrief !== null && $contextBrief !== '') {
-            $prompt = $contextBrief."\n\n".$prompt;
+        if ($promptOverride !== null) {
+            $prompt = $promptOverride;
+            if ($contextBrief !== null && $contextBrief !== '') {
+                $prompt = $contextBrief."\n\n".$prompt;
+            }
+        } else {
+            $prompt = $this->buildPrompt($subtask, $repo, $workingBranch);
+            if ($contextBrief !== null && $contextBrief !== '') {
+                $prompt = $contextBrief."\n\n".$prompt;
+            }
         }
 
         $process = new Process($this->command, $workingDir);

--- a/app/Services/Executors/Executor.php
+++ b/app/Services/Executors/Executor.php
@@ -40,10 +40,9 @@ interface Executor
      * should prepend it to the user prompt so the model orients faster.
      * Defaults to null so existing tests and minimal drivers remain valid.
      *
-     * `$emitter`, when non-null (only passed when `supportsProgressEvents()`
-     * is true — ADR-0011), is the per-run progress channel. Drivers call
-     * `$emitter->emit($type, $payload)` from within tool-call hooks /
-     * stdout handlers / sentinel parsers to surface live events.
+     * `$promptOverride`, when non-null, replaces the executor's default prompt
+     * built from the Subtask (used for merge-conflict resolution and similar).
+     * `$contextBrief` is still prepended when both are set.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult;
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult;
 }

--- a/app/Services/Executors/FakeExecutor.php
+++ b/app/Services/Executors/FakeExecutor.php
@@ -24,13 +24,25 @@ class FakeExecutor implements Executor
         return false;
     }
 
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
     {
         // Pass a real (but throwaway) directory so SubtaskExecutor::tools() can construct
         // a Sandbox during fake/test invocations. The tools are never actually called
         // because the prompt response is intercepted by SubtaskExecutor::fake().
         $agent = new SubtaskExecutor($subtask, $repo, $workingBranch, $workingDir ?? sys_get_temp_dir());
-        $response = $agent->prompt($agent->buildPrompt());
+        if ($promptOverride !== null) {
+            $prompt = $promptOverride;
+            if ($contextBrief !== null && $contextBrief !== '') {
+                $prompt = $contextBrief."\n\n".$prompt;
+            }
+        } else {
+            $prompt = $agent->buildPrompt();
+            if ($contextBrief !== null && $contextBrief !== '') {
+                $prompt = $contextBrief."\n\n".$prompt;
+            }
+        }
+
+        $response = $agent->prompt($prompt);
         $output = $response->toArray();
 
         return new ExecutionResult(

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -38,7 +38,7 @@ class LaravelAiExecutor implements Executor
      *                          or when the agent terminates without producing
      *                          summary/files/commit-message fields.
      */
-    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+    public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
     {
         $context = [
             'subtask_id' => $subtask->getKey(),
@@ -53,9 +53,16 @@ class LaravelAiExecutor implements Executor
         $start = microtime(true);
 
         $agent = new SubtaskExecutor($subtask, $repo, $workingBranch, $workingDir);
-        $prompt = $agent->buildPrompt();
-        if ($contextBrief !== null && $contextBrief !== '') {
-            $prompt = $contextBrief."\n\n".$prompt;
+        if ($promptOverride !== null) {
+            $prompt = $promptOverride;
+            if ($contextBrief !== null && $contextBrief !== '') {
+                $prompt = $contextBrief."\n\n".$prompt;
+            }
+        } else {
+            $prompt = $agent->buildPrompt();
+            if ($contextBrief !== null && $contextBrief !== '') {
+                $prompt = $contextBrief."\n\n".$prompt;
+            }
         }
 
         try {

--- a/app/Services/PullRequests/GithubPullRequestProbe.php
+++ b/app/Services/PullRequests/GithubPullRequestProbe.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Services\PullRequests;
+
+use App\Enums\RepoProvider;
+use App\Models\Repo;
+use App\Models\Story;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Read-only GitHub API helpers for pull requests (mergeability, comments).
+ *
+ * All methods are best-effort: failures return null / false and log — callers
+ * must not treat API errors as fatal (ADR-0004-style resilience on PR surfaces).
+ */
+final class GithubPullRequestProbe
+{
+    /**
+     * Fetch mergeability for a pull request. Per-request memoization avoids
+     * duplicate GETs when {@see Story::pullRequests()} walks siblings.
+     *
+     * @return array{mergeable: ?bool, mergeable_state: ?string}|null Null on error or unsupported repo.
+     */
+    public function probeMergeable(Repo $repo, int $number): ?array
+    {
+        if ($repo->provider !== RepoProvider::Github) {
+            return null;
+        }
+
+        $token = $repo->access_token;
+        if ($token === null || $token === '') {
+            return null;
+        }
+
+        $slug = $repo->ownerRepo();
+        if ($slug === null) {
+            return null;
+        }
+
+        $memoKey = 'specify.github.mergeable.'.$repo->getKey().'.'.$number;
+        $request = request();
+        if ($request !== null && $request->attributes->has($memoKey)) {
+            /** @var array{mergeable: ?bool, mergeable_state: ?string}|null $cached */
+            $cached = $request->attributes->get($memoKey);
+
+            return $cached;
+        }
+
+        $apiBase = rtrim((string) config('specify.github.api_base'), '/');
+
+        try {
+            $response = Http::withToken($token)
+                ->withHeaders(['Accept' => 'application/vnd.github+json'])
+                ->get("{$apiBase}/repos/{$slug}/pulls/{$number}");
+        } catch (\Throwable $e) {
+            Log::warning('specify.github.probe_mergeable.exception', [
+                'repo_id' => $repo->getKey(),
+                'number' => $number,
+                'message' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (! $response->ok()) {
+            Log::warning('specify.github.probe_mergeable.http_error', [
+                'repo_id' => $repo->getKey(),
+                'number' => $number,
+                'status' => $response->status(),
+            ]);
+
+            return null;
+        }
+
+        $mergeableJson = $response->json('mergeable');
+        $state = $response->json('mergeable_state');
+
+        $result = [
+            'mergeable' => is_bool($mergeableJson) ? $mergeableJson : null,
+            'mergeable_state' => is_string($state) ? $state : null,
+        ];
+
+        if ($request !== null) {
+            $request->attributes->set($memoKey, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Post a comment on a pull request (issues API). Best-effort.
+     */
+    public function postIssueComment(Repo $repo, int $pullRequestNumber, string $body): bool
+    {
+        if ($repo->provider !== RepoProvider::Github) {
+            return false;
+        }
+
+        $token = $repo->access_token;
+        if ($token === null || $token === '') {
+            return false;
+        }
+
+        $slug = $repo->ownerRepo();
+        if ($slug === null) {
+            return false;
+        }
+
+        $apiBase = rtrim((string) config('specify.github.api_base'), '/');
+
+        try {
+            $response = Http::withToken($token)
+                ->withHeaders(['Accept' => 'application/vnd.github+json'])
+                ->post("{$apiBase}/repos/{$slug}/issues/{$pullRequestNumber}/comments", [
+                    'body' => $body,
+                ]);
+        } catch (\Throwable $e) {
+            Log::warning('specify.github.issue_comment.exception', [
+                'repo_id' => $repo->getKey(),
+                'number' => $pullRequestNumber,
+                'message' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+
+        if (! $response->successful()) {
+            Log::warning('specify.github.issue_comment.http_error', [
+                'repo_id' => $repo->getKey(),
+                'number' => $pullRequestNumber,
+                'status' => $response->status(),
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -101,7 +101,7 @@ class SubtaskRunPipeline
         }
 
         $emitter?->setPhase('execute');
-        $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null, $emitter);
+        $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null, $emitter, null);
 
         if ($this->cancelObserved($agentRun, 'after_execute', $logCtx)) {
             $this->discardLocalChangesIfPossible($workingDir, $agentRun, $repo, $logCtx);

--- a/app/Services/WorkspaceRunner.php
+++ b/app/Services/WorkspaceRunner.php
@@ -239,6 +239,56 @@ class WorkspaceRunner
     }
 
     /**
+     * `git merge --no-ff origin/{baseBranch}` — allow failure so callers can detect conflicts.
+     */
+    public function mergeNoFfFromOrigin(string $workingDir, string $baseBranch): int
+    {
+        $r = $this->run(
+            ['git', 'merge', '--no-ff', 'origin/'.$baseBranch],
+            $workingDir,
+            allowFailure: true,
+        );
+
+        return $r['exitCode'] ?? 1;
+    }
+
+    public function resetHardToOriginBranch(string $workingDir, string $branch): void
+    {
+        $this->run(['git', 'reset', '--hard', 'origin/'.$branch], $workingDir);
+    }
+
+    public function currentHeadSha(string $workingDir): string
+    {
+        return trim($this->run(['git', 'rev-parse', 'HEAD'], $workingDir)['stdout']);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function unmergedPaths(string $workingDir): array
+    {
+        $r = $this->run(['git', 'diff', '--name-only', '--diff-filter=U'], $workingDir, allowFailure: true);
+        $lines = array_filter(array_map('trim', explode("\n", $r['stdout'])));
+
+        return array_values($lines);
+    }
+
+    public function hasUnmergedPaths(string $workingDir): bool
+    {
+        return $this->unmergedPaths($workingDir) !== [];
+    }
+
+    public function mergeAbort(string $workingDir): void
+    {
+        $this->run(['git', 'merge', '--abort'], $workingDir, allowFailure: true);
+    }
+
+    public function fetchOriginBranch(string $workingDir, string $branch): void
+    {
+        $this->run(['git', 'fetch', 'origin', $branch], $workingDir);
+    }
+
+    /**
      * Inject the access token into HTTPS URLs so authenticated clones work without a credential helper.
      * Local file:// URLs and SSH URLs are returned unchanged.
      */

--- a/config/ai.php
+++ b/config/ai.php
@@ -1,0 +1,151 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default AI Provider Names
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the AI providers below should be the
+    | default for AI operations when no explicit provider is provided
+    | for the operation. This should be any provider defined below.
+    |
+    */
+
+    'default' => 'openai',
+    'default_for_images' => 'gemini',
+    'default_for_audio' => 'openai',
+    'default_for_transcription' => 'openai',
+    'default_for_embeddings' => 'openai',
+    'default_for_reranking' => 'cohere',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Caching
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure caching strategies for AI related operations
+    | such as embedding generation. You are free to adjust these values
+    | based on your application's available caching stores and needs.
+    |
+    */
+
+    'caching' => [
+        'embeddings' => [
+            'cache' => false,
+            'store' => env('CACHE_STORE', 'database'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | AI Providers
+    |--------------------------------------------------------------------------
+    |
+    | Below are each of your AI providers defined for this application. Each
+    | represents an AI provider and API key combination which can be used
+    | to perform tasks like text, image, and audio creation via agents.
+    |
+    | Specify uses SPECIFY_* env names for Anthropic so CLI tools (e.g. Claude
+    | Code) can keep using ANTHROPIC_API_KEY without colliding with this app.
+    |
+    */
+
+    'providers' => [
+        'anthropic' => [
+            'driver' => 'anthropic',
+            'key' => env('SPECIFY_ANTHROPIC_API_KEY'),
+            'url' => env('SPECIFY_ANTHROPIC_URL', 'https://api.anthropic.com/v1'),
+        ],
+
+        'azure' => [
+            'driver' => 'azure',
+            'key' => env('AZURE_OPENAI_API_KEY'),
+            'url' => env('AZURE_OPENAI_URL'),
+            'api_version' => env('AZURE_OPENAI_API_VERSION', '2025-04-01-preview'),
+            'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
+            'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+        ],
+
+        'bedrock' => [
+            'driver' => 'bedrock',
+            'region' => env('AWS_BEDROCK_REGION', 'us-east-1'),
+            'key' => env('AWS_BEARER_TOKEN_BEDROCK'),
+            'access_key_id' => env('AWS_ACCESS_KEY_ID'),
+            'secret_access_key' => env('AWS_SECRET_ACCESS_KEY'),
+            'session_token' => env('AWS_SESSION_TOKEN'),
+            'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIALS', true),
+        ],
+
+        'cohere' => [
+            'driver' => 'cohere',
+            'key' => env('COHERE_API_KEY'),
+            'url' => env('COHERE_URL', 'https://api.cohere.com/v2'),
+        ],
+
+        'deepseek' => [
+            'driver' => 'deepseek',
+            'key' => env('DEEPSEEK_API_KEY'),
+            'url' => env('DEEPSEEK_URL', 'https://api.deepseek.com'),
+        ],
+
+        'eleven' => [
+            'driver' => 'eleven',
+            'key' => env('ELEVENLABS_API_KEY'),
+        ],
+
+        'gemini' => [
+            'driver' => 'gemini',
+            'key' => env('GEMINI_API_KEY'),
+        ],
+
+        'groq' => [
+            'driver' => 'groq',
+            'key' => env('GROQ_API_KEY'),
+            'url' => env('GROQ_URL', 'https://api.groq.com/openai/v1'),
+        ],
+
+        'jina' => [
+            'driver' => 'jina',
+            'key' => env('JINA_API_KEY'),
+        ],
+
+        'mistral' => [
+            'driver' => 'mistral',
+            'key' => env('MISTRAL_API_KEY'),
+            'url' => env('MISTRAL_URL', 'https://api.mistral.ai/v1'),
+        ],
+
+        'ollama' => [
+            'driver' => 'ollama',
+            'key' => env('OLLAMA_API_KEY', ''),
+            'url' => env('OLLAMA_URL', 'http://localhost:11434'),
+        ],
+
+        'openai' => [
+            'driver' => 'openai',
+            'key' => env('OPENAI_API_KEY'),
+            'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        ],
+
+        'openrouter' => [
+            'driver' => 'openrouter',
+            'key' => env('OPENROUTER_API_KEY'),
+            'url' => env('OPENROUTER_URL', 'https://openrouter.ai/api/v1'),
+        ],
+
+        'voyageai' => [
+            'driver' => 'voyageai',
+            'key' => env('VOYAGEAI_API_KEY'),
+            'url' => env('VOYAGEAI_URL', 'https://api.voyageai.com/v1'),
+        ],
+
+        'xai' => [
+            'driver' => 'xai',
+            'key' => env('XAI_API_KEY'),
+            'url' => env('XAI_URL', 'https://api.x.ai/v1'),
+        ],
+    ],
+
+];

--- a/config/specify.php
+++ b/config/specify.php
@@ -157,6 +157,21 @@ return [
         )),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | PR merge-conflict resolution (AI)
+    |--------------------------------------------------------------------------
+    |
+    | Caps how many ResolveConflicts AgentRuns may be queued per pull request
+    | number (per repo) to avoid infinite retry loops when GitHub still
+    | reports merge conflicts after a push.
+    |
+    */
+
+    'conflict_resolution' => [
+        'max_cycles_per_pr' => (int) env('SPECIFY_CONFLICT_RESOLUTION_MAX_CYCLES', 3),
+    ],
+
     'context' => [
         'builder' => env('SPECIFY_CONTEXT_BUILDER', 'recency'),
         'recency' => [

--- a/prompts/conflict-resolver-executor.md
+++ b/prompts/conflict-resolver-executor.md
@@ -1,0 +1,10 @@
+You are resolving a merge conflict for Specify. The repository is checked out in your current working directory on the PR head branch. A `git merge --no-ff` from the integration branch (`origin/{base}`) was attempted and left the tree conflicted.
+
+Your job:
+1. Inspect each file with conflict markers. Understand both sides of the merge.
+2. Produce correct merged content: remove every `<<<<<<<`, `=======`, and `>>>>>>>` marker; keep behaviour that honours both the PR’s intent and the latest base when possible.
+3. Prefer small, correct edits over wide refactors.
+4. Stay on the current branch. Do not rebase, do not change remotes, do not create new branches.
+5. Do **not** run `git commit` or `git push` — the orchestrator will commit and push after verifying the merge state.
+6. Optionally run the project’s tests if they are quick; do not disable or skip tests to force green.
+7. Print a short plaintext summary of what you changed to stdout when you are done (this will be stored on the AgentRun).

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -77,7 +77,7 @@ new #[Title('Run')] class extends Component {
         if (! $run->isTerminal() || ! $run->status->isFailure()) {
             return;
         }
-        if ($run->kind === AgentRunKind::RespondToReview) {
+        if ($run->kind === AgentRunKind::RespondToReview || $run->kind === AgentRunKind::ResolveConflicts) {
             return;
         }
 
@@ -168,7 +168,8 @@ new #[Title('Run')] class extends Component {
             // the manual chain (ADR-0010).
             $canRetry = $run->isTerminal()
                 && $run->status->isFailure()
-                && $run->kind !== AgentRunKind::RespondToReview;
+                && $run->kind !== AgentRunKind::RespondToReview
+                && $run->kind !== AgentRunKind::ResolveConflicts;
             $duration = $run->started_at && $run->finished_at
                 ? $run->started_at->diffInSeconds($run->finished_at)
                 : null;

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -264,6 +264,23 @@ new #[Title('Story')] class extends Component {
         unset($this->story);
     }
 
+    public function resolveConflicts(): void
+    {
+        $story = $this->story;
+        abort_unless($story, 404);
+        abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
+
+        $result = app(ExecutionService::class)->dispatchConflictResolution($story);
+
+        match ($result['status']) {
+            'dispatched' => session()->flash('conflict_resolution', __('AI conflict-resolution run queued.')),
+            'max_cycles_reached' => session()->flash('conflict_resolution_error', __('Maximum AI conflict-resolution attempts reached for this pull request.')),
+            default => session()->flash('conflict_resolution_error', __('Could not start conflict resolution.')),
+        };
+
+        unset($this->story);
+    }
+
     public function resumeExecution(): void
     {
         $story = $this->story;
@@ -371,6 +388,12 @@ new #[Title('Story')] class extends Component {
     public function hasActiveSubtaskRun(): bool
     {
         return (bool) $this->story?->hasActiveSubtaskRun();
+    }
+
+    #[Computed]
+    public function activeConflictResolutionRun(): ?AgentRun
+    {
+        return $this->story?->activeConflictResolutionAgentRun();
     }
 
     /**
@@ -587,7 +610,7 @@ new #[Title('Story')] class extends Component {
 
 <div
     class="flex p-6"
-    @if ($this->pendingPlanRun) wire:poll.3s @endif
+    @if ($this->pendingPlanRun || $this->activeConflictResolutionRun) wire:poll.3s @endif
     x-data="{
         planRunMode: localStorage.getItem('specify.planRunMode') === '1',
         init() {
@@ -608,6 +631,17 @@ new #[Title('Story')] class extends Component {
 
         <div class="flex min-w-0 flex-1 flex-col gap-6 lg:flex-row">
             <div class="flex min-w-0 max-w-4xl flex-1 flex-col gap-6">
+
+        @if (session('conflict_resolution'))
+            <div class="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-200">
+                {{ session('conflict_resolution') }}
+            </div>
+        @endif
+        @if (session('conflict_resolution_error'))
+            <div class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+                {{ session('conflict_resolution_error') }}
+            </div>
+        @endif
 
         {{-- ── Header ──────────────────────────────────────────── --}}
         <div>
@@ -705,7 +739,16 @@ new #[Title('Story')] class extends Component {
                     </flux:modal>
                 @endif
 
-                @php $storyPrs = $story->pullRequests(); @endphp
+                @php
+                    $storyPrs = $story->pullRequests();
+                    $primaryPr = $story->primaryPullRequest();
+                    $canResolve = $primaryPr
+                        && ($primaryPr['mergeable'] ?? null) === false
+                        && ($primaryPr['merged'] ?? null) !== true
+                        && $this->canApproveStory;
+                    $conflictRun = $this->activeConflictResolutionRun;
+                    $showResolveConflicts = $canResolve && ! $conflictRun;
+                @endphp
                 @if ($storyPrs->isNotEmpty())
                     <div class="mt-3 flex flex-col gap-1.5" data-section="story-prs">
                         <div class="flex items-baseline gap-2">
@@ -740,12 +783,45 @@ new #[Title('Story')] class extends Component {
                                             @endif
                                         </flux:badge>
                                     </a>
+                                    @if (($pr['mergeable'] ?? null) === false && ($pr['merged'] ?? null) !== true)
+                                        <flux:badge size="sm" color="amber">{{ __('conflicted') }}</flux:badge>
+                                    @endif
                                     @if ($pr['driver'])
                                         <flux:badge size="sm" icon="cpu-chip">{{ $pr['driver'] }}</flux:badge>
                                     @endif
                                 </div>
                             @endforeach
                         </div>
+                        @if ($conflictRun && $conflictRun->runnable)
+                            @php
+                                $crSub = $conflictRun->runnable;
+                                $crRunUrl = route('runs.show', [
+                                    'project' => $project->id,
+                                    'story' => $story->id,
+                                    'subtask' => $crSub->id,
+                                    'run' => $conflictRun->id,
+                                ]);
+                            @endphp
+                            <div class="flex flex-wrap items-center gap-2 pt-1">
+                                <flux:badge size="sm" color="amber">{{ __('Resolving merge conflicts (AI)…') }}</flux:badge>
+                                <a href="{{ $crRunUrl }}" wire:navigate class="text-xs font-medium text-zinc-600 underline hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200">
+                                    {{ __('Run') }} #{{ $conflictRun->id }}
+                                </a>
+                            </div>
+                        @elseif ($showResolveConflicts)
+                            <div class="pt-1">
+                                <flux:button
+                                    wire:click="resolveConflicts"
+                                    wire:target="resolveConflicts"
+                                    size="sm"
+                                    variant="primary"
+                                    wire:loading.attr="disabled"
+                                >
+                                    <span wire:loading.remove wire:target="resolveConflicts">{{ __('Resolve conflicts (AI)') }}</span>
+                                    <span wire:loading wire:target="resolveConflicts">{{ __('Queueing…') }}</span>
+                                </flux:button>
+                            </div>
+                        @endif
                     </div>
                 @endif
             @endif

--- a/tests/Feature/ConflictResolutionTest.php
+++ b/tests/Feature/ConflictResolutionTest.php
@@ -1,0 +1,216 @@
+<?php
+
+use App\Enums\AgentRunKind;
+use App\Enums\AgentRunStatus;
+use App\Enums\StoryStatus;
+use App\Enums\TaskStatus;
+use App\Enums\TeamRole;
+use App\Jobs\ResolveConflictsJob;
+use App\Models\AcceptanceCriterion;
+use App\Models\AgentRun;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Repo;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\ExecutionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Story + GitHub PR in conflicted (mergeable=false) state for dispatch / UI tests.
+ *
+ * @return array{
+ *     user: User,
+ *     project: Project,
+ *     story: Story,
+ *     subtask: Subtask,
+ *     repo: Repo,
+ *     run: AgentRun,
+ * }
+ */
+function conflictResolutionScene(bool $mergeable = false): array
+{
+    $ws = Workspace::factory()->create();
+    $team = Team::factory()->for($ws)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Owner);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create([
+        'status' => StoryStatus::Approved,
+        'created_by_id' => $user->id,
+    ]);
+
+    $repo = Repo::factory()->for($ws)->create([
+        'url' => 'https://github.com/o/r.git',
+        'access_token' => 'gh-test-token',
+    ]);
+    $project->attachRepo($repo);
+
+    $ac = AcceptanceCriterion::factory()->for($story)->create();
+    $task = Task::factory()->for($story)->create(['acceptance_criterion_id' => $ac->id]);
+    $subtask = Subtask::factory()->for($task)->create();
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'repo_id' => $repo->id,
+        'working_branch' => 'specify/feature/story',
+        'executor_driver' => 'laravel-ai',
+        'kind' => AgentRunKind::Execute,
+        'status' => AgentRunStatus::Succeeded,
+        'output' => [
+            'pull_request_url' => 'https://github.com/o/r/pull/99',
+            'pull_request_number' => 99,
+            'pull_request_merged' => false,
+        ],
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/o/r/pulls/99' => Http::response([
+            'mergeable' => $mergeable,
+            'mergeable_state' => $mergeable ? 'clean' : 'dirty',
+        ], 200),
+    ]);
+
+    return [
+        'user' => $user,
+        'project' => $project,
+        'story' => $story->fresh(),
+        'subtask' => $subtask,
+        'repo' => $repo,
+        'run' => $run,
+    ];
+}
+
+test('pullRequests enriches GitHub PRs with mergeability from the probe', function () {
+    $ctx = conflictResolutionScene(mergeable: false);
+
+    $prs = $ctx['story']->pullRequests();
+    expect($prs)->toHaveCount(1)
+        ->and($prs->first()['mergeable'])->toBeFalse()
+        ->and($prs->first()['mergeable_state'])->toBe('dirty');
+});
+
+test('dispatchConflictResolution queues a ResolveConflicts AgentRun', function () {
+    Queue::fake();
+    $ctx = conflictResolutionScene(mergeable: false);
+
+    $result = app(ExecutionService::class)->dispatchConflictResolution($ctx['story']);
+
+    expect($result['status'])->toBe('dispatched')
+        ->and(AgentRun::where('kind', AgentRunKind::ResolveConflicts)->count())->toBe(1);
+
+    $newRun = AgentRun::where('kind', AgentRunKind::ResolveConflicts)->firstOrFail();
+    expect($newRun->output['pull_request_number'])->toBe(99)
+        ->and((int) $newRun->output['origin_run_id'])->toBe($ctx['run']->id)
+        ->and($newRun->executor_driver)->toBe($ctx['run']->executor_driver);
+
+    Queue::assertPushed(ResolveConflictsJob::class, fn ($job) => $job->agentRunId === $newRun->id);
+});
+
+test('dispatchConflictResolution does nothing when GitHub reports mergeable', function () {
+    Queue::fake();
+    $ctx = conflictResolutionScene(mergeable: true);
+
+    $result = app(ExecutionService::class)->dispatchConflictResolution($ctx['story']);
+
+    expect($result['status'])->toBe('not_applicable');
+    Queue::assertNothingPushed();
+});
+
+test('dispatchConflictResolution returns max_cycles_reached after cap', function () {
+    Queue::fake();
+    $ctx = conflictResolutionScene(mergeable: false);
+    config(['specify.conflict_resolution.max_cycles_per_pr' => 2]);
+
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $ctx['subtask']->id,
+        'repo_id' => $ctx['repo']->id,
+        'kind' => AgentRunKind::ResolveConflicts,
+        'status' => AgentRunStatus::Failed,
+        'output' => ['pull_request_number' => 99, 'origin_run_id' => $ctx['run']->id],
+    ]);
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $ctx['subtask']->id,
+        'repo_id' => $ctx['repo']->id,
+        'kind' => AgentRunKind::ResolveConflicts,
+        'status' => AgentRunStatus::Failed,
+        'output' => ['pull_request_number' => 99, 'origin_run_id' => $ctx['run']->id],
+    ]);
+
+    $result = app(ExecutionService::class)->dispatchConflictResolution($ctx['story']->fresh());
+
+    expect($result['status'])->toBe('max_cycles_reached');
+    Queue::assertNothingPushed();
+});
+
+test('cascade gate ignores ResolveConflicts runs', function () {
+    $ctx = conflictResolutionScene(mergeable: false);
+    $ctx['subtask']->forceFill(['status' => TaskStatus::Done->value])->save();
+
+    $conflictRun = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $ctx['subtask']->id,
+        'repo_id' => $ctx['repo']->id,
+        'kind' => AgentRunKind::ResolveConflicts,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    app(ExecutionService::class)->markFailed($conflictRun, 'merge agent failed');
+
+    expect($ctx['subtask']->fresh()->status->value)->toBe('done');
+});
+
+test('markFailed is idempotent when the run is already terminal', function () {
+    $ctx = conflictResolutionScene(mergeable: false);
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $ctx['subtask']->id,
+        'repo_id' => $ctx['repo']->id,
+        'kind' => AgentRunKind::Execute,
+        'status' => AgentRunStatus::Failed,
+        'error_message' => 'first',
+        'finished_at' => now(),
+    ]);
+
+    app(ExecutionService::class)->markFailed($run, 'second');
+
+    $run->refresh();
+    expect($run->error_message)->toBe('first');
+});
+
+test('story show exposes Resolve conflicts button when PR is conflicted and user can approve', function () {
+    $ctx = conflictResolutionScene(mergeable: false);
+    $this->actingAs($ctx['user']);
+
+    Livewire::test('pages::stories.show', [
+        'project' => $ctx['project']->id,
+        'story' => $ctx['story']->id,
+    ])
+        ->assertSee('Resolve conflicts (AI)')
+        ->assertSee('conflicted');
+});
+
+test('story show hides Resolve conflicts button for members without approve permission', function () {
+    $ctx = conflictResolutionScene(mergeable: false);
+    $member = User::factory()->create();
+    $ctx['story']->feature->project->team->addMember($member, TeamRole::Member);
+    $this->actingAs($member);
+
+    Livewire::test('pages::stories.show', [
+        'project' => $ctx['project']->id,
+        'story' => $ctx['story']->id,
+    ])
+        ->assertDontSee('Resolve conflicts (AI)');
+});

--- a/tests/Feature/ProgressEventsTest.php
+++ b/tests/Feature/ProgressEventsTest.php
@@ -103,7 +103,7 @@ test('CliExecutor emits stdout / stderr / sentinel events when an emitter is pas
     $emitter->setPhase('execute');
 
     (new CliExecutor([$bin]))
-        ->execute($run->runnable, $workingDir, null, null, null, $emitter);
+        ->execute($run->runnable, $workingDir, null, null, null, $emitter, null);
 
     $events = AgentRunEvent::where('agent_run_id', $run->getKey())->orderBy('seq')->get();
     $types = $events->pluck('type')->all();

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -160,7 +160,7 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
             return false;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'I tried but produced no diff',
@@ -229,7 +229,7 @@ test('alreadyComplete returns the Succeeded-class outcome when evidence SHAs are
             return false;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'Confirmed already done by abc1234',
@@ -302,7 +302,7 @@ test('alreadyComplete falls through to noDiff when evidence is empty (ADR-0007 s
             return false;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'I swear it is already done',
@@ -371,7 +371,7 @@ test('alreadyComplete falls through to noDiff when ANY cited SHA is unreachable,
             return false;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'One real, one made up',
@@ -442,7 +442,7 @@ test('alreadyComplete falls through to noDiff when none of the cited SHAs are re
             return false;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(
                 summary: 'Done in commit deadbeef',
@@ -534,7 +534,7 @@ test('context_brief is persisted on AgentRun.output even when the run ends in no
             return false;
         }
 
-        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null): ExecutionResult
+        public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(summary: '', filesChanged: [], commitMessage: 'noop');
         }


### PR DESCRIPTION
## Issue

Reviewers saw unmergeable GitHub PRs on approved stories with no in-app way to drive an automated fix. Anthropic API keys also collided with local Claude Code when both used `ANTHROPIC_API_KEY`.

## What changed

- **Story PRs** — On page load, GitHub is probed (best-effort) for `mergeable` / `mergeable_state`. When the **primary** PR reports `mergeable: false`, approvers see a **conflicted** badge and **Resolve conflicts (AI)**.
- **`ResolveConflicts` AgentRun** — New kind; cascade matches `RespondToReview` (ignored by `finalizeSubtaskFromRun`). Dispatch caps repeats per PR via `specify.conflict_resolution.max_cycles_per_pr`.
- **`ResolveConflictsJob`** — Locks per repo+branch, runs `git merge --no-ff origin/<base>`, then invokes the **same executor driver** as the originating Execute run (`ExecutorFactory` + `config/specify.php`), using a **`promptOverride`** on the shared `Executor` contract. Progress events stream when the driver supports them (e.g. CLI). Commits with a fixed `fix:` message, pushes, posts an issue comment.
- **`Executor::execute(..., ?string $promptOverride = null)`** — Lets one-off prompts (conflict resolution) reuse `CliExecutor`, `LaravelAiExecutor`, and `FakeExecutor` without hardcoding Codex.
- **Config** — Published `config/ai.php` so Anthropic uses **`SPECIFY_ANTHROPIC_API_KEY`** (and optional `SPECIFY_ANTHROPIC_URL`); `.env.example` updated.
- **`markFailed`** — Idempotent when the run is already terminal (refresh + early return).
- **Removed** — Inline Laravel AI `ConflictResolver` agent in favour of executor-driven flow.

## Tests

- `composer test` (Pint + Pest): **362 passed** on this branch.

## Manual smoke

- Story with a single open GitHub PR in conflict → button visible for approvers → run completes → mergeability clears on reload after GitHub updates.
