### PR TITLE
[codex] Clarify plan task language

### DIFF
--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -30,7 +30,7 @@ use RuntimeException;
  *
  * Each public dispatch* / start* method creates an `AgentRun` row, queues the
  * matching job, and (on completion via `markSucceeded`) advances the cascade
- * down through Subtask → Task → Story status. This class is the only place
+ * down through Subtask → Task → Plan → Story status. This class is the only place
  * AgentRun rows should be created.
  *
  * When `executor.race` is non-empty the dispatcher fans out to N siblings —

--- a/resources/views/pages/plans/⚡show.blade.php
+++ b/resources/views/pages/plans/⚡show.blade.php
@@ -39,7 +39,7 @@ new #[Title('Plan')] class extends Component {
                 'story.acceptanceCriteria',
                 'story.scenarios.acceptanceCriterion',
                 'approvals.approver',
-                'tasks.story.feature.project',
+                'tasks.plan.story.feature.project',
                 'tasks.acceptanceCriterion',
                 'tasks.scenario',
                 'tasks.dependencies',
@@ -107,7 +107,7 @@ new #[Title('Plan')] class extends Component {
                                 <flux:badge variant="solid">{{ __('current plan') }}</flux:badge>
                             @endif
                             <flux:badge>{{ count($effective) }}/{{ $policy->required_approvals }} {{ __('approvals') }}</flux:badge>
-                            <flux:badge>{{ $tasks->count() }} {{ __('tasks') }} · {{ $subtaskCount }} {{ __('subtasks') }}</flux:badge>
+                            <flux:badge>{{ $tasks->count() }} {{ __('plan tasks') }} · {{ $subtaskCount }} {{ __('subtasks') }}</flux:badge>
                         </div>
                         <flux:heading size="xl" class="mt-2">{{ $plan->name ?? __('Plan') }}</flux:heading>
                         <flux:text class="mt-1 text-sm text-zinc-500">{{ $feature->name }} · <a href="{{ route('stories.show', ['project' => $project->id, 'story' => $story->id]) }}" wire:navigate class="underline">{{ $story->name }}</a></flux:text>
@@ -152,9 +152,9 @@ new #[Title('Plan')] class extends Component {
 
             <section class="flex flex-col gap-3" data-section="plan-body">
                 <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-                    <flux:heading size="lg">{{ __('Tasks') }}</flux:heading>
+                    <flux:heading size="lg">{{ __('Plan tasks') }}</flux:heading>
                     <flux:text class="text-xs text-zinc-500">
-                        {{ $acs->count() }} {{ __('ACs') }} · {{ $subtaskCount }} {{ __('subtasks') }}
+                        {{ $acs->count() }} {{ __('ACs') }} · {{ $tasks->count() }} {{ __('plan tasks') }} · {{ $subtaskCount }} {{ __('subtasks') }}
                         @if ($repo)
                             · {{ $repo->name }}
                         @endif
@@ -175,7 +175,7 @@ new #[Title('Plan')] class extends Component {
                             </summary>
 
                             @if ($acTasks->isEmpty())
-                                <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No task mapped to this AC in this plan.') }}</flux:text>
+                                <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No plan task mapped to this AC.') }}</flux:text>
                             @else
                                 @foreach ($acTasks as $task)
                                     @include('partials.story-task', ['task' => $task])
@@ -190,7 +190,7 @@ new #[Title('Plan')] class extends Component {
                 @if ($unmappedTasks->isNotEmpty())
                     <flux:card data-ac="unmapped">
                         <details open>
-                            <summary class="cursor-pointer text-sm font-medium">{{ __('Unmapped tasks') }} ({{ $unmappedTasks->count() }})</summary>
+                            <summary class="cursor-pointer text-sm font-medium">{{ __('Plan tasks not mapped to an AC') }} ({{ $unmappedTasks->count() }})</summary>
                             @foreach ($unmappedTasks as $task)
                                 @include('partials.story-task', ['task' => $task])
                             @endforeach

--- a/tests/Feature/PlanShowTest.php
+++ b/tests/Feature/PlanShowTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Enums\PlanStatus;
+use App\Enums\StoryStatus;
+use App\Models\AcceptanceCriterion;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('plan show uses plan-task language for unmapped tasks', function () {
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $user->forceFill(['current_team_id' => $team->id])->save();
+
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
+    AcceptanceCriterion::factory()->for($story)->create(['statement' => 'mapped behavior']);
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
+        'name' => 'cross-cutting task',
+        'acceptance_criterion_id' => null,
+    ]);
+    $task->plan->forceFill([
+        'name' => 'Current implementation plan',
+        'status' => PlanStatus::PendingApproval->value,
+    ])->save();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::plans.show', [
+        'project' => $project->id,
+        'plan' => $task->plan->id,
+    ])
+        ->assertSee('Plan tasks')
+        ->assertSee('1 plan tasks')
+        ->assertSee('No plan task mapped to this AC.')
+        ->assertSee('Plan tasks not mapped to an AC')
+        ->assertSee('cross-cutting task')
+        ->assertDontSee('Unmapped tasks')
+        ->assertDontSee('No task mapped to this AC in this plan.');
+});


### PR DESCRIPTION
## Summary
- Update the Plan show page to label Tasks as Plan tasks in counts, headings, empty states, and unmapped sections.
- Fix the stale Plan show eager-load path from `tasks.story...` to `tasks.plan.story...`.
- Update ExecutionService docs so the completion cascade includes Plan status.
- Add Plan show coverage for the plan-task language and invalid old relation path.

## Verification
- php artisan test tests/Feature/PlanShowTest.php
- vendor/bin/pint --dirty --test --format agent
- composer test