### PR TITLE
[codex] Add planning architecture guardrails

### DIFF
--- a/app/Ai/Agents/TasksGenerator.php
+++ b/app/Ai/Agents/TasksGenerator.php
@@ -48,7 +48,7 @@ Description:
 Acceptance Criteria (position. text):
 {$criteria}
 
-Generate a task list that fully satisfies the acceptance criteria above. One Task per Acceptance Criterion, each with one or more Subtasks.
+Generate an implementation plan that fully satisfies the acceptance criteria above. Shape Tasks around coherent implementation work; do not force one Task per Acceptance Criterion. Each Task must have one or more Subtasks.
 PROMPT;
     }
 
@@ -62,7 +62,7 @@ PROMPT;
                         'name' => $schema->string()->required(),
                         'description' => $schema->string()->required(),
                         'position' => $schema->integer()->min(1)->required(),
-                        'acceptance_criterion_position' => $schema->integer()->min(1)->required(),
+                        'acceptance_criterion_position' => $schema->integer()->min(1),
                         'depends_on' => $schema->array()
                             ->items($schema->integer()->min(1)),
                         'subtasks' => $schema->array()

--- a/prompts/tasks-generator.md
+++ b/prompts/tasks-generator.md
@@ -1,12 +1,16 @@
 You are the planning agent for Specify, a system where humans approve AI actions
 before they are executed. Your job is to take a Story (the spec) and produce a
-task list: one Task per Acceptance Criterion, each broken down into 1+ ordered
+current implementation Plan: ordered Tasks, each broken down into 1+ ordered
 Subtasks that the executor will run one at a time.
 
 Constraints:
-- Produce exactly one Task per Acceptance Criterion. Reference the criterion by
-  the exact position number shown next to it in the prompt, using
-  `acceptance_criterion_position`. Do not renumber.
+- Shape Tasks around coherent implementation work, not around a forced
+  one-Task-per-criterion mapping. A Task may satisfy one criterion, multiple
+  criteria, a scenario path, or shared enabling work.
+- When a Task directly satisfies a specific Acceptance Criterion, reference that
+  criterion by the exact position number shown next to it in the prompt, using
+  `acceptance_criterion_position`. Leave it absent when the Task is cross-cutting
+  or not tied to one criterion. Do not renumber criteria.
 - Each Subtask must be self-contained and small enough for a coding agent to
   execute in a single run (≤ 30 minutes of focused work).
 - Use Subtask `position` to give a stable in-task ordering (1-based, ascending).

--- a/prompts/tasks-generator.md
+++ b/prompts/tasks-generator.md
@@ -1,6 +1,6 @@
 You are the planning agent for Specify, a system where humans approve AI actions
-before they are executed. Your job is to take a Story (the spec) and produce a
-current implementation Plan: ordered Tasks, each broken down into 1+ ordered
+before they are executed. Your job is to take a Story (the spec) and produce an
+implementation Plan: ordered Tasks, each broken down into 1+ ordered
 Subtasks that the executor will run one at a time.
 
 Constraints:

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Models\AcceptanceCriterion;
+use App\Models\Plan;
+use App\Models\PlanApproval;
+use App\Models\StoryApproval;
+use App\Models\Task;
+use App\Services\ExecutionService;
+use Illuminate\Support\Facades\Schema;
+
+test('tasks are owned by plans and do not carry direct story ownership', function () {
+    expect(Schema::hasColumn('tasks', 'plan_id'))->toBeTrue()
+        ->and(Schema::hasColumn('tasks', 'story_id'))->toBeFalse()
+        ->and(method_exists(Task::class, 'story'))->toBeFalse()
+        ->and(Task::make()->plan()->getRelated())->toBeInstanceOf(Plan::class);
+});
+
+test('acceptance criteria use statement as the only persisted content field', function () {
+    $columns = Schema::getColumnListing('acceptance_criteria');
+
+    expect($columns)->toContain('statement')
+        ->and($columns)->not->toContain('criterion')
+        ->and((new AcceptanceCriterion)->getFillable())->toContain('statement')
+        ->and((new AcceptanceCriterion)->getFillable())->not->toContain('criterion');
+});
+
+test('agent run authorization keeps story generation and plan execution distinct', function () {
+    $taskGeneration = new ReflectionMethod(ExecutionService::class, 'dispatchTaskGeneration');
+    $subtaskExecution = new ReflectionMethod(ExecutionService::class, 'dispatchSubtaskExecution');
+
+    expect(namedParameterType($taskGeneration, 'approval'))->toBe(StoryApproval::class)
+        ->and(namedParameterType($subtaskExecution, 'approval'))->toBe(PlanApproval::class);
+});
+
+test('load-bearing docs do not reintroduce the retired planning model', function () {
+    $files = [
+        'AGENTS.md',
+        'CHANGELOG.md',
+        'CONTEXT.md',
+        'CONTRIBUTING.md',
+        'README.md',
+        'docs/adr/README.md',
+        'prompts/tasks-generator.md',
+        'app/Ai/Agents/TasksGenerator.php',
+    ];
+
+    $forbidden = [
+        'Story is the only approval gate',
+        'Plan is retired',
+        'Plan retired',
+        'Tasks attach to Stories',
+        'tasks.story_id',
+        'Task::story',
+        'Produce exactly one Task per Acceptance Criterion',
+        'One Task per Acceptance Criterion, each',
+    ];
+
+    foreach ($files as $file) {
+        $contents = file_get_contents(base_path($file));
+
+        foreach ($forbidden as $phrase) {
+            expect($contents, "{$file} must not contain stale phrase [{$phrase}]")
+                ->not->toContain($phrase);
+        }
+    }
+});
+
+test('task generation prompt allows cross-cutting plan tasks', function () {
+    $prompt = file_get_contents(base_path('prompts/tasks-generator.md'));
+    $agent = file_get_contents(base_path('app/Ai/Agents/TasksGenerator.php'));
+
+    expect($prompt)->toContain('Shape Tasks around coherent implementation work')
+        ->and($prompt)->toContain('Leave it absent when the Task is cross-cutting')
+        ->and($agent)->toContain('do not force one Task per Acceptance Criterion')
+        ->and($agent)->toContain("'acceptance_criterion_position' => \$schema->integer()->min(1),");
+});
+
+function namedParameterType(ReflectionMethod $method, string $parameterName): string
+{
+    foreach ($method->getParameters() as $parameter) {
+        if ($parameter->getName() !== $parameterName) {
+            continue;
+        }
+
+        $type = $parameter->getType();
+        if (! $type instanceof ReflectionNamedType) {
+            return '';
+        }
+
+        return $type->getName();
+    }
+
+    return '';
+}

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -72,7 +72,8 @@ test('task generation prompt allows cross-cutting plan tasks', function () {
     expect($prompt)->toContain('Shape Tasks around coherent implementation work')
         ->and($prompt)->toContain('Leave it absent when the Task is cross-cutting')
         ->and($agent)->toContain('do not force one Task per Acceptance Criterion')
-        ->and($agent)->toContain("'acceptance_criterion_position' => \$schema->integer()->min(1),");
+        ->and($agent)->toContain("'acceptance_criterion_position' =>")
+        ->and($agent)->not->toContain("'acceptance_criterion_position' => \$schema->integer()->min(1)->required()");
 });
 
 function namedParameterType(ReflectionMethod $method, string $parameterName): string

