### PR TITLE
[codex] Align MCP task tools with current Plan

### DIFF
--- a/app/Mcp/Servers/SpecifyServer.php
+++ b/app/Mcp/Servers/SpecifyServer.php
@@ -56,7 +56,7 @@ use Laravel\Mcp\Server\Attributes\Version;
 #[Name('Specify Server')]
 #[Version('0.1.0')]
 #[Instructions(<<<'TXT'
-Tools for managing Specify projects, features, stories, scenarios, and plans. The hierarchy is project → feature → story. A story owns product framing plus acceptance criteria and scenarios. A story may also have one or more implementation plans; the current plan owns tasks, and tasks own subtasks. A story must belong to a feature, so call create-feature before create-story when no matching feature exists. Most tools default to the authenticated user's current project when project_id is omitted.
+Tools for managing Specify projects, features, stories, scenarios, and plans. The hierarchy is Project → Feature → Story → AcceptanceCriterion / Scenario → Plan → Task → Subtask. A story owns product framing plus acceptance criteria and scenarios. A story may also have one or more implementation plans; the current plan owns tasks, and tasks own subtasks. A story must belong to a feature, so call create-feature before create-story when no matching feature exists. Most tools default to the authenticated user's current project when project_id is omitted.
 
 Voice and scope, very important:
 

--- a/app/Mcp/Tools/GenerateTasksTool.php
+++ b/app/Mcp/Tools/GenerateTasksTool.php
@@ -17,7 +17,7 @@ use Laravel\Mcp\Server\Tool;
  * Drives the planning agent for an Approved story. Generates a new current
  * plan containing tasks and subtasks.
  */
-#[Description('Generate a new implementation plan (tasks + subtasks) for an Approved story using the planning agent. The story must be Approved and have no current-plan tasks. Generated tasks create a new current plan that reopens plan approval so a human can review the breakdown before execution.')]
+#[Description('Generate a new current implementation plan (Tasks + Subtasks) for an Approved story using the planning agent. The story must be Approved and have no Tasks in its current Plan. Generated Tasks create a fresh current Plan and reopen Plan approval so a human can review the breakdown before execution.')]
 class GenerateTasksTool extends Tool
 {
     use ResolvesProjectAccess;
@@ -45,11 +45,11 @@ class GenerateTasksTool extends Tool
         }
 
         if ($story->status !== StoryStatus::Approved) {
-            return Response::error('Story must be Approved before generating tasks.');
+            return Response::error('Story must be Approved before generating a plan.');
         }
 
         if ($story->tasks()->exists()) {
-            return Response::error('Story already has current-plan tasks. Use set-tasks / update-task to edit them.');
+            return Response::error('Story already has Tasks in its current Plan. Use set-tasks / update-task to replace or edit the current Plan.');
         }
 
         $run = $execution->dispatchTaskGeneration($story);
@@ -67,7 +67,7 @@ class GenerateTasksTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'story_id' => $schema->integer()->description('Approved story to generate tasks for. Must have no current-plan tasks.')->required(),
+            'story_id' => $schema->integer()->description('Approved story to generate a current implementation Plan for. Must have no Tasks in its current Plan.')->required(),
         ];
     }
 }

--- a/app/Mcp/Tools/GetStoryTool.php
+++ b/app/Mcp/Tools/GetStoryTool.php
@@ -13,7 +13,7 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: get-story
  */
