### PR TITLE
[codex] Fix retry approval language

### DIFF
--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -17,9 +17,9 @@ use RuntimeException;
  * Append-only record of one AI dispatch — task generation or subtask execution.
  *
  * `runnable` is polymorphic over Story (for task generation) and Subtask
- * (for execution). `authorizing_approval` ties the run back to the
- * StoryApproval that authorised it. Stores the agent's input, output, diff,
- * token usage, and timing for audit and replay.
+ * (for execution). `authorizing_approval` ties task generation to a
+ * StoryApproval and subtask execution to a PlanApproval. Stores the agent's
+ * input, output, diff, token usage, and timing for audit and replay.
  *
  * `kind` distinguishes the historical `Execute` run (produces the Subtask
  * diff and opens a PR) from `RespondToReview` (ADR-0008 — pushes a

--- a/resources/views/pages/runs/⚡show.blade.php
+++ b/resources/views/pages/runs/⚡show.blade.php
@@ -228,7 +228,7 @@ new #[Title('Run')] class extends Component {
                             variant="primary"
                             icon="arrow-path"
                             wire:click="retry"
-                            wire:confirm="{{ __('Dispatch a fresh AgentRun for this subtask? The new run is authorised against the current StoryApproval.') }}"
+                            wire:confirm="{{ __('Dispatch a fresh AgentRun for this subtask? The new run is authorised against the current PlanApproval.') }}"
                             class="ml-auto"
                             data-action="retry-run"
                         >{{ __('Retry') }}</flux:button>

--- a/tests/Feature/AgentRunRetryTest.php
+++ b/tests/Feature/AgentRunRetryTest.php
@@ -90,7 +90,9 @@ test('Run console exposes a Retry button on terminal failure runs', function () 
     $this->actingAs($member)
         ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
         ->assertOk()
-        ->assertSee('Retry');
+        ->assertSee('Retry')
+        ->assertSee('authorised against the current PlanApproval')
+        ->assertDontSee('authorised against the current StoryApproval');
 });
 
 test('Run console hides Retry on Succeeded runs', function () {


### PR DESCRIPTION
## Summary
- Update the run-console retry confirmation to say retries authorise against the current PlanApproval.
- Update AgentRun model docs to describe polymorphic StoryApproval/PlanApproval authorisation.
- Add a retry-console assertion guarding against the old current StoryApproval wording.

## Verification
- php artisan test tests/Feature/AgentRunRetryTest.php
- vendor/bin/pint --dirty --test --format agent
- composer test