### PR TITLE
Extract story dependency graph

### DIFF
--- a/app/Mcp/Tools/AddStoryDependencyTool.php
+++ b/app/Mcp/Tools/AddStoryDependencyTool.php
@@ -14,7 +14,7 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: add-story-dependency
  */
-#[Description('Mark a story as depending on another story. Both stories must be in projects the user can access.')]
+#[Description('Mark a story as depending on another story. Both stories must be accessible, in the same workspace, and must not form a cycle.')]
 class AddStoryDependencyTool extends Tool
 {
     use ResolvesProjectAccess;
@@ -74,8 +74,8 @@ class AddStoryDependencyTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'story_id' => $schema->integer()->description('Dependent story.')->required(),
-            'depends_on_story_id' => $schema->integer()->description('Story that must be done first.')->required(),
+            'story_id' => $schema->integer()->description('Dependent story. Must be accessible to the acting user.')->required(),
+            'depends_on_story_id' => $schema->integer()->description('Story that must be done first. Must be accessible, live in the same workspace, and not create a cycle.')->required(),
         ];
     }
 }

--- a/app/Mcp/Tools/AddStoryDependencyTool.php
+++ b/app/Mcp/Tools/AddStoryDependencyTool.php
@@ -3,7 +3,9 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Stories\StoryDependencyGraph;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use InvalidArgumentException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -22,7 +24,7 @@ class AddStoryDependencyTool extends Tool
     /**
      * Handle the MCP tool invocation.
      */
-    public function handle(Request $request): Response
+    public function handle(Request $request, StoryDependencyGraph $dependencies): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -53,7 +55,11 @@ class AddStoryDependencyTool extends Tool
             return $dependency;
         }
 
