### PR TITLE
[codex] Extract plan input normalizer

### DIFF
--- a/app/Jobs/GenerateTasksJob.php
+++ b/app/Jobs/GenerateTasksJob.php
@@ -7,6 +7,7 @@ use App\Enums\PlanSource;
 use App\Models\AgentRun;
 use App\Models\Story;
 use App\Services\ExecutionService;
+use App\Services\Plans\PlanInputNormalizer;
 use App\Services\PlanWriter;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -27,7 +28,7 @@ class GenerateTasksJob implements ShouldQueue
     public function __construct(public int $agentRunId) {}
 
     /** Queue handler — see class docblock. */
-    public function handle(ExecutionService $execution, PlanWriter $planWriter): void
+    public function handle(ExecutionService $execution, PlanInputNormalizer $planInputs, PlanWriter $planWriter): void
     {
         $run = AgentRun::findOrFail($this->agentRunId);
         $story = $run->runnable;
@@ -45,7 +46,7 @@ class GenerateTasksJob implements ShouldQueue
             $response = $agent->prompt($agent->buildPrompt());
             $output = $response->toArray();
 
-            $tasks = $this->normalizeTasks($story, $output['tasks'] ?? []);
+            $tasks = $planInputs->fromGeneratedTasks($story, $output['tasks'] ?? []);
             $result = $planWriter->replacePlan($story, $tasks, [
                 'name' => 'AI plan v'.(((int) $story->plans()->max('version')) + 1),
                 'summary' => $output['summary'] ?? null,
@@ -88,42 +89,5 @@ class GenerateTasksJob implements ShouldQueue
             $run,
             $e?->getMessage() ?: 'Job failed without surfacing an exception (worker died or retries exhausted).',
         );
-    }
-
-    /**
-     * Map agent-generated tasks (referencing acceptance criteria by position
-     * and using `depends_on`) into the plan-writer shape (referencing by id
-     * and using `depends_on_positions`).
-     *
-     * @param  array<int, array<string, mixed>>  $rawTasks
-     * @return list<array<string, mixed>>
-     */
-    private function normalizeTasks(Story $story, array $rawTasks): array
-    {
-        $criteriaByPosition = $story->acceptanceCriteria()->get()->keyBy('position');
-
-        $tasks = [];
-        foreach ($rawTasks as $taskData) {
-            $acPosition = $taskData['acceptance_criterion_position'] ?? null;
-            $criterion = $acPosition !== null ? ($criteriaByPosition[$acPosition] ?? null) : null;
-
-            $tasks[] = [
-                'position' => $taskData['position'],
-                'name' => $taskData['name'],
-                'description' => $taskData['description'] ?? null,
-                'acceptance_criterion_id' => $criterion?->getKey(),
-                'depends_on_positions' => $taskData['depends_on'] ?? [],
-                'subtasks' => array_map(
-                    fn (array $s) => [
-                        'position' => $s['position'],
-                        'name' => $s['name'],
-                        'description' => $s['description'] ?? null,
-                    ],
-                    $taskData['subtasks'] ?? [],
-                ),
-            ];
-        }
-
-        return $tasks;
     }
 }

--- a/app/Services/PlanWriter.php
+++ b/app/Services/PlanWriter.php
@@ -11,6 +11,7 @@ use App\Models\Story;
 use App\Models\Subtask;
 use App\Models\Task;
 use App\Services\Executors\ProposedSubtask;