-#[Description('Get a story in detail, including its acceptance criteria and task progress counts.')]
+#[Description('Get a story in detail, including product framing, acceptance criteria, scenarios, current Plan metadata, and current-Plan Task progress counts.')]
 class GetStoryTool extends Tool
 {
     use ResolvesProjectAccess;

--- a/app/Mcp/Tools/GetTaskTool.php
+++ b/app/Mcp/Tools/GetTaskTool.php
@@ -13,7 +13,7 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: get-task
  */
-#[Description('Get a task in detail, including its subtasks (positions, statuses) and dependency positions.')]
+#[Description('Get a Plan-owned Task in detail, including story_id, plan_id, optional acceptance criterion/scenario links, Subtasks, and dependency positions.')]
 class GetTaskTool extends Tool
 {
     use ResolvesProjectAccess;

--- a/app/Mcp/Tools/ListTasksTool.php
+++ b/app/Mcp/Tools/ListTasksTool.php
@@ -14,7 +14,7 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: list-tasks
  */
-#[Description('List the tasks attached to a story, in position order. Each entry includes subtask counts and the linked acceptance criterion text.')]
+#[Description('List the Tasks in a story\'s current Plan, in position order. Each entry includes plan_id, optional acceptance criterion/scenario links, dependency positions, and Subtask counts.')]
 class ListTasksTool extends Tool
 {
     use ResolvesProjectAccess;
@@ -48,9 +48,11 @@ class ListTasksTool extends Tool
 
         return Response::json([
             'story_id' => $story->id,
+            'current_plan_id' => $story->current_plan_id,
             'count' => $tasks->count(),
             'tasks' => $tasks->map(fn (Task $task) => [
                 'id' => $task->id,
+                'plan_id' => $task->plan_id,
                 'position' => $task->position,
                 'name' => $task->name,
                 'description' => $task->description,
@@ -78,7 +80,7 @@ class ListTasksTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'story_id' => $schema->integer()->description('Story whose tasks to list.')->required(),
+            'story_id' => $schema->integer()->description('Story whose current-Plan Tasks should be listed.')->required(),
         ];
     }
 }

--- a/app/Mcp/Tools/SetTasksTool.php
+++ b/app/Mcp/Tools/SetTasksTool.php
@@ -14,7 +14,7 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: set-tasks
  */
-#[Description('Replace the entire task list for a story in one transaction. Each task gets 1+ ordered subtasks; tasks may declare task-level dependencies via positions; each task may link to one acceptance_criterion_id belonging to the story. Replacing tasks creates a fresh current plan and reopens plan approval. Markdown is supported in description fields.')]
+#[Description('Replace the story\'s current implementation Plan in one transaction by writing a fresh ordered Task/Subtask breakdown. Each Task belongs to the new Plan, may link to an optional acceptance_criterion_id and/or scenario_id from the same Story, and may declare task-level dependencies via positions. Replacing the Plan reopens Plan approval. Markdown is supported in description fields.')]
 class SetTasksTool extends Tool
 {
     use ResolvesProjectAccess;
@@ -73,9 +73,9 @@ class SetTasksTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'story_id' => $schema->integer()->description('Story whose task list to replace.')->required(),
+            'story_id' => $schema->integer()->description('Story whose current implementation Plan should be replaced.')->required(),
             'tasks' => $schema->array()
-                ->description('Ordered list. Each item: {position:int (>=1), name:string, description?:string (markdown), acceptance_criterion_id?:int, scenario_id?:int, depends_on_positions?:int[], subtasks: [{position:int (>=1), name:string, description?:string (markdown)}]}. Each task must have at least one subtask. Position values must be unique within their parent.')
+                ->description('Ordered Tasks for the fresh current Plan. Each item: {position:int (>=1), name:string, description?:string (markdown), acceptance_criterion_id?:int, scenario_id?:int, depends_on_positions?:int[], subtasks: [{position:int (>=1), name:string, description?:string (markdown)}]}. Criterion/scenario links are optional; use them only when a Task directly supports that product artifact. Each Task must have at least one Subtask. Position values must be unique within their parent.')
                 ->required(),
         ];
     }

--- a/app/Mcp/Tools/SetTasksTool.php
+++ b/app/Mcp/Tools/SetTasksTool.php
@@ -14,7 +14,7 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: set-tasks
  */
-#[Description('Replace the story\'s current implementation Plan in one transaction by writing a fresh ordered Task/Subtask breakdown. Each Task belongs to the new Plan, may link to an optional acceptance_criterion_id and/or scenario_id from the same Story, and may declare task-level dependencies via positions. Replacing the Plan reopens Plan approval. Markdown is supported in description fields.')]
+#[Description('Replace the story\'s current implementation Plan in one transaction by writing a fresh ordered Task/Subtask breakdown. Each Task belongs to the new Plan, may link to an optional acceptance_criterion_id and/or scenario_id from the same Story, and may declare task-level dependencies via positions. For Approved stories, the fresh Plan starts PendingApproval; for non-Approved stories, it stays Draft until the Story is approved/submitted. Markdown is supported in description fields.')]
 class SetTasksTool extends Tool
 {
     use ResolvesProjectAccess;
@@ -75,7 +75,7 @@ class SetTasksTool extends Tool
         return [
             'story_id' => $schema->integer()->description('Story whose current implementation Plan should be replaced.')->required(),
             'tasks' => $schema->array()
-                ->description('Ordered Tasks for the fresh current Plan. Each item: {position:int (>=1), name:string, description?:string (markdown), acceptance_criterion_id?:int, scenario_id?:int, depends_on_positions?:int[], subtasks: [{position:int (>=1), name:string, description?:string (markdown)}]}. Criterion/scenario links are optional; use them only when a Task directly supports that product artifact. Each Task must have at least one Subtask. Position values must be unique within their parent.')
+                ->description('Ordered Tasks for the fresh current Plan. Each item: {position:int (>=1), name:string, description?:string (markdown), acceptance_criterion_id?:int, scenario_id?:int, depends_on_positions?:int[], subtasks: [{position:int (>=1), name:string, description?:string (markdown)}]}. Criterion/scenario links are optional; use them only when a Task directly supports that product artifact. Each Task must have at least one Subtask. Position values must be unique within their parent. For Approved stories this replacement creates a PendingApproval Plan; otherwise it creates a Draft Plan.')
                 ->required(),
         ];
     }

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -1,12 +1,28 @@
 <?php
 
+use App\Mcp\Servers\SpecifyServer;
+use App\Mcp\Tools\GenerateTasksTool;
+use App\Mcp\Tools\GetStoryTool;
+use App\Mcp\Tools\GetTaskTool;
+use App\Mcp\Tools\ListTasksTool;
+use App\Mcp\Tools\SetTasksTool;
 use App\Models\AcceptanceCriterion;
+use App\Models\Feature;
 use App\Models\Plan;
 use App\Models\PlanApproval;
+use App\Models\Project;
+use App\Models\Story;
 use App\Models\StoryApproval;
+use App\Models\Subtask;
 use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
 use App\Services\ExecutionService;
 use Illuminate\Support\Facades\Schema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Instructions;
 
 test('tasks are owned by plans and do not carry direct story ownership', function () {
     expect(Schema::hasColumn('tasks', 'plan_id'))->toBeTrue()
@@ -76,6 +92,56 @@ test('task generation prompt allows cross-cutting plan tasks', function () {
         ->and($agent)->not->toContain("'acceptance_criterion_position' => \$schema->integer()->min(1)->required()");
 });
 
+test('mcp instructions and planning tool descriptions speak in current-plan terms', function () {
+    $instructions = serverAttribute(SpecifyServer::class, Instructions::class);
+
+    expect($instructions)->toContain('Project → Feature → Story → AcceptanceCriterion / Scenario → Plan → Task → Subtask')
+        ->and($instructions)->toContain('the current plan owns tasks')
+        ->and($instructions)->toContain('current-plan approval gates execution');
+
+    $descriptions = [
+        GenerateTasksTool::class => descriptionFor(GenerateTasksTool::class),
+        SetTasksTool::class => descriptionFor(SetTasksTool::class),
+        ListTasksTool::class => descriptionFor(ListTasksTool::class),
+        GetTaskTool::class => descriptionFor(GetTaskTool::class),
+        GetStoryTool::class => descriptionFor(GetStoryTool::class),
+    ];
+
+    expect($descriptions[GenerateTasksTool::class])->toContain('fresh current Plan')
+        ->and($descriptions[SetTasksTool::class])->toContain('Replace the story\'s current implementation Plan')
+        ->and($descriptions[ListTasksTool::class])->toContain('Tasks in a story\'s current Plan')
+        ->and($descriptions[GetTaskTool::class])->toContain('Plan-owned Task')
+        ->and($descriptions[GetStoryTool::class])->toContain('current Plan metadata');
+
+    foreach ($descriptions as $description) {
+        expect($description)->not->toContain('tasks attached to a story')
+            ->and($description)->not->toContain('task list for a story')
+            ->and($description)->not->toContain('one acceptance_criterion_id');
+    }
+});
+
+test('list-tasks exposes current plan ownership on every task row', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $task = Task::factory()->forStory($story)->create(['position' => 1]);
+    Subtask::factory()->for($task)->create(['position' => 1]);
+
+    $this->actingAs($user);
+
+    $response = (new ListTasksTool)->handle(new Request(['story_id' => $story->getKey()]));
+    $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload['story_id'])->toBe($story->getKey())
+        ->and($payload['current_plan_id'])->toBe($task->plan_id)
+        ->and($payload['tasks'][0]['id'])->toBe($task->getKey())
+        ->and($payload['tasks'][0]['plan_id'])->toBe($task->plan_id);
+});
+
 function namedParameterType(ReflectionMethod $method, string $parameterName): string
 {
     foreach ($method->getParameters() as $parameter) {
@@ -92,4 +158,25 @@ function namedParameterType(ReflectionMethod $method, string $parameterName): st
     }
 
     return '';
+}
+
+/**
+ * @param  class-string  $class
+ */
+function descriptionFor(string $class): string
+{
+    return serverAttribute($class, Description::class);
+}
+
+/**
+ * @template T of object
+ *
+ * @param  class-string  $class
+ * @param  class-string<T>  $attribute
+ */
+function serverAttribute(string $class, string $attribute): string
+{
+    $attributes = (new ReflectionClass($class))->getAttributes($attribute);
+
+    return $attributes === [] ? '' : $attributes[0]->newInstance()->value;
 }

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\PlanStatus;
 use App\Mcp\Servers\SpecifyServer;
 use App\Mcp\Tools\GenerateTasksTool;
 use App\Mcp\Tools\GetStoryTool;
@@ -109,6 +110,8 @@ test('mcp instructions and planning tool descriptions speak in current-plan term
 
     expect($descriptions[GenerateTasksTool::class])->toContain('fresh current Plan')
         ->and($descriptions[SetTasksTool::class])->toContain('Replace the story\'s current implementation Plan')
+        ->and($descriptions[SetTasksTool::class])->toContain('For Approved stories, the fresh Plan starts PendingApproval')
+        ->and($descriptions[SetTasksTool::class])->toContain('for non-Approved stories, it stays Draft')
         ->and($descriptions[ListTasksTool::class])->toContain('Tasks in a story\'s current Plan')
         ->and($descriptions[GetTaskTool::class])->toContain('Plan-owned Task')
         ->and($descriptions[GetStoryTool::class])->toContain('current Plan metadata');
@@ -128,8 +131,17 @@ test('list-tasks exposes current plan ownership on every task row', function () 
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->forStory($story)->create(['position' => 1]);
-    Subtask::factory()->for($task)->create(['position' => 1]);
+    $supersededTask = Task::factory()->forStory($story)->create(['position' => 1, 'name' => 'old plan task']);
+    Subtask::factory()->for($supersededTask)->create(['position' => 1]);
+    $supersededPlan = $supersededTask->plan;
+
+    $currentPlan = Plan::factory()->for($story)->create([
+        'version' => 2,
+        'status' => PlanStatus::Draft,
+    ]);
+    $story->forceFill(['current_plan_id' => $currentPlan->getKey()])->save();
+    $currentTask = Task::factory()->for($currentPlan)->create(['position' => 1, 'name' => 'current plan task']);
+    Subtask::factory()->for($currentTask)->create(['position' => 1]);
 
     $this->actingAs($user);
 
@@ -137,9 +149,12 @@ test('list-tasks exposes current plan ownership on every task row', function () 
     $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
 
     expect($payload['story_id'])->toBe($story->getKey())
-        ->and($payload['current_plan_id'])->toBe($task->plan_id)
-        ->and($payload['tasks'][0]['id'])->toBe($task->getKey())
-        ->and($payload['tasks'][0]['plan_id'])->toBe($task->plan_id);
+        ->and($payload['current_plan_id'])->toBe($currentPlan->getKey())
+        ->and($payload['tasks'])->toHaveCount(1)
+        ->and($payload['tasks'][0]['id'])->toBe($currentTask->getKey())
+        ->and($payload['tasks'][0]['plan_id'])->toBe($currentPlan->getKey())
+        ->and(collect($payload['tasks'])->pluck('id')->all())->not->toContain($supersededTask->getKey())
+        ->and($supersededPlan->getKey())->not->toBe($currentPlan->getKey());
 });
 
 function namedParameterType(ReflectionMethod $method, string $parameterName): string


### PR DESCRIPTION
## Summary
- Updates MCP server instructions and task/planning tool descriptions to use the current Story -> Plan -> Task -> Subtask model.
- Clarifies generate-tasks and set-tasks as current-Plan operations while keeping existing tool names stable.
- Adds current_plan_id and per-task plan_id to list-tasks output so MCP clients can see Plan ownership directly.
- Extends architecture conformance tests to guard MCP instructions/descriptions and list-tasks payload shape.

## Verification
- php artisan test tests/Feature/PlanningArchitectureConformanceTest.php
- composer test