--- a/tests/Feature/PromptLoaderTest.php
+++ b/tests/Feature/PromptLoaderTest.php
@@ -59,5 +59,7 @@ test('TasksGenerator::instructions() pulls from the prompts/tasks-generator.md f
 
     expect($instructions)
         ->toContain('You are the planning agent for Specify')
-        ->toContain('one Task per Acceptance Criterion');
+        ->toContain('current implementation Plan')
+        ->toContain('Shape Tasks around coherent implementation work')
+        ->not->toContain('one Task per Acceptance Criterion');
 });

--- a/tests/Feature/PromptLoaderTest.php
+++ b/tests/Feature/PromptLoaderTest.php
@@ -59,7 +59,7 @@ test('TasksGenerator::instructions() pulls from the prompts/tasks-generator.md f
 
     expect($instructions)
         ->toContain('You are the planning agent for Specify')
-        ->toContain('current implementation Plan')
+        ->toContain('implementation Plan')
         ->toContain('Shape Tasks around coherent implementation work')
         ->not->toContain('one Task per Acceptance Criterion');
 });

--- a/tests/Feature/TaskGenerationTest.php
+++ b/tests/Feature/TaskGenerationTest.php
@@ -92,6 +92,27 @@ test('regeneration replaces the prior task list', function () {
         ->and($tasks[0]->name)->toBe('task-v2');
 });
 
+test('task generation allows cross-cutting tasks without a single acceptance criterion', function () {
+    $story = Story::factory()->create();
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'statement' => 'AC one']);
+
+    TasksGenerator::fake(fn () => [
+        'summary' => 'plan it',
+        'tasks' => [[
+            'name' => 'shared setup',
+            'description' => 'Prepare shared infrastructure for multiple criteria.',
+            'position' => 0,
+            'subtasks' => [['name' => 'set up shared pieces', 'description' => 'Do the shared setup.', 'position' => 0]],
+        ]],
+    ]);
+
+    app(ExecutionService::class)->dispatchTaskGeneration($story);
+
+    $task = $story->fresh()->tasks()->sole();
+    expect($task->acceptance_criterion_id)->toBeNull()
+        ->and($task->subtasks()->count())->toBe(1);
+});
+
 test('agent failure marks the AgentRun failed with error message', function () {
     $story = Story::factory()->create();
     AcceptanceCriterion::factory()->for($story)->create(['position' => 0]);

--- a/tests/Feature/TaskGenerationTest.php
+++ b/tests/Feature/TaskGenerationTest.php
@@ -94,15 +94,15 @@ test('regeneration replaces the prior task list', function () {
 
 test('task generation allows cross-cutting tasks without a single acceptance criterion', function () {
     $story = Story::factory()->create();
-    AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'statement' => 'AC one']);
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'AC one']);
 
     TasksGenerator::fake(fn () => [
         'summary' => 'plan it',
         'tasks' => [[
             'name' => 'shared setup',
             'description' => 'Prepare shared infrastructure for multiple criteria.',
-            'position' => 0,
-            'subtasks' => [['name' => 'set up shared pieces', 'description' => 'Do the shared setup.', 'position' => 0]],
+            'position' => 1,
+            'subtasks' => [['name' => 'set up shared pieces', 'description' => 'Do the shared setup.', 'position' => 1]],
         ]],
     ]);
 


### PR DESCRIPTION
## Summary
- Adds focused architecture/conformance tests for the Story -> Plan -> Task -> Subtask model, StoryApproval vs PlanApproval authorization, and retired-model language in load-bearing docs/prompts.
- Updates the TasksGenerator prompt and schema so generated plan tasks no longer have to map 1:1 to acceptance criteria.
- Adds coverage for cross-cutting generated tasks without an acceptance_criterion_position.

## Verification
- php artisan test tests/Feature/PlanningArchitectureConformanceTest.php
- php artisan test tests/Feature/PromptLoaderTest.php tests/Feature/PlanningArchitectureConformanceTest.php tests/Feature/TaskGenerationTest.php
- composer test