### PR TITLE
[codex] Extract approval policy resolver

### DIFF
--- a/app/Models/ApprovalPolicy.php
+++ b/app/Models/ApprovalPolicy.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Approval rule attached to a Workspace, Project, or Story (cascade).
  *
- * `Story::effectivePolicy()` walks up Story → Project → Workspace and falls
- * back to `default()`. Holds the threshold (`required_approvals`) and
+ * `\App\Services\Approvals\ApprovalPolicyResolver` walks up Story → Project
+ * → Workspace and falls back to `default()`. Holds the threshold (`required_approvals`) and
  * the `allow_self_approval` / `auto_approve` flags ApprovalService consults.
  */
 #[Fillable(['scope_type', 'scope_id', 'required_approvals', 'allow_self_approval', 'auto_approve', 'notes'])]

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\StoryKind;
 use App\Enums\StoryStatus;
 use App\Models\Concerns\HasSlug;
+use App\Services\Approvals\ApprovalPolicyResolver;
 use App\Services\ApprovalService;
 use App\Services\Stories\StoryPullRequestProjection;
 use App\Services\Stories\StoryRunProjection;
@@ -210,25 +211,7 @@ class Story extends Model
 
     public function effectivePolicy(): ApprovalPolicy
     {
-        $project = $this->feature?->project;
-        $workspace = $project?->team?->workspace;
-
-        $candidates = collect([
-            ApprovalPolicy::query()
-                ->where('scope_type', ApprovalPolicy::SCOPE_STORY)
-                ->where('scope_id', $this->getKey())
-                ->first(),
-            $project ? ApprovalPolicy::query()
-                ->where('scope_type', ApprovalPolicy::SCOPE_PROJECT)
-                ->where('scope_id', $project->getKey())
-                ->first() : null,
-            $workspace ? ApprovalPolicy::query()
-                ->where('scope_type', ApprovalPolicy::SCOPE_WORKSPACE)
-                ->where('scope_id', $workspace->getKey())
-                ->first() : null,
-        ])->filter();
-
-        return $candidates->first() ?? ApprovalPolicy::default();
+        return app(ApprovalPolicyResolver::class)->forStory($this);
     }
 
     public function isApproved(): bool

--- a/app/Services/Approvals/ApprovalPolicyResolver.php
+++ b/app/Services/Approvals/ApprovalPolicyResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Services\Approvals;
+
+use App\Models\ApprovalPolicy;
+use App\Models\Story;
+use App\Models\Team;
+
+class ApprovalPolicyResolver
+{
+    public function forStory(Story $story): ApprovalPolicy
+    {
+        $storyPolicy = ApprovalPolicy::query()
+            ->where('scope_type', ApprovalPolicy::SCOPE_STORY)
+            ->where('scope_id', $story->getKey())
+            ->first();
+
+        if ($storyPolicy) {
+            return $storyPolicy;
+        }
+
+        $project = $story->feature?->project;
+        if ($project) {
+            $projectPolicy = ApprovalPolicy::query()
+                ->where('scope_type', ApprovalPolicy::SCOPE_PROJECT)
+                ->where('scope_id', $project->getKey())
+                ->first();
+
+            if ($projectPolicy) {
+                return $projectPolicy;
+            }
+        }
+
+        $workspaceId = $project?->team_id
+            ? Team::query()->whereKey($project->team_id)->value('workspace_id')
+            : null;
+
+        if ($workspaceId) {
+            $workspacePolicy = ApprovalPolicy::query()
+                ->where('scope_type', ApprovalPolicy::SCOPE_WORKSPACE)
+                ->where('scope_id', $workspaceId)
+                ->first();
+
+            if ($workspacePolicy) {
+                return $workspacePolicy;
+            }
+        }
+
+        return ApprovalPolicy::default();
+    }
+}

--- a/tests/Feature/ApprovalPolicyResolverTest.php
+++ b/tests/Feature/ApprovalPolicyResolverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Models\ApprovalPolicy;
+use App\Services\Approvals\ApprovalPolicyResolver;
+
+test('approval policy resolver falls back to the default policy', function () {
+    $story = makeStory();
+
+    $policy = app(ApprovalPolicyResolver::class)->forStory($story);
+
+    expect($policy->exists)->toBeFalse()
+        ->and($policy->required_approvals)->toBe(0)
+        ->and($policy->allow_self_approval)->toBeFalse()
+        ->and($policy->auto_approve)->toBeFalse();
+});
+
+test('approval policy resolver uses workspace project story precedence', function () {
+    $story = makeStory();
+    $project = $story->feature->project;
+    $workspace = $project->team->workspace;
+
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_WORKSPACE,
+        'scope_id' => $workspace->id,
+        'required_approvals' => 3,
+    ]);
+
+    expect(app(ApprovalPolicyResolver::class)->forStory($story)->required_approvals)->toBe(3);
+
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_PROJECT,
+        'scope_id' => $project->id,
+        'required_approvals' => 2,
+    ]);
+
+    expect(app(ApprovalPolicyResolver::class)->forStory($story)->required_approvals)->toBe(2);
+
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_STORY,
+        'scope_id' => $story->id,
+        'required_approvals' => 1,
+    ]);
+
+    expect(app(ApprovalPolicyResolver::class)->forStory($story)->required_approvals)->toBe(1);
+});
+
+test('approval policy resolver short-circuits before loading broader scope relations', function () {
+    $story = makeStory();
+
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_STORY,
+        'scope_id' => $story->id,
+        'required_approvals' => 1,
+    ]);
+
+    $policy = app(ApprovalPolicyResolver::class)->forStory($story);
+
+    expect($policy->required_approvals)->toBe(1)
+        ->and($story->relationLoaded('feature'))->toBeFalse();
+});
+
+test('approval policy resolver reads workspace id without hydrating team workspace relations', function () {
+    $story = makeStory()->load('feature.project');
+    $project = $story->feature->project;
+    $workspace = $project->team->workspace;
+    $project->unsetRelation('team');
+
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_WORKSPACE,
+        'scope_id' => $workspace->id,
+        'required_approvals' => 3,
+    ]);
+
+    $policy = app(ApprovalPolicyResolver::class)->forStory($story);
+
+    expect($policy->required_approvals)->toBe(3)
+        ->and($project->relationLoaded('team'))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Add `ApprovalPolicyResolver` for Story -> Project -> Workspace approval policy precedence.
- Keep `Story::effectivePolicy()` as a delegate for existing approval callers.
- Update ApprovalPolicy documentation to point at the resolver.
- Add focused resolver tests for default fallback and precedence.

## Why

The Story model still owned approval policy lookup after the approval-gate extraction. This PR gives approval policy resolution its own module and test surface while preserving caller-facing behavior.

## Validation

- `php artisan test --compact tests/Feature/ApprovalPolicyResolverTest.php tests/Feature/ApprovalTest.php tests/Feature/PlanApprovalTest.php`
- `vendor/bin/pint --dirty --test`
- `composer test`
