### PR TITLE
[codex] Extract story run projection

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -2,12 +2,12 @@
 
 namespace App\Models;
 
-use App\Enums\AgentRunKind;
 use App\Enums\StoryKind;
 use App\Enums\StoryStatus;
 use App\Models\Concerns\HasSlug;
 use App\Services\ApprovalService;
 use App\Services\Stories\StoryPullRequestProjection;
+use App\Services\Stories\StoryRunProjection;
 use Database\Factories\StoryFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -140,13 +140,7 @@ class Story extends Model
      */
     public function hasActiveSubtaskRun(): bool
     {
-        return AgentRun::query()
-            ->where('runnable_type', Subtask::class)
-            ->whereIn('runnable_id', Subtask::query()
-                ->whereIn('task_id', $this->tasks()->select('tasks.id'))
-                ->select('id'))
-            ->active()
-            ->exists();
+        return app(StoryRunProjection::class)->hasActiveSubtaskRun($this);
     }
 
     /**
@@ -154,16 +148,7 @@ class Story extends Model
      */
     public function activeConflictResolutionAgentRun(): ?AgentRun
     {
-        return AgentRun::query()
-            ->where('runnable_type', Subtask::class)
-            ->whereIn('runnable_id', Subtask::query()
-                ->whereIn('task_id', $this->tasks()->select('tasks.id'))
-                ->select('id'))
-            ->where('kind', AgentRunKind::ResolveConflicts->value)
-            ->active()
-            ->with('runnable')
-            ->latest('id')
-            ->first();
+        return app(StoryRunProjection::class)->activeConflictResolutionRun($this);
     }
 
     public function creator(): BelongsTo

--- a/app/Services/Stories/StoryRunProjection.php
+++ b/app/Services/Stories/StoryRunProjection.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Enums\AgentRunKind;
+use App\Models\AgentRun;
+use App\Models\Story;
+use App\Models\Subtask;
+use Illuminate\Database\Eloquent\Builder;
+
+class StoryRunProjection
+{
+    public function hasActiveSubtaskRun(Story $story): bool
+    {
+        return AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->whereIn('runnable_id', $this->subtaskIdQueryFor($story))
+            ->active()
+            ->exists();
+    }
+
+    public function activeConflictResolutionRun(Story $story): ?AgentRun
+    {
+        return AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->whereIn('runnable_id', $this->subtaskIdQueryFor($story))
+            ->where('kind', AgentRunKind::ResolveConflicts->value)
+            ->active()
+            ->with('runnable')
+            ->latest('id')
+            ->first();
+    }
+
+    private function subtaskIdQueryFor(Story $story): Builder
+    {
+        return Subtask::query()
+            ->whereIn('task_id', $story->tasks()->select('tasks.id'))
+            ->select('id');
+    }
+}

--- a/tests/Feature/StoryRunProjectionTest.php
+++ b/tests/Feature/StoryRunProjectionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Enums\AgentRunKind;
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Models\Plan;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Services\Stories\StoryRunProjection;
+
+test('story run projection detects active subtask runs under the current plan', function () {
+    $story = Story::factory()->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+
+    $oldPlan = Plan::factory()->for($story)->create(['version' => 1]);
+    $oldTask = Task::factory()->for($oldPlan)->create();
+    $oldSubtask = Subtask::factory()->for($oldTask)->create();
+
+    expect(app(StoryRunProjection::class)->hasActiveSubtaskRun($story))->toBeFalse();
+
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $oldSubtask->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    expect(app(StoryRunProjection::class)->hasActiveSubtaskRun($story->fresh()))->toBeFalse();
+
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    expect(app(StoryRunProjection::class)->hasActiveSubtaskRun($story->fresh()))->toBeTrue();
+});
+
+test('story run projection returns latest active conflict resolution run', function () {
+    $story = Story::factory()->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create();
+    $subtask = Subtask::factory()->for($task)->create();
+
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'kind' => AgentRunKind::ResolveConflicts,
+        'status' => AgentRunStatus::Failed,
+    ]);
+    $running = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'kind' => AgentRunKind::ResolveConflicts,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $result = app(StoryRunProjection::class)->activeConflictResolutionRun($story->fresh());
+
+    expect($result)->not->toBeNull()
+        ->and($result->id)->toBe($running->id);
+});


### PR DESCRIPTION
## Summary

- Add `StoryRunProjection` for Story-level active Subtask run state.
- Move active run and active conflict-resolution queries out of the `Story` model.
- Keep `Story::hasActiveSubtaskRun()` and `Story::activeConflictResolutionAgentRun()` as delegates for existing UI callers.
- Add focused projection coverage.

## Why

The Story model still carried operational read queries after the PR projection extraction. This PR moves active execution state behind a dedicated read module while preserving caller-facing behavior.

## Validation

- `php artisan test --compact tests/Feature/StoryRunProjectionTest.php tests/Feature/ConflictResolutionTest.php`
- `vendor/bin/pint --dirty --test`
- `composer test`