+use App\Services\Plans\PlanInputNormalizer;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
@@ -24,7 +25,7 @@ use InvalidArgumentException;
  */
 class PlanWriter
 {
-    public function __construct(public ApprovalService $approvals) {}
+    public function __construct(private PlanInputNormalizer $planInputs) {}
 
     /**
      * @param  list<array{
@@ -41,6 +42,8 @@ class PlanWriter
      */
     public function replacePlan(Story $story, array $tasks, array $attributes = []): array
     {
+        $tasks = $this->planInputs->forPlanWriter($tasks);
+
         $this->validate($story, $tasks);
 
         $result = DB::transaction(function () use ($story, $tasks, $attributes) {

--- a/app/Services/Plans/PlanInputNormalizer.php
+++ b/app/Services/Plans/PlanInputNormalizer.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services\Plans;
+
+use App\Models\Story;
+
+class PlanInputNormalizer
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $rawTasks
+     * @return list<array<string, mixed>>
+     */
+    public function fromGeneratedTasks(Story $story, array $rawTasks): array
+    {
+        $criteria = $story->relationLoaded('acceptanceCriteria')
+            ? $story->acceptanceCriteria
+            : $story->acceptanceCriteria()->get();
+        $criteriaByPosition = $criteria->keyBy('position');
+
+        $tasks = [];
+        foreach ($rawTasks as $taskData) {
+            $acPosition = $taskData['acceptance_criterion_position'] ?? null;
+            $criterion = $acPosition !== null ? ($criteriaByPosition[$acPosition] ?? null) : null;
+
+            $tasks[] = [
+                'position' => $taskData['position'],
+                'name' => $taskData['name'],
+                'description' => $taskData['description'] ?? null,
+                'acceptance_criterion_id' => $criterion?->getKey(),
+                'depends_on_positions' => $this->positionList($taskData['depends_on'] ?? []),
+                'subtasks' => array_map(
+                    fn (array $subtaskData) => [
+                        'position' => $subtaskData['position'],
+                        'name' => $subtaskData['name'],
+                        'description' => $subtaskData['description'] ?? null,
+                    ],
+                    $taskData['subtasks'] ?? [],
+                ),
+            ];
+        }
+
+        return $tasks;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $tasks
+     * @return list<array<string, mixed>>
+     */
+    public function forPlanWriter(array $tasks): array
+    {
+        return array_values(array_map(
+            fn (array $taskData) => [
+                'position' => $taskData['position'],
+                'name' => $taskData['name'],
+                'description' => $taskData['description'] ?? null,
+                'acceptance_criterion_id' => $taskData['acceptance_criterion_id'] ?? null,
+                'scenario_id' => $taskData['scenario_id'] ?? null,
+                'depends_on_positions' => $this->positionList($taskData['depends_on_positions'] ?? []),
+                'subtasks' => array_values(array_map(
+                    fn (array $subtaskData) => [
+                        'position' => $subtaskData['position'],
+                        'name' => $subtaskData['name'],
+                        'description' => $subtaskData['description'] ?? null,
+                    ],
+                    $taskData['subtasks'] ?? [],
+                )),
+            ],
+            $tasks,
+        ));
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function positionList(mixed $positions): array
+    {
+        if (! is_array($positions)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(
+            array_map(static fn ($position) => (int) $position, $positions),
+            static fn (int $position) => $position >= 1,
+        )));
+    }
+}

--- a/tests/Feature/PlanInputNormalizerTest.php
+++ b/tests/Feature/PlanInputNormalizerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\AcceptanceCriterion;
+use App\Services\Plans\PlanInputNormalizer;
+
+test('generated tasks are normalized into plan writer input', function () {
+    $story = makeStory();
+    $criterion = AcceptanceCriterion::factory()->for($story)->create(['position' => 2]);
+
+    $tasks = app(PlanInputNormalizer::class)->fromGeneratedTasks($story, [
+        [
+            'position' => 1,
+            'name' => 'Build shared support',
+            'subtasks' => [
+                ['position' => 1, 'name' => 'Wire support'],
+            ],
+        ],
+        [
+            'position' => 2,
+            'name' => 'Criterion work',
+            'acceptance_criterion_position' => 2,
+            'depends_on' => [1],
+            'subtasks' => [
+                ['position' => 1, 'name' => 'Implement criterion'],
+            ],
+        ],
+        [
+            'position' => 3,
+            'name' => 'Cross-cutting verification',
+            'depends_on' => [2, 2, 0, -1, 'bad'],
+            'subtasks' => [
+                ['position' => 1, 'name' => 'Verify all paths', 'description' => 'Run checks.'],
+            ],
+        ],
+    ]);
+
+    expect($tasks)->toBe([
+        [
+            'position' => 1,
+            'name' => 'Build shared support',
+            'description' => null,
+            'acceptance_criterion_id' => null,
+            'depends_on_positions' => [],
+            'subtasks' => [
+                ['position' => 1, 'name' => 'Wire support', 'description' => null],
+            ],
+        ],
+        [
+            'position' => 2,
+            'name' => 'Criterion work',
+            'description' => null,
+            'acceptance_criterion_id' => $criterion->id,
+            'depends_on_positions' => [1],
+            'subtasks' => [
+                ['position' => 1, 'name' => 'Implement criterion', 'description' => null],
+            ],
+        ],
+        [
+            'position' => 3,
+            'name' => 'Cross-cutting verification',
+            'description' => null,
+            'acceptance_criterion_id' => null,
+            'depends_on_positions' => [2],
+            'subtasks' => [
+                ['position' => 1, 'name' => 'Verify all paths', 'description' => 'Run checks.'],
+            ],
+        ],
+    ]);
+});
+
+test('plan writer input is canonicalized before validation and writing', function () {
+    $tasks = app(PlanInputNormalizer::class)->forPlanWriter([
+        7 => [
+            'position' => 3,
+            'name' => 'Task',
+            'depends_on_positions' => [1, 1, 0, 'bad'],
+            'subtasks' => [
+                9 => ['position' => 1, 'name' => 'Subtask'],
+            ],
+        ],
+    ]);
+
+    expect($tasks)->toBe([
+        [
+            'position' => 3,
+            'name' => 'Task',
+            'description' => null,
+            'acceptance_criterion_id' => null,
+            'scenario_id' => null,
+            'depends_on_positions' => [1],
+            'subtasks' => [
+                ['position' => 1, 'name' => 'Subtask', 'description' => null],
+            ],
+        ],
+    ]);
+});

--- a/tests/Feature/TaskGenerationTest.php
+++ b/tests/Feature/TaskGenerationTest.php
@@ -22,26 +22,26 @@ beforeEach(function () {
 
 test('dispatching task generation runs the job, creates Tasks linked to ACs with Subtasks, marks AgentRun succeeded', function () {
     $story = Story::factory()->create();
-    $ac1 = AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'statement' => 'AC one']);
-    $ac2 = AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'AC two']);
+    $ac1 = AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'AC one']);
+    $ac2 = AcceptanceCriterion::factory()->for($story)->create(['position' => 2, 'statement' => 'AC two']);
 
     TasksGenerator::fake(fn () => [
         'summary' => 'plan it',
         'tasks' => [
             [
-                'name' => 't0', 'description' => 'desc0', 'position' => 0,
-                'acceptance_criterion_position' => 0,
+                'name' => 't0', 'description' => 'desc0', 'position' => 1,
+                'acceptance_criterion_position' => 1,
                 'subtasks' => [
-                    ['name' => 's0', 'description' => 'sd0', 'position' => 0],
-                    ['name' => 's1', 'description' => 'sd1', 'position' => 1],
+                    ['name' => 's0', 'description' => 'sd0', 'position' => 1],
+                    ['name' => 's1', 'description' => 'sd1', 'position' => 2],
                 ],
             ],
             [
-                'name' => 't1', 'description' => 'desc1', 'position' => 1,
-                'acceptance_criterion_position' => 1,
-                'depends_on' => [0],
+                'name' => 't1', 'description' => 'desc1', 'position' => 2,
+                'acceptance_criterion_position' => 2,
+                'depends_on' => [1],
                 'subtasks' => [
-                    ['name' => 's0', 'description' => 'sd0', 'position' => 0],
+                    ['name' => 's0', 'description' => 'sd0', 'position' => 1],
                 ],
             ],
         ],
@@ -63,14 +63,14 @@ test('dispatching task generation runs the job, creates Tasks linked to ACs with
 
 test('regeneration replaces the prior task list', function () {
     $story = Story::factory()->create();
-    AcceptanceCriterion::factory()->for($story)->create(['position' => 0, 'statement' => 'AC one']);
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'AC one']);
 
     TasksGenerator::fake(fn () => [
         'summary' => 'v1',
         'tasks' => [[
-            'name' => 'task-v1', 'description' => 'd', 'position' => 0,
-            'acceptance_criterion_position' => 0,
-            'subtasks' => [['name' => 's', 'description' => 'sd', 'position' => 0]],
+            'name' => 'task-v1', 'description' => 'd', 'position' => 1,
+            'acceptance_criterion_position' => 1,
+            'subtasks' => [['name' => 's', 'description' => 'sd', 'position' => 1]],
         ]],
     ]);
 
@@ -80,9 +80,9 @@ test('regeneration replaces the prior task list', function () {
     TasksGenerator::fake(fn () => [
         'summary' => 'v2',
         'tasks' => [[
-            'name' => 'task-v2', 'description' => 'd', 'position' => 0,
-            'acceptance_criterion_position' => 0,
-            'subtasks' => [['name' => 's', 'description' => 'sd', 'position' => 0]],
+            'name' => 'task-v2', 'description' => 'd', 'position' => 1,
+            'acceptance_criterion_position' => 1,
+            'subtasks' => [['name' => 's', 'description' => 'sd', 'position' => 1]],
         ]],
     ]);
 
@@ -115,7 +115,7 @@ test('task generation allows cross-cutting tasks without a single acceptance cri
 
 test('agent failure marks the AgentRun failed with error message', function () {
     $story = Story::factory()->create();
-    AcceptanceCriterion::factory()->for($story)->create(['position' => 0]);
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
 
     TasksGenerator::fake(function () {
         throw new RuntimeException('agent down');
@@ -134,7 +134,7 @@ test('agent failure marks the AgentRun failed with error message', function () {
 
 test('regeneration on an Approved story keeps story approval intact but reopens current plan approval', function () {
     $story = Story::factory()->create(['status' => StoryStatus::Approved, 'revision' => 1]);
-    AcceptanceCriterion::factory()->for($story)->create(['position' => 0]);
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
     $story = $story->fresh();
     $approver = User::factory()->create();
     StoryApproval::create([
@@ -153,9 +153,9 @@ test('regeneration on an Approved story keeps story approval intact but reopens 
     TasksGenerator::fake(fn () => [
         'summary' => 'plan',
         'tasks' => [[
-            'name' => 't', 'description' => 'd', 'position' => 0,
-            'acceptance_criterion_position' => 0,
-            'subtasks' => [['name' => 's', 'description' => 'sd', 'position' => 0]],
+            'name' => 't', 'description' => 'd', 'position' => 1,
+            'acceptance_criterion_position' => 1,
+            'subtasks' => [['name' => 's', 'description' => 'sd', 'position' => 1]],
         ]],
     ]);
 


### PR DESCRIPTION
## Summary

- Add `PlanInputNormalizer` to canonicalize generated task output and direct PlanWriter task input.
- Move TasksGenerator output mapping out of `GenerateTasksJob`.
- Have `PlanWriter` normalize incoming task arrays before validation and persistence.
- Add focused tests for generated input and direct plan-writer input canonicalization.

## Why

Plan replacement has one write seam, but the input shape was still interpreted in callers. This PR concentrates the agent/MCP-facing plan task shape before it reaches PlanWriter validation and keeps the queue job focused on orchestration.

## Validation

- `php artisan test --compact tests/Feature/PlanInputNormalizerTest.php tests/Feature/TaskGenerationTest.php`
- `vendor/bin/pint --dirty --test`
- `composer test`
