### PR TITLE
[codex] Assert plan completion cascade

### DIFF
--- a/tests/Feature/CliExecutorTest.php
+++ b/tests/Feature/CliExecutorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\AgentRunStatus;
+use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Models\AcceptanceCriterion;
@@ -214,6 +215,7 @@ test('full pipeline with cli driver: clone → branch → cli edits → commit �
         ->and($run->diff)->toContain('AGENT_NOTE.md')
         ->and($run->diff)->toContain('edited by agent')
         ->and($subtask->fresh()->status)->toBe(TaskStatus::Done)
+        ->and($story->fresh()->currentPlan->status)->toBe(PlanStatus::Done)
         ->and($story->fresh()->status)->toBe(StoryStatus::Done);
 
     $remoteBranches = new Process(['git', 'branch', '--list'], $bare);

--- a/tests/Feature/SubtaskExecutionTest.php
+++ b/tests/Feature/SubtaskExecutionTest.php
@@ -2,6 +2,7 @@
 
 use App\Ai\Agents\SubtaskExecutor;
 use App\Enums\AgentRunStatus;
+use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Models\AcceptanceCriterion;
@@ -132,6 +133,7 @@ test('full story execution: subtasks succeed and story flips to Done', function 
     app(ExecutionService::class)->startStoryExecution($story->fresh());
 
     expect($story->fresh()->status)->toBe(StoryStatus::Done)
+        ->and($story->fresh()->currentPlan->status)->toBe(PlanStatus::Done)
         ->and($taskA->fresh()->status)->toBe(TaskStatus::Done)
         ->and($taskB->fresh()->status)->toBe(TaskStatus::Done);
 });


### PR DESCRIPTION
## Summary
- Add `PlanStatus::Done` assertions to the full Story execution cascade test.
- Add the same assertion to the CLI executor end-to-end completion path.

## Verification
- php artisan test tests/Feature/SubtaskExecutionTest.php tests/Feature/CliExecutorTest.php
- vendor/bin/pint --dirty --test --format agent
- composer test