### PR TITLE
[codex] Rename task factory current-plan helper

### DIFF
--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -25,7 +25,7 @@ class TaskFactory extends Factory
         });
     }
 
-    public function forStory(Story $story): static
+    public function forCurrentPlanOf(Story $story): static
     {
         return $this->state(function () use ($story) {
             $planId = $story->fresh()?->current_plan_id;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,9 @@
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
         </testsuite>
+        <testsuite name="Architecture">
+            <directory>tests/Architecture</directory>
+        </testsuite>
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>

--- a/tests/Architecture/TaskFactoryArchitectureTest.php
+++ b/tests/Architecture/TaskFactoryArchitectureTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Database\Factories\TaskFactory;
+
+arch('task factory helper names current plan ownership')
+    ->expect(TaskFactory::class)
+    ->toHaveMethod('forCurrentPlanOf')
+    ->not->toHaveMethod('for'.'Story');

--- a/tests/Feature/ApprovalsIndexTest.php
+++ b/tests/Feature/ApprovalsIndexTest.php
@@ -39,7 +39,7 @@ test('approvals board shows separate story and plan queues', function () {
         'status' => StoryStatus::Approved,
         'name' => 'Plan queue item',
     ]);
-    $task = Task::factory()->forStory($planStory)->create(['position' => 1]);
+    $task = Task::factory()->forCurrentPlanOf($planStory)->create(['position' => 1]);
     $task->plan->forceFill(['status' => PlanStatus::PendingApproval->value, 'name' => 'Execution plan'])->save();
 
     $this->actingAs($user);

--- a/tests/Feature/CliExecutorTest.php
+++ b/tests/Feature/CliExecutorTest.php
@@ -197,7 +197,7 @@ test('full pipeline with cli driver: clone → branch → cli edits → commit �
     ]);
 
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->forStory($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'append', 'position' => 0]);
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();
     $story->fresh()->submitForApproval();

--- a/tests/Feature/ConflictResolutionTest.php
+++ b/tests/Feature/ConflictResolutionTest.php
@@ -57,7 +57,7 @@ function conflictResolutionScene(bool $mergeable = false): array
     $project->attachRepo($repo);
 
     $ac = AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->forStory($story)->create(['acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/CurrentPlanProjectionTest.php
+++ b/tests/Feature/CurrentPlanProjectionTest.php
@@ -14,7 +14,7 @@ test('acceptance criterion met only reflects done tasks in the current plan', fu
     $story = Story::factory()->create();
     $ac = AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
 
-    $oldTask = Task::factory()->forStory($story)->create([
+    $oldTask = Task::factory()->forCurrentPlanOf($story)->create([
         'acceptance_criterion_id' => $ac->id,
         'status' => TaskStatus::Done,
         'position' => 1,

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -41,16 +41,16 @@ test('dashboard counts pending stories, pending plans, executing stories, and fa
 
     Story::factory()->count(2)->for($feature)->create(['status' => StoryStatus::PendingApproval]);
     $approved = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $task = Task::factory()->forStory($approved)->create();
+    $task = Task::factory()->forCurrentPlanOf($approved)->create();
     $task->plan->forceFill(['status' => PlanStatus::Approved->value])->save();
 
     $planPendingStory = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $planPendingTask = Task::factory()->forStory($planPendingStory)->create();
+    $planPendingTask = Task::factory()->forCurrentPlanOf($planPendingStory)->create();
     $planPendingTask->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
     Subtask::factory()->for($task)->create(['status' => TaskStatus::InProgress]);
 
     $approved2 = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $taskWithFailedRun = Task::factory()->forStory($approved2)->create();
+    $taskWithFailedRun = Task::factory()->forCurrentPlanOf($approved2)->create();
     $taskWithFailedRun->plan->forceFill(['status' => PlanStatus::Approved->value])->save();
     $subtaskWithFailedRun = Subtask::factory()->for($taskWithFailedRun)->create();
     AgentRun::factory()->create([
@@ -118,7 +118,7 @@ test('awaiting your approval lists pending stories and pending current plans the
         'name' => 'Approve my plan',
         'status' => StoryStatus::Approved,
     ]);
-    $planTask = Task::factory()->forStory($planStory)->create();
+    $planTask = Task::factory()->forCurrentPlanOf($planStory)->create();
     $planTask->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
 
     $this->actingAs($user);
@@ -162,7 +162,7 @@ test('recent runs are clickable and link to the run console', function () {
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/DependenciesTest.php
+++ b/tests/Feature/DependenciesTest.php
@@ -14,8 +14,8 @@ uses(RefreshDatabase::class);
 
 test('task can depend on another task in the same current plan', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->forStory($story)->create(['name' => 'a']);
-    $b = Task::factory()->forStory($story)->create(['name' => 'b']);
+    $a = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'a']);
+    $b = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'b']);
 
     $b->addDependency($a);
 
@@ -40,9 +40,9 @@ test('task self-dependency is rejected', function () {
 
 test('task dependency cycle is prevented', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->forStory($story)->create();
-    $b = Task::factory()->forStory($story)->create();
-    $c = Task::factory()->forStory($story)->create();
+    $a = Task::factory()->forCurrentPlanOf($story)->create();
+    $b = Task::factory()->forCurrentPlanOf($story)->create();
+    $c = Task::factory()->forCurrentPlanOf($story)->create();
 
     $b->addDependency($a);
     $c->addDependency($b);
@@ -53,8 +53,8 @@ test('task dependency cycle is prevented', function () {
 
 test('task isReady reflects dependency status', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->forStory($story)->create(['status' => TaskStatus::Pending]);
-    $b = Task::factory()->forStory($story)->create(['status' => TaskStatus::Pending]);
+    $a = Task::factory()->forCurrentPlanOf($story)->create(['status' => TaskStatus::Pending]);
+    $b = Task::factory()->forCurrentPlanOf($story)->create(['status' => TaskStatus::Pending]);
     $b->addDependency($a);
 
     expect($b->isReady())->toBeFalse();

--- a/tests/Feature/IaRedirectsTest.php
+++ b/tests/Feature/IaRedirectsTest.php
@@ -129,7 +129,7 @@ test('/runs/{id} 301-redirects to nested run console for subtask runs', function
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/MultiExecutorRaceTest.php
+++ b/tests/Feature/MultiExecutorRaceTest.php
@@ -38,7 +38,7 @@ function approvedSubtaskForRace(): Subtask
     ]);
 
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->forStory($story)->create(['acceptance_criterion_id' => $ac->id, 'position' => 0]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['acceptance_criterion_id' => $ac->id, 'position' => 0]);
     Subtask::factory()->for($task)->create(['position' => 0, 'name' => 'race-me']);
 
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();

--- a/tests/Feature/PlanApprovalTest.php
+++ b/tests/Feature/PlanApprovalTest.php
@@ -27,7 +27,7 @@ function makePlan(): Plan
 
     $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
     $criterion = AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
-    $task = Task::factory()->forStory($story)->create([
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
         'position' => 1,
         'acceptance_criterion_id' => $criterion->id,
     ]);

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -131,7 +131,7 @@ test('list-tasks exposes current plan ownership on every task row', function () 
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $supersededTask = Task::factory()->forStory($story)->create(['position' => 1, 'name' => 'old plan task']);
+    $supersededTask = Task::factory()->forCurrentPlanOf($story)->create(['position' => 1, 'name' => 'old plan task']);
     Subtask::factory()->for($supersededTask)->create(['position' => 1]);
     $supersededPlan = $supersededTask->plan;
 

--- a/tests/Feature/PlansIndexTest.php
+++ b/tests/Feature/PlansIndexTest.php
@@ -24,7 +24,7 @@ test('plans index lists current plans for the selected project', function () {
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
-    $task = Task::factory()->forStory($story)->create(['position' => 1]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['position' => 1]);
     $task->plan->forceFill(['name' => 'Current plan', 'status' => PlanStatus::PendingApproval->value])->save();
 
     $this->actingAs($user);

--- a/tests/Feature/PrPayloadBuilderTest.php
+++ b/tests/Feature/PrPayloadBuilderTest.php
@@ -16,7 +16,7 @@ function makeSubtaskWithCriterion(int $acPosition = 3, ?string $criterion = 'Use
         'position' => $acPosition,
         'statement' => $criterion,
     ]);
-    $task = Task::factory()->forStory($story)->create([
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
         'name' => 'Wire export endpoint',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
@@ -44,7 +44,7 @@ test('title renders AC#0 instead of dropping the AC tag (regression: truthiness 
 
 test('title falls back to Story tag when AC position is null', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create([
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
         'name' => 'task',
         'position' => 1,
         'acceptance_criterion_id' => null,

--- a/tests/Feature/ProgressEventsTest.php
+++ b/tests/Feature/ProgressEventsTest.php
@@ -159,7 +159,7 @@ test('SubtaskRunPipeline tags events with the current phase and writes them unde
         'required_approvals' => 0,
     ]);
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->forStory($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'append', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'append', 'position' => 0]);
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();
     $story->fresh()->submitForApproval();
@@ -185,7 +185,7 @@ test('GET /runs/{run}/events returns events scoped + after a cursor', function (
     $user = User::factory()->create();
     $project->team->addMember($user);
 
-    $task = Task::factory()->forStory($story)->create(['position' => 0]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['position' => 0]);
     $subtask = Subtask::factory()->for($task)->create(['position' => 0]);
 
     $run = AgentRun::create([
@@ -226,7 +226,7 @@ test('GET /runs/{run}/events 404s when the user has no project access', function
     Workspace::factory()->for($outsider, 'owner')->create();
 
     $story = makeStory();
-    $task = Task::factory()->forStory($story)->create(['position' => 0]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['position' => 0]);
     $subtask = Subtask::factory()->for($task)->create(['position' => 0]);
     $run = AgentRun::create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/PullRequestTest.php
+++ b/tests/Feature/PullRequestTest.php
@@ -196,7 +196,7 @@ test('full pipeline records pull_request_error after a non-fatal PR failure on a
     ]);
 
     $ac = $story->acceptanceCriteria()->first() ?? AcceptanceCriterion::factory()->for($story)->create();
-    $task = Task::factory()->forStory($story)->create(['name' => 'add file', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'add file', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'add file', 'position' => 0]);
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();
     $story->fresh()->submitForApproval();

--- a/tests/Feature/RunHistoryTest.php
+++ b/tests/Feature/RunHistoryTest.php
@@ -26,7 +26,7 @@ function runScene(): array
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
 
     return compact('user', 'project', 'feature', 'story', 'task');
 }
@@ -60,7 +60,7 @@ test('does not show runs from outside the user\'s teams', function () {
     $otherProject = Project::factory()->for($otherTeam)->create();
     $otherFeature = Feature::factory()->for($otherProject)->create();
     $otherStory = Story::factory()->for($otherFeature)->create();
-    $otherTask = Task::factory()->forStory($otherStory)->create();
+    $otherTask = Task::factory()->forCurrentPlanOf($otherStory)->create();
     $hiddenSub = Subtask::factory()->for($otherTask)->create(['name' => 'hidden-sub']);
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -31,7 +31,7 @@ function makeApprovedTask(): Task
     $story = Story::factory()->create(['status' => StoryStatus::Approved, 'revision' => 1]);
     $ac = AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
 
-    return Task::factory()->forStory($story)->create([
+    return Task::factory()->forCurrentPlanOf($story)->create([
         'name' => 'wire CSV export',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,

--- a/tests/Feature/StoriesIndexTest.php
+++ b/tests/Feature/StoriesIndexTest.php
@@ -59,8 +59,8 @@ test('status filter narrows the list', function () {
 test('story summary labels task progress as current-plan tasks', function () {
     ['user' => $user, 'project' => $project, 'feature' => $feature] = storyIndexScene();
     $story = Story::factory()->for($feature)->create(['name' => 'planned-story', 'status' => StoryStatus::Approved]);
-    Task::factory()->forStory($story)->create(['status' => TaskStatus::Done]);
-    Task::factory()->forStory($story)->create(['status' => TaskStatus::Pending]);
+    Task::factory()->forCurrentPlanOf($story)->create(['status' => TaskStatus::Done]);
+    Task::factory()->forCurrentPlanOf($story)->create(['status' => TaskStatus::Pending]);
 
     $this->actingAs($user);
 

--- a/tests/Feature/StoryAutoExecutionTest.php
+++ b/tests/Feature/StoryAutoExecutionTest.php
@@ -34,7 +34,7 @@ function approvedStoryScene(): array
     $project->attachRepo($repo);
 
     $ac = $story->acceptanceCriteria()->first();
-    $task = Task::factory()->forStory($story)->create(['position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['position' => 0, 'acceptance_criterion_id' => $ac->id]);
     Subtask::factory()->for($task)->create(['position' => 0]);
 
     return ['story' => $story->fresh(), 'project' => $project, 'task' => $task, 'plan' => Plan::query()->findOrFail($task->plan_id)];

--- a/tests/Feature/StoryPullRequestsTest.php
+++ b/tests/Feature/StoryPullRequestsTest.php
@@ -13,7 +13,7 @@ uses(RefreshDatabase::class);
 function storyWithSubtaskAndRun(array $output, array $runOverrides = []): array
 {
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     $run = AgentRun::factory()->create(array_merge([
         'runnable_type' => Subtask::class,
@@ -51,7 +51,7 @@ test('pullRequests surfaces a single-driver PR as primary', function () {
 
 test('pullRequests deduplicates retries that adopted the same upstream PR', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     // Two AgentRuns on the same Subtask both adopting the same PR — e.g.
@@ -77,7 +77,7 @@ test('pullRequests deduplicates retries that adopted the same upstream PR', func
 
 test('pullRequests in race mode surfaces every sibling and primary is null until merge', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     foreach (['cli' => 21, 'specify' => 22, 'codex' => 23] as $driver => $number) {
@@ -107,7 +107,7 @@ test('pullRequests in race mode surfaces every sibling and primary is null until
 
 test('primaryPullRequest hoists the merged sibling and pullRequests sorts it first', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     AgentRun::factory()->create([
@@ -148,7 +148,7 @@ test('pullRequests preserves run-id-desc order within the unmerged partition whe
     // non-merged candidates can drift across PHP/Laravel versions —
     // reviewers reading the candidate list would see entries shuffle.
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     foreach ([
@@ -182,7 +182,7 @@ test('pullRequests entries expose run_finished_at, not opened_at', function () {
     // Renamed in review feedback: opened_at implied an authoritative PR
     // open timestamp; we only have the AgentRun's terminal time.
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -200,7 +200,7 @@ test('pullRequests entries expose run_finished_at, not opened_at', function () {
 
 test('pullRequests excludes RespondToReview-kind runs (those just push commits, not PRs)', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
     AgentRun::factory()->create([

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -192,7 +192,7 @@ test('approval tracks render separately for story contract and current plan', fu
         'position' => 1,
         'statement' => 'AC-text-must-lead',
     ]);
-    $task = Task::factory()->forStory($s['story'])->create([
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create([
         'name' => 'task-name-secondary',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
@@ -220,7 +220,7 @@ test('plan section is AC-led: AC text leads, Task name follows', function () {
         'position' => 1,
         'statement' => 'AC-text-must-lead',
     ]);
-    Task::factory()->forStory($s['story'])->create([
+    Task::factory()->forCurrentPlanOf($s['story'])->create([
         'name' => 'task-name-secondary',
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
@@ -260,7 +260,7 @@ test('task missing acceptance_criterion_id renders under current-plan unmapped t
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);
 
-    Task::factory()->forStory($s['story'])->create([
+    Task::factory()->forCurrentPlanOf($s['story'])->create([
         'name' => 'orphan-task',
         'position' => 1,
         'acceptance_criterion_id' => null,
@@ -281,7 +281,7 @@ test('appended subtask renders provenance glyph and tooltip referencing originat
     $ac = AcceptanceCriterion::create([
         'story_id' => $s['story']->id, 'position' => 1, 'statement' => 'ac',
     ]);
-    $task = Task::factory()->forStory($s['story'])->create([
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create([
         'position' => 1,
         'acceptance_criterion_id' => $ac->id,
     ]);

--- a/tests/Feature/StoryShowTest.php
+++ b/tests/Feature/StoryShowTest.php
@@ -31,7 +31,7 @@ test('story show renders AC, tasks with subtasks, and runs', function () {
     $ac = AcceptanceCriterion::create([
         'story_id' => $story->id, 'position' => 0, 'statement' => 'must-render-AC',
     ]);
-    $task = Task::factory()->forStory($story)->create(['name' => 'task-name', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'task-name', 'position' => 0, 'acceptance_criterion_id' => $ac->id]);
     $sub = Subtask::factory()->for($task)->create(['name' => 'sub-name', 'position' => 0]);
     AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/SubtaskAndRunShowTest.php
+++ b/tests/Feature/SubtaskAndRunShowTest.php
@@ -25,7 +25,7 @@ function subtaskScene(): array
     $project = Project::factory()->for($team)->create();
     $feature = Feature::factory()->for($project)->create();
     $story = Story::factory()->for($feature)->create();
-    $task = Task::factory()->forStory($story)->create(['name' => 'parent-task', 'position' => 1]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'parent-task', 'position' => 1]);
     $subtask = Subtask::factory()->for($task)->create(['name' => 'parent-subtask', 'position' => 1]);
 
     return compact('user', 'project', 'feature', 'story', 'task', 'subtask');

--- a/tests/Feature/SubtaskExecutionTest.php
+++ b/tests/Feature/SubtaskExecutionTest.php
@@ -118,8 +118,8 @@ test('full story execution: subtasks succeed and story flips to Done', function 
     $ac1 = $story->acceptanceCriteria()->first();
     $ac2 = AcceptanceCriterion::factory()->for($story)->create(['position' => 2]);
 
-    $taskA = Task::factory()->forStory($story)->create(['name' => 'a', 'position' => 0, 'acceptance_criterion_id' => $ac1->id]);
-    $taskB = Task::factory()->forStory($story)->create(['name' => 'b', 'position' => 1, 'acceptance_criterion_id' => $ac2->id]);
+    $taskA = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'a', 'position' => 0, 'acceptance_criterion_id' => $ac1->id]);
+    $taskB = Task::factory()->forCurrentPlanOf($story)->create(['name' => 'b', 'position' => 1, 'acceptance_criterion_id' => $ac2->id]);
     Subtask::factory()->for($taskA)->create(['position' => 0]);
     Subtask::factory()->for($taskB)->create(['position' => 0]);
     $taskB->addDependency($taskA);

--- a/tests/Feature/SubtaskOrderingTest.php
+++ b/tests/Feature/SubtaskOrderingTest.php
@@ -11,7 +11,7 @@ uses(RefreshDatabase::class);
 
 test('a subtask is only actionable when all lower-position siblings in the same task are Done', function () {
     $story = Story::factory()->create();
-    $task = Task::factory()->forStory($story)->create(['position' => 0]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['position' => 0]);
     $a = Subtask::factory()->for($task)->create(['position' => 0, 'status' => TaskStatus::Pending]);
     $b = Subtask::factory()->for($task)->create(['position' => 1, 'status' => TaskStatus::Pending]);
     $c = Subtask::factory()->for($task)->create(['position' => 2, 'status' => TaskStatus::Pending]);
@@ -32,10 +32,10 @@ test('a subtask is only actionable when all lower-position siblings in the same 
 
 test('subtasks of a task with unfinished dependencies are not actionable', function () {
     $story = Story::factory()->create();
-    $blocker = Task::factory()->forStory($story)->create(['position' => 0, 'status' => TaskStatus::Pending]);
+    $blocker = Task::factory()->forCurrentPlanOf($story)->create(['position' => 0, 'status' => TaskStatus::Pending]);
     Subtask::factory()->for($blocker)->create(['position' => 0]);
 
-    $dependent = Task::factory()->forStory($story)->create(['position' => 1, 'status' => TaskStatus::Pending]);
+    $dependent = Task::factory()->forCurrentPlanOf($story)->create(['position' => 1, 'status' => TaskStatus::Pending]);
     Subtask::factory()->for($dependent)->create(['position' => 0]);
     $dependent->addDependency($blocker);
 

--- a/tests/Feature/TaskDependencyConstraintTest.php
+++ b/tests/Feature/TaskDependencyConstraintTest.php
@@ -10,8 +10,8 @@ test('task dependencies must live in the same plan', function () {
     $storyA = Story::factory()->create();
     $storyB = Story::factory()->create();
 
-    $a = Task::factory()->forStory($storyA)->create();
-    $b = Task::factory()->forStory($storyB)->create();
+    $a = Task::factory()->forCurrentPlanOf($storyA)->create();
+    $b = Task::factory()->forCurrentPlanOf($storyB)->create();
 
     expect(fn () => $b->addDependency($a))
         ->toThrow(InvalidArgumentException::class, 'same plan');
@@ -19,8 +19,8 @@ test('task dependencies must live in the same plan', function () {
 
 test('task dependencies within the same story are allowed', function () {
     $story = Story::factory()->create();
-    $a = Task::factory()->forStory($story)->create();
-    $b = Task::factory()->forStory($story)->create();
+    $a = Task::factory()->forCurrentPlanOf($story)->create();
+    $b = Task::factory()->forCurrentPlanOf($story)->create();
 
     $b->addDependency($a);
 

--- a/tests/Feature/TaskShowTest.php
+++ b/tests/Feature/TaskShowTest.php
@@ -27,7 +27,7 @@ function taskShowScene(): array
         'position' => 1,
         'statement' => 'Users can edit a story.',
     ]);
-    $task = Task::factory()->forStory($story)->create([
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
         'name' => 'Add edit form',
         'position' => 1,
         'status' => TaskStatus::InProgress,
@@ -63,7 +63,7 @@ test('task show 404s when task is outside the user accessible projects', functio
     $otherProject = Project::factory()->for($otherTeam)->create();
     $otherFeature = Feature::factory()->for($otherProject)->create();
     $otherStory = Story::factory()->for($otherFeature)->create();
-    $otherTask = Task::factory()->forStory($otherStory)->create();
+    $otherTask = Task::factory()->forCurrentPlanOf($otherStory)->create();
 
     $this->actingAs($user);
 

--- a/tests/Feature/TriageTest.php
+++ b/tests/Feature/TriageTest.php
@@ -56,7 +56,7 @@ function pendingPlanFor(Feature $feature, string $name = 'Visible plan story')
         'status' => StoryStatus::Approved,
         'name' => $name,
     ]);
-    $task = Task::factory()->forStory($story)->create(['position' => 1]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create(['position' => 1]);
     $task->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
 
     return $task->plan->fresh();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -106,7 +106,7 @@ function approvedStoryInProjectWithRepo(): Story
     ]);
 
     $ac = $story->acceptanceCriteria()->first();
-    $task = Task::factory()->forStory($story)->create([
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
         'acceptance_criterion_id' => $ac?->id,
         'position' => 1,
     ]);


### PR DESCRIPTION
## Summary
- Rename `TaskFactory::forStory()` to `forCurrentPlanOf()` so test fixtures describe Plan-owned Tasks accurately.
- Update test fixtures to use the current-plan helper name.
- Add a planning architecture conformance guard that blocks the retired helper API and call sites from returning.

## Verification
- php artisan test tests/Feature/PlanningArchitectureConformanceTest.php
- vendor/bin/pint --dirty --test --format agent
- composer test