### PR TITLE
[codex] Remove old copy assertions

### DIFF
--- a/tests/Feature/AgentRunRetryTest.php
+++ b/tests/Feature/AgentRunRetryTest.php
@@ -91,8 +91,7 @@ test('Run console exposes a Retry button on terminal failure runs', function () 
         ->get("/projects/{$project->id}/stories/{$story->id}/subtasks/{$subtask->id}/runs/{$run->id}")
         ->assertOk()
         ->assertSee('Retry')
-        ->assertSee('authorised against the current PlanApproval')
-        ->assertDontSee('authorised against the current StoryApproval');
+        ->assertSee('authorised against the current PlanApproval');
 });
 
 test('Run console hides Retry on Succeeded runs', function () {

--- a/tests/Feature/PlanShowTest.php
+++ b/tests/Feature/PlanShowTest.php
@@ -45,7 +45,5 @@ test('plan show uses plan-task language for unmapped tasks', function () {
         ->assertSee('1 plan tasks')
         ->assertSee('No plan task mapped to this AC.')
         ->assertSee('Plan tasks not mapped to an AC')
-        ->assertSee('cross-cutting task')
-        ->assertDontSee('Unmapped tasks')
-        ->assertDontSee('No task mapped to this AC in this plan.');
+        ->assertSee('cross-cutting task');
 });

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -252,8 +252,7 @@ test('plan section labels current-plan task counts and empty AC mappings', funct
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertSee('Current plan')
         ->assertSee('0 current-plan tasks')
-        ->assertSee('No current-plan task is mapped to this AC yet.')
-        ->assertDontSee('No task generated for this AC yet.');
+        ->assertSee('No current-plan task is mapped to this AC yet.');
 });
 
 test('task missing acceptance_criterion_id renders under current-plan unmapped tasks', function () {


### PR DESCRIPTION
## Summary
- Remove negative assertions that preserved retired UI copy in executable tests.
- Keep the adjacent positive assertions for current Plan/current-plan wording.

## Verification
- php artisan test tests/Feature/PlanShowTest.php tests/Feature/AgentRunRetryTest.php tests/Feature/StoryShowPageTest.php
- vendor/bin/pint --dirty --test --format agent
- composer test