### PR TITLE
[codex] Clarify current plan task UI

### DIFF
--- a/resources/views/components/story/summary-card.blade.php
+++ b/resources/views/components/story/summary-card.blade.php
@@ -26,7 +26,7 @@
                     <flux:badge>{{ __('by') }} {{ $story->creator->name }}</flux:badge>
                 @endif
                 @if ($tasksTotal > 0)
-                    <flux:badge>{{ $tasksDone }}/{{ $tasksTotal }} {{ __('tasks') }}</flux:badge>
+                    <flux:badge>{{ $tasksDone }}/{{ $tasksTotal }} {{ __('current-plan tasks') }}</flux:badge>
                 @endif
                 @if ($story->updated_at)
                     <flux:text class="ml-auto text-xs text-zinc-500">{{ $story->updated_at->diffForHumans() }}</flux:text>

--- a/resources/views/partials/story-show/plan.blade.php
+++ b/resources/views/partials/story-show/plan.blade.php
@@ -1,9 +1,9 @@
 <section class="flex flex-col gap-3" data-section="plan">
     <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <flux:heading size="lg">{{ __('Plan') }}</flux:heading>
+            <flux:heading size="lg">{{ __('Current plan') }}</flux:heading>
             <flux:text class="text-xs text-zinc-500">
-                {{ $acs->count() }} {{ __('ACs') }} · {{ $subtaskCount }} {{ __('subtasks') }}
+                {{ $acs->count() }} {{ __('ACs') }} · {{ $story->tasks->count() }} {{ __('current-plan tasks') }} · {{ $subtaskCount }} {{ __('subtasks') }}
                 @if ($story->currentPlan)
                     · {{ __('current') }} {{ $story->currentPlan->name ?? ('v'.$story->currentPlan->version) }}
                 @endif
@@ -69,7 +69,7 @@
                 </summary>
 
                 @if ($acTasks->isEmpty())
-                    <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No task generated for this AC yet.') }}</flux:text>
+                    <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No current-plan task is mapped to this AC yet.') }}</flux:text>
                 @else
                     @foreach ($acTasks as $task)
                         @include('partials.story-task', ['task' => $task])
@@ -89,7 +89,7 @@
         <flux:card data-ac="unmapped">
             <details :open="planRunMode">
                 <summary class="cursor-pointer text-sm font-medium">
-                    {{ __('Unmapped tasks') }} ({{ $unmappedTasks->count() }})
+                    {{ __('Current-plan tasks not mapped to an AC') }} ({{ $unmappedTasks->count() }})
                 </summary>
                 @foreach ($unmappedTasks as $task)
                     @include('partials.story-task', ['task' => $task])
@@ -99,7 +99,7 @@
     @endif
 
     @if ($acs->isEmpty() && $story->tasks->isEmpty() && ! $this->pendingPlanRun && $story->status !== \App\Enums\StoryStatus::Approved)
-        <flux:text class="text-zinc-500">{{ __('Plan is generated once the story contract is approved.') }}</flux:text>
+        <flux:text class="text-zinc-500">{{ __('Current plan is generated once the story contract is approved.') }}</flux:text>
     @endif
 
     @if ($story->currentPlan && $story->currentPlan->status !== \App\Enums\PlanStatus::Approved && $story->tasks->isNotEmpty())

--- a/tests/Feature/StoriesIndexTest.php
+++ b/tests/Feature/StoriesIndexTest.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Enums\StoryStatus;
+use App\Enums\TaskStatus;
 use App\Models\Feature;
 use App\Models\Project;
 use App\Models\Story;
+use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Workspace;
@@ -52,6 +54,20 @@ test('status filter narrows the list', function () {
         ->set('status', 'approved')
         ->assertSee('approved-story')
         ->assertDontSee('draft-story');
+});
+
+test('story summary labels task progress as current-plan tasks', function () {
+    ['user' => $user, 'project' => $project, 'feature' => $feature] = storyIndexScene();
+    $story = Story::factory()->for($feature)->create(['name' => 'planned-story', 'status' => StoryStatus::Approved]);
+    Task::factory()->forStory($story)->create(['status' => TaskStatus::Done]);
+    Task::factory()->forStory($story)->create(['status' => TaskStatus::Pending]);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::stories.index', ['project' => $project->id])
+        ->assertSee('planned-story')
+        ->assertSee('1/2 current-plan tasks')
+        ->assertDontSee('1/2 tasks');
 });
 
 test('redirects guests', function () {

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -237,7 +237,26 @@ test('plan section is AC-led: AC text leads, Task name follows', function () {
         ->and($acIdx)->toBeLessThan($taskIdx);
 });
 
-test('task missing acceptance_criterion_id renders under Unmapped tasks', function () {
+test('plan section labels current-plan task counts and empty AC mappings', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1);
+
+    AcceptanceCriterion::create([
+        'story_id' => $s['story']->id,
+        'position' => 1,
+        'statement' => 'empty-ac',
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->assertSee('Current plan')
+        ->assertSee('0 current-plan tasks')
+        ->assertSee('No current-plan task is mapped to this AC yet.')
+        ->assertDontSee('No task generated for this AC yet.');
+});
+
+test('task missing acceptance_criterion_id renders under current-plan unmapped tasks', function () {
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);
 
@@ -251,6 +270,7 @@ test('task missing acceptance_criterion_id renders under Unmapped tasks', functi
 
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertSeeHtml('data-ac="unmapped"')
+        ->assertSee('Current-plan tasks not mapped to an AC')
         ->assertSee('orphan-task');
 });
 


### PR DESCRIPTION
## Summary
- Rename the Story plan section to “Current plan” and show current-plan task counts alongside AC and subtask counts.
- Replace old generated/unmapped task wording with current-plan mapping language.
- Update Story summary cards to label task progress as current-plan tasks.
- Add focused Story show/index assertions guarding the new UI language.

## Verification
- php artisan test tests/Feature/StoryShowPageTest.php tests/Feature/StoriesIndexTest.php
- vendor/bin/pint --dirty --test --format agent
- composer test