### PR TITLE
[codex] clean planning model ownership

### DIFF
--- a/app/Ai/Agents/ReviewResponder.php
+++ b/app/Ai/Agents/ReviewResponder.php
@@ -88,9 +88,9 @@ class ReviewResponder implements Agent, HasStructuredOutput, HasTools
 
     public function buildPrompt(): string
     {
-        $subtask = $this->subtask->loadMissing('task.story.feature.project', 'task.acceptanceCriterion');
+        $subtask = $this->subtask->loadMissing('task.plan.story.feature.project', 'task.acceptanceCriterion');
         $task = $subtask->task;
-        $story = $task?->story;
+        $story = $task?->plan?->story;
         $criterion = $task?->acceptanceCriterion?->statement;
 
         $criterionBlock = $criterion ? "Acceptance Criterion: {$criterion}\n\n" : '';

--- a/app/Ai/Agents/SubtaskExecutor.php
+++ b/app/Ai/Agents/SubtaskExecutor.php
@@ -53,7 +53,7 @@ class SubtaskExecutor implements Agent, HasStructuredOutput, HasTools
         $sandbox = new Sandbox($this->workingDir);
         $context = [
             'subtask_id' => $this->subtask->getKey(),
-            'story_id' => $this->subtask->task?->story_id,
+            'story_id' => $this->subtask->task?->plan?->story_id,
             'branch' => $this->workingBranch,
         ];
 
@@ -75,9 +75,9 @@ class SubtaskExecutor implements Agent, HasStructuredOutput, HasTools
 
     public function buildPrompt(): string
     {
-        $subtask = $this->subtask->loadMissing('task.story.feature.project', 'task.acceptanceCriterion');
+        $subtask = $this->subtask->loadMissing('task.plan.story.feature.project', 'task.acceptanceCriterion');
         $task = $subtask->task;
-        $story = $task?->story;
+        $story = $task?->plan?->story;
         $criterion = $task?->acceptanceCriterion?->statement;
 
         $repoBlock = $this->repo

--- a/app/Http/Controllers/RunEventsController.php
+++ b/app/Http/Controllers/RunEventsController.php
@@ -62,10 +62,10 @@ class RunEventsController extends Controller
         }
 
         if ($run->runnable_type === Subtask::class) {
-            $subtask = Subtask::with('task.plan', 'task.story.feature')->find($run->runnable_id);
+            $subtask = Subtask::with('task.plan', 'task.plan.story.feature')->find($run->runnable_id);
 
-            return $subtask?->task?->story !== null
-                && in_array($subtask->task->story->feature->project_id, $accessible, true);
+            return $subtask?->task?->plan?->story !== null
+                && in_array($subtask->task->plan->story->feature->project_id, $accessible, true);
         }
 
         return false;

--- a/app/Mcp/Tools/AddAcceptanceCriterionTool.php
+++ b/app/Mcp/Tools/AddAcceptanceCriterionTool.php
@@ -31,8 +31,7 @@ class AddAcceptanceCriterionTool extends Tool
 
         $validated = $request->validate([
             'story_id' => ['required', 'integer'],
-            'criterion' => ['nullable', 'string'],
-            'statement' => ['nullable', 'string'],
+            'statement' => ['required', 'string'],
             'position' => ['nullable', 'integer'],
         ]);
 
@@ -41,16 +40,11 @@ class AddAcceptanceCriterionTool extends Tool
             return $story;
         }
 
-        $statement = $validated['statement'] ?? $validated['criterion'] ?? null;
-        if (! is_string($statement) || trim($statement) === '') {
-            return Response::error('statement is required.');
-        }
-
         $position = $validated['position']
             ?? (int) ($story->acceptanceCriteria()->max('position') ?? 0) + 1;
 
         $ac = $story->acceptanceCriteria()->create([
-            'statement' => $statement,
+            'statement' => $validated['statement'],
             'position' => $position,
         ]);
 
@@ -70,8 +64,7 @@ class AddAcceptanceCriterionTool extends Tool
     {
         return [
             'story_id' => $schema->integer()->description('Story to add the criterion to.')->required(),
-            'criterion' => $schema->string()->description('Deprecated alias for statement. Observable behaviour the story must satisfy as one atomic rule statement.'),
-            'statement' => $schema->string()->description('Observable behaviour the story must satisfy. Use one atomic rule statement, not a full Given/When/Then scenario.'),
+            'statement' => $schema->string()->description('Observable behaviour the story must satisfy. Use one atomic rule statement, not a full Given/When/Then scenario.')->required(),
             'position' => $schema->integer()->description('Position in the list. Defaults to last + 1.'),
         ];
     }

--- a/app/Mcp/Tools/AddAcceptanceCriterionTool.php
+++ b/app/Mcp/Tools/AddAcceptanceCriterionTool.php
@@ -31,9 +31,14 @@ class AddAcceptanceCriterionTool extends Tool
 
         $validated = $request->validate([
             'story_id' => ['required', 'integer'],
-            'statement' => ['required', 'string'],
+            'statement' => ['required', 'string', 'max:1000'],
             'position' => ['nullable', 'integer'],
         ]);
+
+        $statement = trim($validated['statement']);
+        if ($statement === '') {
+            return Response::error('statement is required.');
+        }
 
         $story = $this->resolveAccessibleStory($validated['story_id'], $user);
         if ($story instanceof Response) {
@@ -44,7 +49,7 @@ class AddAcceptanceCriterionTool extends Tool
             ?? (int) ($story->acceptanceCriteria()->max('position') ?? 0) + 1;
 
         $ac = $story->acceptanceCriteria()->create([
-            'statement' => $validated['statement'],
+            'statement' => $statement,
             'position' => $position,
         ]);
 

--- a/app/Mcp/Tools/GetRunTool.php
+++ b/app/Mcp/Tools/GetRunTool.php
@@ -76,11 +76,11 @@ class GetRunTool extends Tool
     {
         return match ($run->runnable_type) {
             Subtask::class => Subtask::query()
-                ->with('task.story.feature:id,project_id')
-                ->find($run->runnable_id)?->task?->story?->feature?->project_id,
+                ->with('task.plan.story.feature:id,project_id')
+                ->find($run->runnable_id)?->task?->plan?->story?->feature?->project_id,
             Task::class => Task::query()
-                ->with('story.feature:id,project_id')
-                ->find($run->runnable_id)?->story?->feature?->project_id,
+                ->with('plan.story.feature:id,project_id')
+                ->find($run->runnable_id)?->plan?->story?->feature?->project_id,
             Story::class => Story::query()
                 ->with('feature:id,project_id')
                 ->find($run->runnable_id)?->feature?->project_id,

--- a/app/Mcp/Tools/GetTaskTool.php
+++ b/app/Mcp/Tools/GetTaskTool.php
@@ -36,20 +36,20 @@ class GetTaskTool extends Tool
         }
 
         $task = Task::query()
-            ->with(['story.feature', 'plan', 'acceptanceCriterion', 'scenario', 'subtasks', 'dependencies:id,position'])
+            ->with(['plan.story.feature', 'acceptanceCriterion', 'scenario', 'subtasks', 'dependencies:id,position'])
             ->find($taskId);
 
         if (! $task) {
             return Response::error('Task not found.');
         }
 
-        if (! $this->canAccessProject($user, (int) $task->story->feature->project_id)) {
+        if (! $this->canAccessProject($user, (int) $task->plan->story->feature->project_id)) {
             return Response::error('Task not accessible.');
         }
 
         return Response::json([
             'id' => $task->id,
-            'story_id' => $task->story_id,
+            'story_id' => $task->plan->story_id,
             'plan_id' => $task->plan_id,
             'position' => $task->position,
             'name' => $task->name,

--- a/app/Mcp/Tools/ListRunsTool.php
+++ b/app/Mcp/Tools/ListRunsTool.php
@@ -45,21 +45,21 @@ class ListRunsTool extends Tool
         $query = AgentRun::query()->latest('id')->limit($limit);
 
         if ($subtaskId) {
-            $subtask = Subtask::query()->with('task.story.feature')->find($subtaskId);
+            $subtask = Subtask::query()->with('task.plan.story.feature')->find($subtaskId);
             if (! $subtask) {
                 return Response::error('Subtask not found.');
             }
-            $projectId = $subtask->task?->story?->feature?->project_id;
+            $projectId = $subtask->task?->plan?->story?->feature?->project_id;
             if (! $projectId || ! $this->canAccessProject($user, (int) $projectId)) {
                 return Response::error('Subtask not accessible.');
             }
             $query->where('runnable_type', Subtask::class)->where('runnable_id', $subtask->id);
         } elseif ($taskId) {
-            $task = Task::query()->with('story.feature', 'subtasks:id,task_id')->find($taskId);
+            $task = Task::query()->with('plan.story.feature', 'subtasks:id,task_id')->find($taskId);
             if (! $task) {
                 return Response::error('Task not found.');
             }
-            if (! $this->canAccessProject($user, (int) $task->story->feature->project_id)) {
+            if (! $this->canAccessProject($user, (int) $task->plan->story->feature->project_id)) {
                 return Response::error('Task not accessible.');
             }
             $subtaskIds = $task->subtasks->pluck('id')->all();
@@ -74,7 +74,7 @@ class ListRunsTool extends Tool
                 }
             });
         } else {
-            $story = Story::query()->with('feature', 'tasks:id,story_id,plan_id')->find($storyId);
+            $story = Story::query()->with('feature', 'tasks:id,plan_id')->find($storyId);
             if (! $story) {
                 return Response::error('Story not found.');
             }

--- a/app/Mcp/Tools/UpdateSubtaskTool.php
+++ b/app/Mcp/Tools/UpdateSubtaskTool.php
@@ -39,12 +39,12 @@ class UpdateSubtaskTool extends Tool
             'position' => ['nullable', 'integer', 'min:1'],
         ]);
 
-        $subtask = Subtask::query()->with('task.story.feature')->find($validated['subtask_id']);
+        $subtask = Subtask::query()->with('task.plan.story.feature')->find($validated['subtask_id']);
         if (! $subtask) {
             return Response::error('Subtask not found.');
         }
 
-        $story = $subtask->task?->story;
+        $story = $subtask->task?->plan?->story;
         if (! $story) {
             return Response::error('Subtask is orphaned.');
         }

--- a/app/Mcp/Tools/UpdateTaskTool.php
+++ b/app/Mcp/Tools/UpdateTaskTool.php
@@ -43,12 +43,12 @@ class UpdateTaskTool extends Tool
             'depends_on_positions.*' => ['integer', 'min:1'],
         ]);
 