-        $story->dependencies()->syncWithoutDetaching([$dependency->id]);
+        try {
+            $dependencies->addDependency($story, $dependency);
+        } catch (InvalidArgumentException $e) {
+            return Response::error($e->getMessage());
+        }
 
         return Response::json([
             'story_id' => $story->id,

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -7,6 +7,7 @@ use App\Enums\StoryStatus;
 use App\Models\Concerns\HasSlug;
 use App\Services\Approvals\ApprovalPolicyResolver;
 use App\Services\ApprovalService;
+use App\Services\Stories\StoryDependencyGraph;
 use App\Services\Stories\StoryPullRequestProjection;
 use App\Services\Stories\StoryRunProjection;
 use Database\Factories\StoryFactory;
@@ -18,7 +19,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
-use InvalidArgumentException;
 
 /**
  * Product contract under a Feature.
@@ -254,54 +254,21 @@ class Story extends Model
 
     public function addDependency(self $other): void
     {
-        if ($this->is($other)) {
-            throw new InvalidArgumentException('A story cannot depend on itself.');
-        }
-
-        if ($this->workspaceId() !== $other->workspaceId()) {
-            throw new InvalidArgumentException('Story dependencies must live in the same workspace.');
-        }
-
-        if ($other->dependsOnTransitively($this)) {
-            throw new InvalidArgumentException('Adding this dependency would create a cycle.');
-        }
-
-        $this->dependencies()->syncWithoutDetaching([$other->getKey()]);
+        app(StoryDependencyGraph::class)->addDependency($this, $other);
     }
 
     public function dependsOnTransitively(self $candidate): bool
     {
-        $visited = [];
-        $stack = [$this->getKey()];
-
-        while ($stack !== []) {
-            $id = array_pop($stack);
-            if (isset($visited[$id])) {
-                continue;
-            }
-            $visited[$id] = true;
-
-            $deps = self::find($id)?->dependencies()->pluck('stories.id')->all() ?? [];
-            foreach ($deps as $depId) {
-                if ($depId === $candidate->getKey()) {
-                    return true;
-                }
-                $stack[] = $depId;
-            }
-        }
-
-        return false;
+        return app(StoryDependencyGraph::class)->dependsOnTransitively($this, $candidate);
     }
 
     public function isReady(): bool
     {
-        return $this->dependencies()
-            ->where('status', '!=', StoryStatus::Done->value)
-            ->doesntExist();
+        return app(StoryDependencyGraph::class)->isReady($this);
     }
 
     public function workspaceId(): ?int
     {
-        return $this->feature?->project?->team?->workspace_id;
+        return app(StoryDependencyGraph::class)->workspaceId($this);
     }
 }

--- a/app/Services/Stories/StoryDependencyGraph.php
+++ b/app/Services/Stories/StoryDependencyGraph.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Enums\StoryStatus;
+use App\Models\Feature;
+use App\Models\Story;
+use InvalidArgumentException;
+
+class StoryDependencyGraph
+{
+    public function addDependency(Story $story, Story $dependency): void
+    {
+        if ($story->is($dependency)) {
+            throw new InvalidArgumentException('A story cannot depend on itself.');
+        }
+
+        if ($this->workspaceId($story) !== $this->workspaceId($dependency)) {
+            throw new InvalidArgumentException('Story dependencies must live in the same workspace.');
+        }
+
+        if ($this->dependsOnTransitively($dependency, $story)) {
+            throw new InvalidArgumentException('Adding this dependency would create a cycle.');
+        }
+
+        $story->dependencies()->syncWithoutDetaching([$dependency->getKey()]);
+    }
+
+    public function dependsOnTransitively(Story $story, Story $candidate): bool
+    {
+        $visited = [];
+        $stack = [$story->getKey()];
+
+        while ($stack !== []) {
+            $id = array_pop($stack);
+            if (isset($visited[$id])) {
+                continue;
+            }
+            $visited[$id] = true;
+
+            $deps = Story::find($id)?->dependencies()->pluck('stories.id')->all() ?? [];
+            foreach ($deps as $depId) {
+                if ($depId === $candidate->getKey()) {
+                    return true;
+                }
+                $stack[] = $depId;
+            }
+        }
+
+        return false;
+    }
+
+    public function isReady(Story $story): bool
+    {
+        return $story->dependencies()
+            ->where('status', '!=', StoryStatus::Done->value)
+            ->doesntExist();
+    }
+
+    public function workspaceId(Story $story): ?int
+    {
+        return Feature::query()
+            ->join('projects', 'projects.id', '=', 'features.project_id')
+            ->join('teams', 'teams.id', '=', 'projects.team_id')
+            ->whereKey($story->feature_id)
+            ->value('teams.workspace_id');
+    }
+}

--- a/tests/Feature/DependenciesTest.php
+++ b/tests/Feature/DependenciesTest.php
@@ -2,13 +2,17 @@
 
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
+use App\Mcp\Tools\AddStoryDependencyTool;
 use App\Models\Feature;
 use App\Models\Project;
 use App\Models\Story;
 use App\Models\Task;
 use App\Models\Team;
+use App\Models\User;
 use App\Models\Workspace;
+use App\Services\Stories\StoryDependencyGraph;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
 
 uses(RefreshDatabase::class);
 
@@ -106,4 +110,54 @@ test('story dependency cycle is prevented', function () {
 
     expect(fn () => $a->addDependency($c))
         ->toThrow(InvalidArgumentException::class, 'cycle');
+});
+
+test('add story dependency tool rejects accessible stories across workspaces', function () {
+    $user = User::factory()->create();
+
+    $workspaceA = Workspace::factory()->create();
+    $teamA = Team::factory()->for($workspaceA)->create();
+    $teamA->addMember($user);
+    $projectA = Project::factory()->for($teamA)->create();
+    $storyA = Story::factory()->for(Feature::factory()->for($projectA))->create();
+
+    $workspaceB = Workspace::factory()->create();
+    $teamB = Team::factory()->for($workspaceB)->create();
+    $teamB->addMember($user);
+    $projectB = Project::factory()->for($teamB)->create();
+    $storyB = Story::factory()->for(Feature::factory()->for($projectB))->create();
+
+    $this->actingAs($user);
+
+    $response = app(AddStoryDependencyTool::class)->handle(new Request([
+        'story_id' => $storyA->id,
+        'depends_on_story_id' => $storyB->id,
+    ]), app(StoryDependencyGraph::class));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('same workspace')
+        ->and($storyA->fresh()->dependencies()->whereKey($storyB->id)->exists())->toBeFalse();
+});
+
+test('add story dependency tool rejects cycles', function () {
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $a = Story::factory()->for($feature)->create();
+    $b = Story::factory()->for($feature)->create();
+
+    $b->addDependency($a);
+    $this->actingAs($user);
+
+    $response = app(AddStoryDependencyTool::class)->handle(new Request([
+        'story_id' => $a->id,
+        'depends_on_story_id' => $b->id,
+    ]), app(StoryDependencyGraph::class));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('cycle')
+        ->and($a->fresh()->dependencies()->whereKey($b->id)->exists())->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- add `StoryDependencyGraph` as the single module for story dependency invariants
- delegate `Story` dependency/readiness helpers to the graph
- route `add-story-dependency` MCP calls through the graph instead of writing the pivot directly
- cover MCP same-workspace and cycle rejection paths

## Validation
- php artisan test --compact tests/Feature/DependenciesTest.php
- vendor/bin/pint --dirty --test
- composer test