-        $task = Task::query()->with('story.feature', 'story.acceptanceCriteria:id,story_id', 'story.scenarios:id,story_id')->find($validated['task_id']);
+        $task = Task::query()->with('plan.story.feature', 'plan.story.acceptanceCriteria:id,story_id', 'plan.story.scenarios:id,story_id')->find($validated['task_id']);
         if (! $task) {
             return Response::error('Task not found.');
         }
 
-        if (! $this->canAccessProject($user, (int) $task->story->feature->project_id)) {
+        if (! $this->canAccessProject($user, (int) $task->plan->story->feature->project_id)) {
             return Response::error('Task not accessible.');
         }
 
@@ -74,7 +74,7 @@ class UpdateTaskTool extends Tool
             }
             if (array_key_exists('acceptance_criterion_id', $validated)) {
                 $acId = $validated['acceptance_criterion_id'];
-                if ($acId !== null && ! $task->story->acceptanceCriteria->contains('id', $acId)) {
+                if ($acId !== null && ! $task->plan->story->acceptanceCriteria->contains('id', $acId)) {
                     throw new \RuntimeException("acceptance_criterion_id {$acId} does not belong to this story.");
                 }
                 $updates['acceptance_criterion_id'] = $acId;
@@ -82,7 +82,7 @@ class UpdateTaskTool extends Tool
             }
             if (array_key_exists('scenario_id', $validated)) {
                 $scenarioId = $validated['scenario_id'];
-                if ($scenarioId !== null && ! $task->story->scenarios->contains('id', $scenarioId)) {
+                if ($scenarioId !== null && ! $task->plan->story->scenarios->contains('id', $scenarioId)) {
                     throw new \RuntimeException("scenario_id {$scenarioId} does not belong to this story.");
                 }
                 $updates['scenario_id'] = $scenarioId;
@@ -95,7 +95,6 @@ class UpdateTaskTool extends Tool
 
             if (array_key_exists('depends_on_positions', $validated) && is_array($validated['depends_on_positions'])) {
                 $byPosition = Task::query()
-                    ->where('story_id', $task->story_id)
                     ->where('plan_id', $task->plan_id)
                     ->get(['id', 'position'])
                     ->keyBy('position');
@@ -122,7 +121,7 @@ class UpdateTaskTool extends Tool
 
         return Response::json([
             'id' => $task->id,
-            'story_id' => $task->story_id,
+            'story_id' => $task->plan->story_id,
             'plan_id' => $task->plan_id,
             'position' => $task->position,
             'name' => $task->name,

--- a/app/Models/AcceptanceCriterion.php
+++ b/app/Models/AcceptanceCriterion.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * Atomic observable rule a Story must satisfy.
  */
-#[Fillable(['story_id', 'position', 'statement', 'criterion'])]
+#[Fillable(['story_id', 'position', 'statement'])]
 class AcceptanceCriterion extends Model
 {
     /** @use HasFactory<AcceptanceCriterionFactory> */
@@ -64,14 +64,6 @@ class AcceptanceCriterion extends Model
     public function tasks(): HasMany
     {
         return $this->hasMany(Task::class);
-    }
-
-    protected function criterion(): Attribute
-    {
-        return Attribute::make(
-            get: fn () => $this->statement,
-            set: fn (?string $value) => ['statement' => $value],
-        );
     }
 
     protected function met(): Attribute

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -130,11 +130,8 @@ class Story extends Model
 
     public function tasks(): HasMany
     {
-        return $this->hasMany(Task::class)
-            ->join('stories as story_task_scope', 'story_task_scope.id', '=', 'tasks.story_id')
-            ->whereColumn('tasks.plan_id', 'story_task_scope.current_plan_id')
-            ->select('tasks.*')
-            ->orderBy('tasks.position');
+        return $this->hasMany(Task::class, 'plan_id', 'current_plan_id')
+            ->orderBy('position');
     }
 
     /**

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -15,7 +15,7 @@ use InvalidArgumentException;
 /**
  * Actionable work item under a Plan.
  */
-#[Fillable(['plan_id', 'story_id', 'acceptance_criterion_id', 'scenario_id', 'position', 'name', 'description', 'status'])]
+#[Fillable(['plan_id', 'acceptance_criterion_id', 'scenario_id', 'position', 'name', 'description', 'status'])]
 class Task extends Model
 {
     /** @use HasFactory<TaskFactory> */
@@ -31,11 +31,6 @@ class Task extends Model
     public function plan(): BelongsTo
     {
         return $this->belongsTo(Plan::class);
-    }
-
-    public function story(): BelongsTo
-    {
-        return $this->belongsTo(Story::class);
     }
 
     public function acceptanceCriterion(): BelongsTo

--- a/app/Services/ConflictResolutionPrompt.php
+++ b/app/Services/ConflictResolutionPrompt.php
@@ -22,9 +22,9 @@ final class ConflictResolutionPrompt
         int $pullRequestNumber,
         array $unmergedPaths,
     ): string {
-        $subtask->loadMissing('task.story', 'task.acceptanceCriterion');
+        $subtask->loadMissing('task.plan.story', 'task.acceptanceCriterion');
         $task = $subtask->task;
-        $story = $task?->story;
+        $story = $task?->plan?->story;
         $criterion = $task?->acceptanceCriterion?->statement;
 
         $criterionBlock = $criterion ? "Acceptance Criterion: {$criterion}\n\n" : '';

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -77,7 +77,7 @@ class ExecutionService
      */
     public function dispatchSubtaskExecution(Subtask $subtask, ?PlanApproval $approval = null, ?Repo $repo = null): AgentRun
     {
-        $repo ??= $subtask->task?->story?->feature?->project?->primaryRepo();
+        $repo ??= $subtask->task?->plan?->story?->feature?->project?->primaryRepo();
 
         $race = $this->executors->raceDrivers();
         if ($race === []) {
@@ -231,7 +231,7 @@ class ExecutionService
 
     private function workingBranchFor(Subtask $subtask, ?string $driverSuffix): string
     {
-        $story = $subtask->task?->story;
+        $story = $subtask->task?->plan?->story;
         $feature = $story?->feature;
 
         $featureSlug = $feature?->slug ?? 'feature-'.($feature?->getKey() ?? 'orphan');
@@ -499,7 +499,7 @@ class ExecutionService
             throw new RuntimeException('Only failed / cancelled / aborted runs can be retried.');
         }
 
-        $story = $subtask->task?->story;
+        $story = $subtask->task?->plan?->story;
         if (! $story || $story->status !== StoryStatus::Approved) {
             throw new RuntimeException('Story is not Approved; retry is gated on a current plan approval.');
         }
@@ -644,7 +644,7 @@ class ExecutionService
             $task->forceFill(['status' => TaskStatus::Done->value])->save();
         }
 
-        $story = $task->story;
+        $story = $task->plan->story;
         if (! $story) {
             return;
         }

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -208,9 +208,9 @@ class CliExecutor implements Executor
 
     private function buildPrompt(Subtask $subtask, ?Repo $repo, ?string $workingBranch): string
     {
-        $subtask->loadMissing('task.story', 'task.acceptanceCriterion');
+        $subtask->loadMissing('task.plan.story', 'task.acceptanceCriterion');
         $task = $subtask->task;
-        $story = $task?->story;
+        $story = $task?->plan?->story;
         $criterion = $task?->acceptanceCriterion?->statement;
 
         $repoLine = $repo

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -42,7 +42,7 @@ class LaravelAiExecutor implements Executor
     {
         $context = [
             'subtask_id' => $subtask->getKey(),
-            'story_id' => $subtask->task?->story_id,
+            'story_id' => $subtask->task?->plan?->story_id,
             'branch' => $workingBranch,
             'working_dir' => $workingDir,
         ];

--- a/app/Services/PlanWriter.php
+++ b/app/Services/PlanWriter.php
@@ -43,7 +43,7 @@ class PlanWriter
     {
         $this->validate($story, $tasks);
 
-        $result = DB::transaction(function () use ($story, $tasks) {
+        $result = DB::transaction(function () use ($story, $tasks, $attributes) {
             $previousPlan = $story->currentPlan;
 
             if ($previousPlan) {
@@ -70,7 +70,6 @@ class PlanWriter
             foreach ($tasks as $taskData) {
                 $task = Task::create([
                     'plan_id' => $plan->getKey(),
-                    'story_id' => $story->getKey(),
                     'acceptance_criterion_id' => $taskData['acceptance_criterion_id'] ?? null,
                     'scenario_id' => $taskData['scenario_id'] ?? null,
                     'position' => $taskData['position'],

--- a/app/Services/PullRequests/PrPayloadBuilder.php
+++ b/app/Services/PullRequests/PrPayloadBuilder.php
@@ -22,7 +22,7 @@ class PrPayloadBuilder
     public static function title(Subtask $subtask, ?string $driver = null): string
     {
         $task = $subtask->task;
-        $story = $task?->story;
+        $story = $task?->plan?->story;
         $acPos = $task?->acceptanceCriterion?->position;
 
         $tag = $story && $acPos !== null
@@ -52,7 +52,7 @@ class PrPayloadBuilder
     public static function body(Subtask $subtask, array $output): string
     {
         $task = $subtask->task;
-        $story = $task?->story;
+        $story = $task?->plan?->story;
         $criterion = $task?->acceptanceCriterion?->statement;
         $summary = self::clamp(trim((string) ($output['summary'] ?? '')), 8_192);
         $files = (array) ($output['files_changed'] ?? []);

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -411,7 +411,7 @@ class SubtaskRunPipeline
         return [
             'run_id' => $agentRun->getKey(),
             'subtask_id' => $subtask->getKey(),
-            'story_id' => $subtask->task?->story_id,
+            'story_id' => $subtask->task?->plan?->story_id,
             'branch' => $agentRun->working_branch,
         ];
     }

--- a/app/Services/WorkspaceRunner.php
+++ b/app/Services/WorkspaceRunner.php
@@ -44,7 +44,7 @@ class WorkspaceRunner
 
         if ($run->runnable_type === Subtask::class) {
             $subtask = $run->runnable;
-            $story = $subtask?->task?->story;
+            $story = $subtask?->task?->plan?->story;
             $feature = $story?->feature;
             if ($feature && $story && $feature->slug && $story->slug) {
                 return $base.'/specify/'.$feature->slug.'/'.$story->slug;

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -15,22 +15,29 @@ class TaskFactory extends Factory
 {
     public function configure(): static
     {
-        return $this->afterMaking(function (Task $task) {
-            if ($task->story_id && ! $task->plan_id) {
-                $story = Story::query()->find($task->story_id);
-                $plan = $story?->current_plan_id
-                    ? Plan::query()->find($story->current_plan_id)
-                    : Plan::factory()->create(['story_id' => $task->story_id]);
-                $task->plan_id = $plan?->id;
+        return $this->afterCreating(function (Task $task) {
+            $plan = $task->plan;
+            $story = $plan?->story;
+
+            if ($story && ! $story->current_plan_id) {
+                $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
+            }
+        });
+    }
+
+    public function forStory(Story $story): static
+    {
+        return $this->state(function () use ($story) {
+            $freshStory = $story->fresh();
+            $plan = $freshStory?->current_plan_id
+                ? Plan::query()->find($freshStory->current_plan_id)
+                : Plan::factory()->create(['story_id' => $story->getKey()]);
+
+            if ($plan && ! $freshStory?->current_plan_id) {
+                $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
             }
 
-            if ($task->plan_id && ! $task->story_id) {
-                $task->story_id = Plan::query()->find($task->plan_id)?->story_id;
-            }
-        })->afterCreating(function (Task $task) {
-            if ($task->story && ! $task->story->current_plan_id) {
-                $task->story->forceFill(['current_plan_id' => $task->plan_id])->save();
-            }
+            return ['plan_id' => $plan?->getKey()];
         });
     }
 
@@ -40,8 +47,7 @@ class TaskFactory extends Factory
     public function definition(): array
     {
         return [
-            'plan_id' => null,
-            'story_id' => Story::factory(),
+            'plan_id' => Plan::factory(),
             'acceptance_criterion_id' => null,
             'scenario_id' => null,
             'position' => 1,

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -16,7 +16,7 @@ class TaskFactory extends Factory
     public function configure(): static
     {
         return $this->afterCreating(function (Task $task) {
-            $plan = $task->plan;
+            $plan = $task->plan()->first();
             $story = $plan?->story;
 
             if ($story && ! $story->current_plan_id) {
@@ -28,16 +28,18 @@ class TaskFactory extends Factory
     public function forStory(Story $story): static
     {
         return $this->state(function () use ($story) {
-            $freshStory = $story->fresh();
-            $plan = $freshStory?->current_plan_id
-                ? Plan::query()->find($freshStory->current_plan_id)
-                : Plan::factory()->create(['story_id' => $story->getKey()]);
-
-            if ($plan && ! $freshStory?->current_plan_id) {
-                $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
+            $planId = $story->fresh()?->current_plan_id;
+            if ($planId) {
+                return ['plan_id' => $planId];
             }
 
-            return ['plan_id' => $plan?->getKey()];
+            return [
+                'plan_id' => Plan::factory()
+                    ->for($story)
+                    ->afterCreating(function (Plan $plan) use ($story) {
+                        $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
+                    }),
+            ];
         });
     }
 

--- a/database/migrations/2026_04_29_051134_create_acceptance_criteria_table.php
+++ b/database/migrations/2026_04_29_051134_create_acceptance_criteria_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('story_id')->constrained()->cascadeOnDelete();
             $table->unsignedInteger('position')->default(0);
-            $table->text('criterion');
+            $table->text('statement');
             $table->timestamps();
         });
     }

--- a/database/migrations/2026_05_03_120000_restructure_story_planning_model.php
+++ b/database/migrations/2026_05_03_120000_restructure_story_planning_model.php
@@ -15,10 +15,6 @@ return new class extends Migration
             $table->text('outcome')->nullable()->after('intent');
         });
 
-        Schema::table('acceptance_criteria', function (Blueprint $table) {
-            $table->renameColumn('criterion', 'statement');
-        });
-
         Schema::create('scenarios', function (Blueprint $table) {
             $table->id();
             $table->foreignId('story_id')->constrained()->cascadeOnDelete();
@@ -45,8 +41,7 @@ return new class extends Migration
         });
 
         Schema::table('tasks', function (Blueprint $table) {
-            $table->foreignId('story_id')->after('plan_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('acceptance_criterion_id')->nullable()->after('story_id')
+            $table->foreignId('acceptance_criterion_id')->nullable()->after('plan_id')
                 ->constrained('acceptance_criteria')->nullOnDelete();
             $table->foreignId('scenario_id')->nullable()->after('acceptance_criterion_id')
                 ->constrained('scenarios')->nullOnDelete();
@@ -58,7 +53,6 @@ return new class extends Migration
         Schema::table('tasks', function (Blueprint $table) {
             $table->dropConstrainedForeignId('scenario_id');
             $table->dropConstrainedForeignId('acceptance_criterion_id');
-            $table->dropConstrainedForeignId('story_id');
         });
 
         Schema::table('plans', function (Blueprint $table) {
@@ -66,10 +60,6 @@ return new class extends Migration
         });
 
         Schema::dropIfExists('scenarios');
-
-        Schema::table('acceptance_criteria', function (Blueprint $table) {
-            $table->renameColumn('statement', 'criterion');
-        });
 
         Schema::table('stories', function (Blueprint $table) {
             $table->dropColumn(['kind', 'actor', 'intent', 'outcome']);

--- a/docs/plans/restructure-story-planning-model.md
+++ b/docs/plans/restructure-story-planning-model.md
@@ -28,6 +28,14 @@ Refactor Specify's product and planning model so that these concepts each have a
 - proposal / design / implementation planning
 - executable tasks and subtasks
 
+Greenfield cleanup constraint:
+- Do not preserve legacy names, compatibility aliases, duplicate ownership columns, or old traversal helpers.
+- The product layer is `Feature -> Story -> AcceptanceCriterion/Scenario`.
+- The delivery layer is `Story -> Plan -> Task -> Subtask`.
+- Cross-links are explicit: `Story.current_plan_id`, optional `Scenario.acceptance_criterion_id`, optional `Task.acceptance_criterion_id`, and optional `Task.scenario_id`.
+- `Task` must not store `story_id`; resolve the Story through `Task -> Plan -> Story`.
+- Acceptance criteria must use `statement` only; remove `criterion` columns, attributes, request aliases, and tests.
+
 The current structure stores features, stories, acceptance criteria, tasks, and subtasks, but it mixes product structure with implementation structure and flattens behavior examples into text blobs.
 
 ---

--- a/resources/views/components/run/summary-card.blade.php
+++ b/resources/views/components/run/summary-card.blade.php
@@ -114,10 +114,10 @@
 
         <flux:heading class="mt-2">{{ $title }}</flux:heading>
 
-        @if ($run->runnable instanceof \App\Models\Subtask && $run->runnable->task?->story)
+        @if ($run->runnable instanceof \App\Models\Subtask && $run->runnable->task?->plan?->story)
             <flux:text class="mt-1 text-xs text-zinc-500">
-                {{ $run->runnable->task->story->feature?->project?->name }}
-                &middot; {{ $run->runnable->task->story->name }}
+                {{ $run->runnable->task->plan->story->feature?->project?->name }}
+                &middot; {{ $run->runnable->task->plan->story->name }}
                 @if ($run->runnable->task->plan)
                     &middot; {{ __('plan') }} v{{ $run->runnable->task->plan->version }}
                 @endif

--- a/resources/views/pages/runs/⚡index.blade.php
+++ b/resources/views/pages/runs/⚡index.blade.php
@@ -34,14 +34,14 @@ new #[Title('Runs')] class extends Component {
         return AgentRun::query()
             ->where(function ($q) use ($projectIds) {
                 $q->whereHasMorph('runnable', [Subtask::class], function ($qq) use ($projectIds) {
-                    $qq->whereHas('task.story.feature', fn ($qqq) => $qqq->whereIn('project_id', $projectIds));
+                    $qq->whereHas('task.plan.story.feature', fn ($qqq) => $qqq->whereIn('project_id', $projectIds));
                 })
                 ->orWhereHasMorph('runnable', [Story::class], function ($qq) use ($projectIds) {
                     $qq->whereHas('feature', fn ($qqq) => $qqq->whereIn('project_id', $projectIds));
                 });
             })
             ->when($this->status, fn ($q, $s) => $q->where('status', $s))
-            ->with('runnable.task.plan', 'runnable.task.story.feature.project', 'repo')
+            ->with('runnable.task.plan', 'runnable.task.plan.story.feature.project', 'repo')
             ->latest('id')
             ->paginate(25);
     }

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -128,13 +128,13 @@ new #[Title('Run')] class extends Component {
             ->where('runnable_type', Subtask::class)
             ->where('runnable_id', $this->subtask_id)
             ->whereHasMorph('runnable', [Subtask::class], fn ($q) => $q
-                ->whereHas('task.story', fn ($qq) => $qq->where('id', $this->story_id))
-                ->whereHas('task.story.feature', fn ($qq) => $qq
+                ->whereHas('task.plan.story', fn ($qq) => $qq->where('id', $this->story_id))
+                ->whereHas('task.plan.story.feature', fn ($qq) => $qq
                     ->where('project_id', $this->project_id)
                     ->whereIn('project_id', $accessible)
                 )
             )
-            ->with(['runnable.task.plan', 'runnable.task.acceptanceCriterion', 'runnable.task.scenario', 'runnable.task.story.feature.project', 'repo'])
+            ->with(['runnable.task.plan', 'runnable.task.acceptanceCriterion', 'runnable.task.scenario', 'runnable.task.plan.story.feature.project', 'repo'])
             ->first();
     }
 
@@ -152,7 +152,7 @@ new #[Title('Run')] class extends Component {
             $run = $this->run;
             $subtask = $run->runnable;
             $task = $subtask->task;
-            $story = $task->story;
+            $story = $task->plan->story;
             $feature = $story->feature;
             $project = $feature->project;
             $rail = match ($run->status) {

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -136,7 +136,7 @@ new #[Title('Story')] class extends Component {
         return DB::transaction(function () use ($story, $existing, &$kept, &$changed) {
             foreach ($this->editCriteria as $i => $row) {
                 $position = $i + 1;
-                $text = trim((string) ($row['statement'] ?? $row['criterion'] ?? ''));
+                $text = trim((string) ($row['statement'] ?? ''));
                 $id = $row['id'] ?? null;
 
                 if ($id !== null && $existing->has($id)) {
@@ -452,7 +452,7 @@ new #[Title('Story')] class extends Component {
         $kept = [];
         foreach ($this->editCriteria as $row) {
             $id = $row['id'] ?? null;
-            $text = trim((string) ($row['statement'] ?? $row['criterion'] ?? ''));
+            $text = trim((string) ($row['statement'] ?? ''));
             if ($id === null) {
                 if ($text !== '') {
                     $added++;

--- a/resources/views/pages/subtasks/⚡show.blade.php
+++ b/resources/views/pages/subtasks/⚡show.blade.php
@@ -34,13 +34,13 @@ new #[Title('Subtask')] class extends Component {
     public function subtask(): ?Subtask
     {
         return Subtask::query()
-            ->whereHas('task.story.feature', fn ($q) => $q
+            ->whereHas('task.plan.story.feature', fn ($q) => $q
                 ->where('project_id', $this->project_id)
                 ->whereIn('project_id', Auth::user()->accessibleProjectIds())
             )
-            ->whereHas('task.story', fn ($q) => $q->where('id', $this->story_id))
+            ->whereHas('task.plan.story', fn ($q) => $q->where('id', $this->story_id))
             ->with([
-                'task.story.feature.project',
+                'task.plan.story.feature.project',
                 'task.plan',
                 'task.acceptanceCriterion',
                 'task.scenario',
@@ -69,7 +69,7 @@ new #[Title('Subtask')] class extends Component {
         @php
             $subtask = $this->subtask;
             $task = $subtask->task;
-            $story = $task->story;
+            $story = $task->plan->story;
             $feature = $story->feature;
             $project = $feature->project;
             $runs = $this->runs;

--- a/resources/views/pages/tasks/⚡show.blade.php
+++ b/resources/views/pages/tasks/⚡show.blade.php
@@ -33,14 +33,13 @@ new #[Title('Task')] class extends Component {
     public function task(): ?Task
     {
         return Task::query()
-            ->whereHas('story.feature', fn ($q) => $q
+            ->whereHas('plan.story.feature', fn ($q) => $q
                 ->where('project_id', $this->project_id)
                 ->whereIn('project_id', Auth::user()->accessibleProjectIds())
             )
-            ->whereHas('story', fn ($q) => $q->where('id', $this->story_id))
+            ->whereHas('plan.story', fn ($q) => $q->where('id', $this->story_id))
             ->with([
-                'story.feature.project',
-                'plan',
+                'plan.story.feature.project',
                 'acceptanceCriterion',
                 'scenario',
                 'dependencies',
@@ -57,7 +56,7 @@ new #[Title('Task')] class extends Component {
     @else
         @php
             $task = $this->task;
-            $story = $task->story;
+            $story = $task->plan->story;
             $feature = $story->feature;
             $project = $feature->project;
             $ac = $task->acceptanceCriterion;

--- a/resources/views/pages/⚡dashboard.blade.php
+++ b/resources/views/pages/⚡dashboard.blade.php
@@ -50,8 +50,9 @@ new #[Title('Dashboard')] class extends Component {
             ->whereExists(function ($q) {
                 $q->selectRaw('1')
                     ->from('tasks')
+                    ->join('plans', 'plans.id', '=', 'tasks.plan_id')
                     ->join('subtasks', 'subtasks.task_id', '=', 'tasks.id')
-                    ->whereColumn('tasks.story_id', 'stories.id')
+                    ->whereColumn('plans.story_id', 'stories.id')
                     ->whereColumn('tasks.plan_id', 'stories.current_plan_id')
                     ->whereIn('subtasks.status', [TaskStatus::InProgress->value, TaskStatus::Pending->value]);
             })
@@ -64,7 +65,7 @@ new #[Title('Dashboard')] class extends Component {
         return AgentRun::query()
             ->where('status', AgentRunStatus::Failed)
             ->whereHasMorph('runnable', [Subtask::class], function ($q) {
-                $q->whereHas('task.story.feature', fn ($qq) => $qq->whereIn('project_id', $this->projectIds));
+                $q->whereHas('task.plan.story.feature', fn ($qq) => $qq->whereIn('project_id', $this->projectIds));
             })
             ->count();
     }
@@ -74,9 +75,9 @@ new #[Title('Dashboard')] class extends Component {
     {
         return AgentRun::query()
             ->whereHasMorph('runnable', [Subtask::class], function ($q) {
-                $q->whereHas('task.story.feature', fn ($qq) => $qq->whereIn('project_id', $this->projectIds));
+                $q->whereHas('task.plan.story.feature', fn ($qq) => $qq->whereIn('project_id', $this->projectIds));
             })
-            ->with('runnable.task.plan', 'runnable.task.story.feature.project', 'repo')
+            ->with('runnable.task.plan', 'runnable.task.plan.story.feature.project', 'repo')
             ->latest('id')
             ->limit(5)
             ->get();
@@ -252,10 +253,10 @@ new #[Title('Dashboard')] class extends Component {
             </div>
             @forelse ($this->recentRuns as $run)
                 @php
-                    $runHref = $run->runnable && $run->runnable->task?->story
+                    $runHref = $run->runnable && $run->runnable->task?->plan?->story
                         ? route('runs.show', [
-                            'project' => $run->runnable->task->story->feature->project_id,
-                            'story' => $run->runnable->task->story->id,
+                            'project' => $run->runnable->task->plan->story->feature->project_id,
+                            'story' => $run->runnable->task->plan->story->id,
                             'subtask' => $run->runnable->id,
                             'run' => $run->id,
                         ])

--- a/resources/views/partials/story-task.blade.php
+++ b/resources/views/partials/story-task.blade.php
@@ -17,7 +17,7 @@
 
     <flux:heading class="mt-1" size="sm">
         <a
-            href="{{ route('tasks.show', ['project' => $task->story->feature->project_id, 'story' => $task->story_id, 'task' => $task->id]) }}"
+            href="{{ route('tasks.show', ['project' => $task->plan->story->feature->project_id, 'story' => $task->plan->story_id, 'task' => $task->id]) }}"
             wire:navigate
             class="hover:underline"
         >{{ $task->name }}</a>
@@ -46,7 +46,7 @@
                     <div class="flex flex-wrap items-center gap-2">
                         <flux:badge size="sm">T{{ $task->position }}.{{ $sub->position }}</flux:badge>
                         <a
-                            href="{{ route('subtasks.show', ['project' => $task->story->feature->project_id, 'story' => $task->story_id, 'subtask' => $sub->id]) }}"
+                            href="{{ route('subtasks.show', ['project' => $task->plan->story->feature->project_id, 'story' => $task->plan->story_id, 'subtask' => $sub->id]) }}"
                             wire:navigate
                             class="font-medium hover:underline"
                         >{{ $sub->name }}</a>
@@ -72,8 +72,8 @@
                     @if ($latestRun)
                         @php
                             $runUrl = route('runs.show', [
-                                'project' => $task->story->feature->project_id,
-                                'story' => $task->story_id,
+                                'project' => $task->plan->story->feature->project_id,
+                                'story' => $task->plan->story_id,
                                 'subtask' => $sub->id,
                                 'run' => $latestRun->id,
                             ]);
@@ -97,8 +97,8 @@
 
                             <x-run.history-panel
                                 :runs="$priorRuns"
-                                :project-id="$task->story->feature->project_id"
-                                :story-id="$task->story_id"
+                                :project-id="$task->plan->story->feature->project_id"
+                                :story-id="$task->plan->story_id"
                                 :subtask-id="$sub->id"
                             />
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,9 +66,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         }
 
         if ($r->runnable_type === Subtask::class) {
-            $subtask = Subtask::with('task.story.feature')->find($r->runnable_id);
-            abort_unless($subtask?->task?->story, 404);
-            $story = $subtask->task->story;
+            $subtask = Subtask::with('task.plan.story.feature')->find($r->runnable_id);
+            abort_unless($subtask?->task?->plan?->story, 404);
+            $story = $subtask->task->plan->story;
             abort_unless(in_array($story->feature->project_id, auth()->user()->accessibleProjectIds(), true), 404);
 
             return redirect()->route('runs.show', [

--- a/tests/Feature/ApprovalsIndexTest.php
+++ b/tests/Feature/ApprovalsIndexTest.php
@@ -39,7 +39,7 @@ test('approvals board shows separate story and plan queues', function () {
         'status' => StoryStatus::Approved,
         'name' => 'Plan queue item',
     ]);
-    $task = Task::factory()->for($planStory)->create(['position' => 1]);
+    $task = Task::factory()->forStory($planStory)->create(['position' => 1]);
     $task->plan->forceFill(['status' => PlanStatus::PendingApproval->value, 'name' => 'Execution plan'])->save();
 
     $this->actingAs($user);

--- a/tests/Feature/CliExecutorTest.php
+++ b/tests/Feature/CliExecutorTest.php
@@ -197,7 +197,7 @@ test('full pipeline with cli driver: clone → branch → cli edits → commit �
     ]);
 
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->for($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forStory($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'append', 'position' => 0]);
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();
     $story->fresh()->submitForApproval();

--- a/tests/Feature/ConflictResolutionTest.php
+++ b/tests/Feature/ConflictResolutionTest.php
@@ -57,7 +57,7 @@ function conflictResolutionScene(bool $mergeable = false): array
     $project->attachRepo($repo);
 
     $ac = AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->for($story)->create(['acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forStory($story)->create(['acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/CurrentPlanProjectionTest.php
+++ b/tests/Feature/CurrentPlanProjectionTest.php
@@ -14,7 +14,7 @@ test('acceptance criterion met only reflects done tasks in the current plan', fu
     $story = Story::factory()->create();
     $ac = AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
 
-    $oldTask = Task::factory()->for($story)->create([
+    $oldTask = Task::factory()->forStory($story)->create([
         'acceptance_criterion_id' => $ac->id,
         'status' => TaskStatus::Done,
         'position' => 1,
@@ -26,7 +26,6 @@ test('acceptance criterion met only reflects done tasks in the current plan', fu
         'status' => PlanStatus::PendingApproval,
     ]);
     $newTask = Task::factory()->create([
-        'story_id' => $story->id,
         'plan_id' => $newPlan->id,
         'acceptance_criterion_id' => $ac->id,
         'status' => TaskStatus::Pending,

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -41,16 +41,16 @@ test('dashboard counts pending stories, pending plans, executing stories, and fa
 
     Story::factory()->count(2)->for($feature)->create(['status' => StoryStatus::PendingApproval]);
     $approved = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $task = Task::factory()->for($approved)->create();
+    $task = Task::factory()->forStory($approved)->create();
     $task->plan->forceFill(['status' => PlanStatus::Approved->value])->save();
 
     $planPendingStory = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $planPendingTask = Task::factory()->for($planPendingStory)->create();
+    $planPendingTask = Task::factory()->forStory($planPendingStory)->create();
     $planPendingTask->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
     Subtask::factory()->for($task)->create(['status' => TaskStatus::InProgress]);
 
     $approved2 = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $taskWithFailedRun = Task::factory()->for($approved2)->create();
+    $taskWithFailedRun = Task::factory()->forStory($approved2)->create();
     $taskWithFailedRun->plan->forceFill(['status' => PlanStatus::Approved->value])->save();
     $subtaskWithFailedRun = Subtask::factory()->for($taskWithFailedRun)->create();
     AgentRun::factory()->create([
@@ -118,7 +118,7 @@ test('awaiting your approval lists pending stories and pending current plans the
         'name' => 'Approve my plan',
         'status' => StoryStatus::Approved,
     ]);
-    $planTask = Task::factory()->for($planStory)->create();
+    $planTask = Task::factory()->forStory($planStory)->create();
     $planTask->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
 
     $this->actingAs($user);
@@ -162,7 +162,7 @@ test('recent runs are clickable and link to the run console', function () {
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/DependenciesTest.php
+++ b/tests/Feature/DependenciesTest.php
@@ -14,8 +14,8 @@ uses(RefreshDatabase::class);
 
 test('task can depend on another task in the same current plan', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->for($story)->create(['name' => 'a']);
-    $b = Task::factory()->for($story)->create(['name' => 'b']);
+    $a = Task::factory()->forStory($story)->create(['name' => 'a']);
+    $b = Task::factory()->forStory($story)->create(['name' => 'b']);
 
     $b->addDependency($a);
 
@@ -40,9 +40,9 @@ test('task self-dependency is rejected', function () {
 
 test('task dependency cycle is prevented', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->for($story)->create();
-    $b = Task::factory()->for($story)->create();
-    $c = Task::factory()->for($story)->create();
+    $a = Task::factory()->forStory($story)->create();
+    $b = Task::factory()->forStory($story)->create();
+    $c = Task::factory()->forStory($story)->create();
 
     $b->addDependency($a);
     $c->addDependency($b);
@@ -53,8 +53,8 @@ test('task dependency cycle is prevented', function () {
 
 test('task isReady reflects dependency status', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->for($story)->create(['status' => TaskStatus::Pending]);
-    $b = Task::factory()->for($story)->create(['status' => TaskStatus::Pending]);
+    $a = Task::factory()->forStory($story)->create(['status' => TaskStatus::Pending]);
+    $b = Task::factory()->forStory($story)->create(['status' => TaskStatus::Pending]);
     $b->addDependency($a);
 
     expect($b->isReady())->toBeFalse();

--- a/tests/Feature/IaRedirectsTest.php
+++ b/tests/Feature/IaRedirectsTest.php
@@ -129,7 +129,7 @@ test('/runs/{id} 301-redirects to nested run console for subtask runs', function
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/MultiExecutorRaceTest.php
+++ b/tests/Feature/MultiExecutorRaceTest.php
@@ -38,7 +38,7 @@ function approvedSubtaskForRace(): Subtask
     ]);
 
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->for($story)->create(['acceptance_criterion_id' => $ac->id, 'position' => 0]);
+    $task = Task::factory()->forStory($story)->create(['acceptance_criterion_id' => $ac->id, 'position' => 0]);
     Subtask::factory()->for($task)->create(['position' => 0, 'name' => 'race-me']);
 
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();

--- a/tests/Feature/PlanApprovalTest.php
+++ b/tests/Feature/PlanApprovalTest.php
@@ -27,7 +27,7 @@ function makePlan(): Plan
 
     $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
     $criterion = AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
-    $task = Task::factory()->for($story)->create([
+    $task = Task::factory()->forStory($story)->create([
         'position' => 1,
         'acceptance_criterion_id' => $criterion->id,
     ]);

--- a/tests/Feature/PlansIndexTest.php
+++ b/tests/Feature/PlansIndexTest.php
@@ -24,7 +24,7 @@ test('plans index lists current plans for the selected project', function () {
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $task = Task::factory()->for($story)->create(['position' => 1]);
+    $task = Task::factory()->forStory($story)->create(['position' => 1]);
     $task->plan->forceFill(['name' => 'Current plan', 'status' => PlanStatus::PendingApproval->value])->save();
 
     $this->actingAs($user);

--- a/tests/Feature/PrPayloadBuilderTest.php
+++ b/tests/Feature/PrPayloadBuilderTest.php
@@ -14,9 +14,9 @@ function makeSubtaskWithCriterion(int $acPosition = 3, ?string $criterion = 'Use
     $story = Story::factory()->create(['name' => 'Add CSV export']);
     $ac = AcceptanceCriterion::factory()->for($story)->create([
         'position' => $acPosition,
-        'criterion' => $criterion,
+        'statement' => $criterion,
     ]);
-    $task = Task::factory()->for($story)->create([
+    $task = Task::factory()->forStory($story)->create([
         'name' => 'Wire export endpoint',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
@@ -32,7 +32,7 @@ test('title locates the subtask in the Story / AC tree', function () {
     $subtask = makeSubtaskWithCriterion(acPosition: 3);
 
     expect(PrPayloadBuilder::title($subtask))
-        ->toBe(sprintf('Specify [Story #%d AC#%d]: Add export route and controller', $subtask->task->story_id, 3));
+        ->toBe(sprintf('Specify [Story #%d AC#%d]: Add export route and controller', $subtask->task->plan->story_id, 3));
 });
 
 test('title renders AC#0 instead of dropping the AC tag (regression: truthiness check)', function () {
@@ -44,7 +44,7 @@ test('title renders AC#0 instead of dropping the AC tag (regression: truthiness 
 
 test('title falls back to Story-only tag when AC position is null', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create([
+    $task = Task::factory()->forStory($story)->create([
         'name' => 'task',
         'position' => 1,
         'acceptance_criterion_id' => null,

--- a/tests/Feature/ProgressEventsTest.php
+++ b/tests/Feature/ProgressEventsTest.php
@@ -159,7 +159,7 @@ test('SubtaskRunPipeline tags events with the current phase and writes them unde
         'required_approvals' => 0,
     ]);
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->for($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forStory($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'append', 'position' => 0]);
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();
     $story->fresh()->submitForApproval();
@@ -185,7 +185,7 @@ test('GET /runs/{run}/events returns events scoped + after a cursor', function (
     $user = User::factory()->create();
     $project->team->addMember($user);
 
-    $task = Task::factory()->for($story)->create(['position' => 0]);
+    $task = Task::factory()->forStory($story)->create(['position' => 0]);
     $subtask = Subtask::factory()->for($task)->create(['position' => 0]);
 
     $run = AgentRun::create([
@@ -226,7 +226,7 @@ test('GET /runs/{run}/events 404s when the user has no project access', function
     Workspace::factory()->for($outsider, 'owner')->create();
 
     $story = makeStory();
-    $task = Task::factory()->for($story)->create(['position' => 0]);
+    $task = Task::factory()->forStory($story)->create(['position' => 0]);
     $subtask = Subtask::factory()->for($task)->create(['position' => 0]);
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/PullRequestTest.php
+++ b/tests/Feature/PullRequestTest.php
@@ -196,7 +196,7 @@ test('full pipeline records pull_request_error after a non-fatal PR failure on a
     ]);
 
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->for($story)->create(['name' => 'add file', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forStory($story)->create(['name' => 'add file', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'add file', 'position' => 0]);
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();
     $story->fresh()->submitForApproval();

--- a/tests/Feature/RunHistoryTest.php
+++ b/tests/Feature/RunHistoryTest.php
@@ -26,7 +26,7 @@ function runScene(): array
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
 
     return compact('user', 'project', 'feature', 'story', 'task');
 }
@@ -60,7 +60,7 @@ test('does not show runs from outside the user\'s teams', function () {
     $otherProject = Project::factory()->for($otherTeam)->create();
     $otherFeature = Feature::factory()->for($otherProject)->create();
     $otherStory = Story::factory()->for($otherFeature)->create();
-    $otherTask = Task::factory()->for($otherStory)->create();
+    $otherTask = Task::factory()->forStory($otherStory)->create();
     $hiddenSub = Subtask::factory()->for($otherTask)->create(['name' => 'hidden-sub']);
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -31,7 +31,7 @@ function makeApprovedTask(): Task
     $story = Story::factory()->create(['status' => StoryStatus::Approved, 'revision' => 1]);
     $ac = AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
 
-    return Task::factory()->for($story)->create([
+    return Task::factory()->forStory($story)->create([
         'name' => 'wire CSV export',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
@@ -41,7 +41,7 @@ function makeApprovedTask(): Task
 test('PlanWriter::appendProposedSubtasks appends without resetting Story approval (ADR-0005 carve-out)', function () {
     $task = makeApprovedTask();
     Subtask::factory()->for($task)->create(['position' => 1, 'name' => 'first', 'status' => TaskStatus::Done]);
-    $story = $task->story;
+    $story = $task->plan->story;
 
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,
@@ -139,7 +139,7 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
     // would be orphaned under a Task whose run was marked Failed.
     $task = makeApprovedTask();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'main', 'position' => 1]);
-    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $repo = Repo::factory()->for($task->plan->story->feature->project->team->workspace)->create();
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->getKey(),
@@ -208,7 +208,7 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
 test('alreadyComplete returns the Succeeded-class outcome when evidence SHAs are reachable from HEAD (ADR-0007)', function () {
     $task = makeApprovedTask();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'already-done', 'position' => 1]);
-    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $repo = Repo::factory()->for($task->plan->story->feature->project->team->workspace)->create();
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->getKey(),
@@ -281,7 +281,7 @@ test('alreadyComplete returns the Succeeded-class outcome when evidence SHAs are
 test('alreadyComplete falls through to noDiff when evidence is empty (ADR-0007 safety net)', function () {
     $task = makeApprovedTask();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'sus-claim', 'position' => 1]);
-    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $repo = Repo::factory()->for($task->plan->story->feature->project->team->workspace)->create();
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->getKey(),
@@ -350,7 +350,7 @@ test('alreadyComplete falls through to noDiff when evidence is empty (ADR-0007 s
 test('alreadyComplete falls through to noDiff when ANY cited SHA is unreachable, even if others verify (ADR-0007 all-or-nothing)', function () {
     $task = makeApprovedTask();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'partial-claim', 'position' => 1]);
-    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $repo = Repo::factory()->for($task->plan->story->feature->project->team->workspace)->create();
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->getKey(),
@@ -421,7 +421,7 @@ test('alreadyComplete falls through to noDiff when ANY cited SHA is unreachable,
 test('alreadyComplete falls through to noDiff when none of the cited SHAs are reachable (ADR-0007 safety net)', function () {
     $task = makeApprovedTask();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'hallucinated', 'position' => 1]);
-    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $repo = Repo::factory()->for($task->plan->story->feature->project->team->workspace)->create();
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->getKey(),
@@ -513,7 +513,7 @@ test('CliExecutor returns false/empty when the sentinel is absent', function () 
 test('context_brief is persisted on AgentRun.output even when the run ends in noDiff', function () {
     $task = makeApprovedTask();
     $subtask = Subtask::factory()->for($task)->create(['name' => 'main', 'position' => 1]);
-    $repo = Repo::factory()->for($task->story->feature->project->team->workspace)->create();
+    $repo = Repo::factory()->for($task->plan->story->feature->project->team->workspace)->create();
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->getKey(),

--- a/tests/Feature/StoryAutoExecutionTest.php
+++ b/tests/Feature/StoryAutoExecutionTest.php
@@ -34,7 +34,7 @@ function approvedStoryScene(): array
     $project->attachRepo($repo);
 
     $ac = $story->acceptanceCriteria()->first();
-    $task = Task::factory()->for($story)->create(['position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forStory($story)->create(['position' => 0, 'acceptance_criterion_id' => $ac->id]);
     Subtask::factory()->for($task)->create(['position' => 0]);
 
     return ['story' => $story->fresh(), 'project' => $project, 'task' => $task, 'plan' => Plan::query()->findOrFail($task->plan_id)];

--- a/tests/Feature/StoryPullRequestsTest.php
+++ b/tests/Feature/StoryPullRequestsTest.php
@@ -13,7 +13,7 @@ uses(RefreshDatabase::class);
 function storyWithSubtaskAndRun(array $output, array $runOverrides = []): array
 {
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create(array_merge([
         'runnable_type' => Subtask::class,
@@ -51,7 +51,7 @@ test('pullRequests surfaces a single-driver PR as primary', function () {
 
 test('pullRequests deduplicates retries that adopted the same upstream PR', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     // Two AgentRuns on the same Subtask both adopting the same PR — e.g.
@@ -77,7 +77,7 @@ test('pullRequests deduplicates retries that adopted the same upstream PR', func
 
 test('pullRequests in race mode surfaces every sibling and primary is null until merge', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     foreach (['cli' => 21, 'specify' => 22, 'codex' => 23] as $driver => $number) {
@@ -107,7 +107,7 @@ test('pullRequests in race mode surfaces every sibling and primary is null until
 
 test('primaryPullRequest hoists the merged sibling and pullRequests sorts it first', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     AgentRun::factory()->create([
@@ -148,7 +148,7 @@ test('pullRequests preserves run-id-desc order within the unmerged partition whe
     // non-merged candidates can drift across PHP/Laravel versions —
     // reviewers reading the candidate list would see entries shuffle.
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     foreach ([
@@ -182,7 +182,7 @@ test('pullRequests entries expose run_finished_at, not opened_at', function () {
     // Renamed in review feedback: opened_at implied an authoritative PR
     // open timestamp; we only have the AgentRun's terminal time.
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -200,7 +200,7 @@ test('pullRequests entries expose run_finished_at, not opened_at', function () {
 
 test('pullRequests excludes RespondToReview-kind runs (those just push commits, not PRs)', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create();
+    $task = Task::factory()->forStory($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     AgentRun::factory()->create([

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -190,9 +190,9 @@ test('approval tracks render separately for story contract and current plan', fu
     $ac = AcceptanceCriterion::create([
         'story_id' => $s['story']->id,
         'position' => 1,
-        'criterion' => 'AC-text-must-lead',
+        'statement' => 'AC-text-must-lead',
     ]);
-    $task = Task::factory()->for($s['story'])->create([
+    $task = Task::factory()->forStory($s['story'])->create([
         'name' => 'task-name-secondary',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
@@ -218,9 +218,9 @@ test('plan section is AC-led: AC text leads, Task name follows', function () {
     $ac = AcceptanceCriterion::create([
         'story_id' => $s['story']->id,
         'position' => 1,
-        'criterion' => 'AC-text-must-lead',
+        'statement' => 'AC-text-must-lead',
     ]);
-    Task::factory()->for($s['story'])->create([
+    Task::factory()->forStory($s['story'])->create([
         'name' => 'task-name-secondary',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
@@ -241,7 +241,7 @@ test('task missing acceptance_criterion_id renders under Unmapped tasks', functi
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);
 
-    Task::factory()->for($s['story'])->create([
+    Task::factory()->forStory($s['story'])->create([
         'name' => 'orphan-task',
         'position' => 1,
         'acceptance_criterion_id' => null,
@@ -259,9 +259,9 @@ test('appended subtask renders provenance glyph and tooltip referencing originat
     attachPolicy($s['ws'], required: 1);
 
     $ac = AcceptanceCriterion::create([
-        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'ac',
+        'story_id' => $s['story']->id, 'position' => 1, 'statement' => 'ac',
     ]);
-    $task = Task::factory()->for($s['story'])->create([
+    $task = Task::factory()->forStory($s['story'])->create([
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
     ]);
@@ -289,7 +289,7 @@ test('reset-approval banner renders with delta when AC count changes during edit
     attachPolicy($s['ws'], required: 1);
 
     $original = AcceptanceCriterion::create([
-        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'original-ac',
+        'story_id' => $s['story']->id, 'position' => 1, 'statement' => 'original-ac',
     ]);
     forceStoryStatus($s['story'], StoryStatus::Approved);
 
@@ -298,8 +298,8 @@ test('reset-approval banner renders with delta when AC count changes during edit
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->call('startEdit')
         ->set('editCriteria', [
-            ['id' => $original->id, 'criterion' => 'original-ac'],
-            ['id' => null, 'criterion' => 'newly-added-ac'],
+            ['id' => $original->id, 'statement' => 'original-ac'],
+            ['id' => null, 'statement' => 'newly-added-ac'],
         ])
         ->assertSeeHtml('data-banner="reset-approval"')
         ->assertSee('+1')
@@ -311,7 +311,7 @@ test('reset-approval banner renders ~1 when an existing AC text is edited on App
     attachPolicy($s['ws'], required: 1);
 
     $original = AcceptanceCriterion::create([
-        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'original-ac',
+        'story_id' => $s['story']->id, 'position' => 1, 'statement' => 'original-ac',
     ]);
     forceStoryStatus($s['story'], StoryStatus::Approved);
 
@@ -320,7 +320,7 @@ test('reset-approval banner renders ~1 when an existing AC text is edited on App
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->call('startEdit')
         ->set('editCriteria', [
-            ['id' => $original->id, 'criterion' => 'edited-ac-text'],
+            ['id' => $original->id, 'statement' => 'edited-ac-text'],
         ])
         ->assertSeeHtml('data-banner="reset-approval"')
         ->assertSee('~1')
@@ -332,7 +332,7 @@ test('reset-approval banner does not render when nothing changes during edit', f
     attachPolicy($s['ws'], required: 1);
 
     AcceptanceCriterion::create([
-        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'unchanged-ac',
+        'story_id' => $s['story']->id, 'position' => 1, 'statement' => 'unchanged-ac',
     ]);
     forceStoryStatus($s['story'], StoryStatus::Approved);
 
@@ -349,7 +349,7 @@ test('plan section renders with compact/expanded toggle controls', function () {
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);
     AcceptanceCriterion::create([
-        'story_id' => $s['story']->id, 'position' => 1, 'criterion' => 'has-an-ac',
+        'story_id' => $s['story']->id, 'position' => 1, 'statement' => 'has-an-ac',
     ]);
 
     $this->actingAs($s['user']);

--- a/tests/Feature/StoryShowTest.php
+++ b/tests/Feature/StoryShowTest.php
@@ -29,9 +29,9 @@ test('story show renders AC, tasks with subtasks, and runs', function () {
     ['user' => $user, 'feature' => $feature] = storyShowScene();
     $story = Story::factory()->for($feature)->create(['name' => 'visible-story']);
     $ac = AcceptanceCriterion::create([
-        'story_id' => $story->id, 'position' => 0, 'criterion' => 'must-render-AC',
+        'story_id' => $story->id, 'position' => 0, 'statement' => 'must-render-AC',
     ]);
-    $task = Task::factory()->for($story)->create(['name' => 'task-name', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forStory($story)->create(['name' => 'task-name', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $sub = Subtask::factory()->for($task)->create(['name' => 'sub-name', 'position' => 0]);
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/SubtaskAndRunShowTest.php
+++ b/tests/Feature/SubtaskAndRunShowTest.php
@@ -25,7 +25,7 @@ function subtaskScene(): array
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->for($story)->create(['name' => 'parent-task', 'position' => 1]);
+    $task = Task::factory()->forStory($story)->create(['name' => 'parent-task', 'position' => 1]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'parent-subtask', 'position' => 1]);
 
     return compact('user', 'project', 'feature', 'story', 'task', 'subtask');

--- a/tests/Feature/SubtaskExecutionTest.php
+++ b/tests/Feature/SubtaskExecutionTest.php
@@ -118,8 +118,8 @@ test('full story execution: subtasks succeed and story flips to Done', function 
     $ac1 = $story->acceptanceCriteria()->first();
     $ac2 = AcceptanceCriterion::factory()->for($story)->create(['position' => 2]);
 
-    $taskA = Task::factory()->for($story)->create(['name' => 'a', 'position' => 0, 'acceptance_criterion_id' => $ac1->id]);
-    $taskB = Task::factory()->for($story)->create(['name' => 'b', 'position' => 1, 'acceptance_criterion_id' => $ac2->id]);
+    $taskA = Task::factory()->forStory($story)->create(['name' => 'a', 'position' => 0, 'acceptance_criterion_id' => $ac1->id]);
+    $taskB = Task::factory()->forStory($story)->create(['name' => 'b', 'position' => 1, 'acceptance_criterion_id' => $ac2->id]);
     Subtask::factory()->for($taskA)->create(['position' => 0]);
     Subtask::factory()->for($taskB)->create(['position' => 0]);
     $taskB->addDependency($taskA);

--- a/tests/Feature/SubtaskOrderingTest.php
+++ b/tests/Feature/SubtaskOrderingTest.php
@@ -11,7 +11,7 @@ uses(RefreshDatabase::class);
 
 test('a subtask is only actionable when all lower-position siblings in the same task are Done', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->for($story)->create(['position' => 0]);
+    $task = Task::factory()->forStory($story)->create(['position' => 0]);
     $a = Subtask::factory()->for($task)->create(['position' => 0, 'status' => TaskStatus::Pending]);
     $b = Subtask::factory()->for($task)->create(['position' => 1, 'status' => TaskStatus::Pending]);
     $c = Subtask::factory()->for($task)->create(['position' => 2, 'status' => TaskStatus::Pending]);
@@ -32,10 +32,10 @@ test('a subtask is only actionable when all lower-position siblings in the same 
 
 test('subtasks of a task with unfinished dependencies are not actionable', function () {
     $story = Story::factory()->create();
-    $blocker = Task::factory()->for($story)->create(['position' => 0, 'status' => TaskStatus::Pending]);
+    $blocker = Task::factory()->forStory($story)->create(['position' => 0, 'status' => TaskStatus::Pending]);
     Subtask::factory()->for($blocker)->create(['position' => 0]);
 
-    $dependent = Task::factory()->for($story)->create(['position' => 1, 'status' => TaskStatus::Pending]);
+    $dependent = Task::factory()->forStory($story)->create(['position' => 1, 'status' => TaskStatus::Pending]);
     Subtask::factory()->for($dependent)->create(['position' => 0]);
     $dependent->addDependency($blocker);
 

--- a/tests/Feature/TaskDependencyConstraintTest.php
+++ b/tests/Feature/TaskDependencyConstraintTest.php
@@ -10,8 +10,8 @@ test('task dependencies must live in the same plan', function () {
     $storyA = Story::factory()->create();
     $storyB = Story::factory()->create();
 
-    $a = Task::factory()->for($storyA)->create();
-    $b = Task::factory()->for($storyB)->create();
+    $a = Task::factory()->forStory($storyA)->create();
+    $b = Task::factory()->forStory($storyB)->create();
 
     expect(fn () => $b->addDependency($a))
         ->toThrow(InvalidArgumentException::class, 'same plan');
@@ -19,8 +19,8 @@ test('task dependencies must live in the same plan', function () {
 
 test('task dependencies within the same story are allowed', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->for($story)->create();
-    $b = Task::factory()->for($story)->create();
+    $a = Task::factory()->forStory($story)->create();
+    $b = Task::factory()->forStory($story)->create();
 
     $b->addDependency($a);
 

--- a/tests/Feature/TaskGenerationTest.php
+++ b/tests/Feature/TaskGenerationTest.php
@@ -22,8 +22,8 @@ beforeEach(function () {
 
 test('dispatching task generation runs the job, creates Tasks linked to ACs with Subtasks, marks AgentRun succeeded', function () {
     $story = Story::factory()->create();
-    $ac1 = AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'criterion' => 'AC one']);
-    $ac2 = AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'criterion' => 'AC two']);
+    $ac1 = AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'statement' => 'AC one']);
+    $ac2 = AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'AC two']);
 
     TasksGenerator::fake(fn () => [
         'summary' => 'plan it',
@@ -63,7 +63,7 @@ test('dispatching task generation runs the job, creates Tasks linked to ACs with
 
 test('regeneration replaces the prior task list', function () {
     $story = Story::factory()->create();
-    AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'criterion' => 'AC one']);
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'statement' => 'AC one']);
 
     TasksGenerator::fake(fn () => [
         'summary' => 'v1',

--- a/tests/Feature/TaskShowTest.php
+++ b/tests/Feature/TaskShowTest.php
@@ -25,9 +25,9 @@ function taskShowScene(): array
     $ac = AcceptanceCriterion::create([
         'story_id' => $story->id,
         'position' => 1,
-        'criterion' => 'Users can edit a story.',
+        'statement' => 'Users can edit a story.',
     ]);
-    $task = Task::factory()->for($story)->create([
+    $task = Task::factory()->forStory($story)->create([
         'name' => 'Add edit form',
         'position' => 1,
         'status' => TaskStatus::InProgress,
@@ -63,7 +63,7 @@ test('task show 404s when task is outside the user accessible projects', functio
     $otherProject = Project::factory()->for($otherTeam)->create();
     $otherFeature = Feature::factory()->for($otherProject)->create();
     $otherStory = Story::factory()->for($otherFeature)->create();
-    $otherTask = Task::factory()->for($otherStory)->create();
+    $otherTask = Task::factory()->forStory($otherStory)->create();
 
     $this->actingAs($user);
 

--- a/tests/Feature/TriageTest.php
+++ b/tests/Feature/TriageTest.php
@@ -56,7 +56,7 @@ function pendingPlanFor(Feature $feature, string $name = 'Visible plan story')
         'status' => StoryStatus::Approved,
         'name' => $name,
     ]);
-    $task = Task::factory()->for($story)->create(['position' => 1]);
+    $task = Task::factory()->forStory($story)->create(['position' => 1]);
     $task->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
 
     return $task->plan->fresh();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -106,8 +106,7 @@ function approvedStoryInProjectWithRepo(): Story
     ]);
 
     $ac = $story->acceptanceCriteria()->first();
-    $task = Task::factory()->create([
-        'story_id' => $story->id,
+    $task = Task::factory()->forStory($story)->create([
         'acceptance_criterion_id' => $ac?->id,
         'position' => 1,
     ]);


### PR DESCRIPTION
## What changed

This cleans up the planning model so the code matches the new greenfield structure:

```text
Feature
  -> Story
       -> AcceptanceCriterion
       -> Scenario
       -> Plan
            -> Task
                 -> Subtask
```

Cross-links remain explicit:

- `Story.current_plan_id`
- optional `Scenario.acceptance_criterion_id`
- optional `Task.acceptance_criterion_id`
- optional `Task.scenario_id`

## Model cleanup

- Removed task-owned Story state: `Task` no longer stores `story_id` and no longer exposes `Task::story()`.
- Updated app code to resolve Story through `Task -> Plan -> Story` everywhere: agents, services, MCP tools, routes, views, and tests.
- Simplified `Story::tasks()` to project tasks from the current plan instead of joining through `tasks.story_id`.
- Updated `TaskFactory` with `forStory()` so tests can still express setup intent without reintroducing task-level story ownership.
- Removed the `criterion` compatibility alias. Acceptance criteria now use `statement` only in migrations, model fillable fields, MCP input, Livewire edit handling, and tests.
- Fixed `PlanWriter::replacePlan()` so plan metadata attributes are captured inside the transaction.

## Why

The new model separates product contract from delivery plan:

- Product layer: `Feature -> Story -> AcceptanceCriterion/Scenario`
- Delivery layer: `Story -> Plan -> Task -> Subtask`

Keeping `tasks.story_id`, `Task::story()`, and `criterion` fallbacks let the retired model leak into the current implementation. Since this is greenfield and no compatibility path is needed, this PR removes those fallbacks instead of preserving shims.

## Validation

- `composer test`
- Pint passed
- Pest passed: 388 tests, 989 assertions
