### PR TITLE
Extract story approval submission

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -7,6 +7,7 @@ use App\Enums\StoryStatus;
 use App\Models\Concerns\HasSlug;
 use App\Services\Approvals\ApprovalPolicyResolver;
 use App\Services\ApprovalService;
+use App\Services\Stories\StoryApprovalSubmission;
 use App\Services\Stories\StoryDependencyGraph;
 use App\Services\Stories\StoryPullRequestProjection;
 use App\Services\Stories\StoryRunProjection;
@@ -221,15 +222,7 @@ class Story extends Model
 
     public function submitForApproval(): void
     {
-        if ($this->status === StoryStatus::Rejected) {
-            throw new \RuntimeException('Cannot submit a rejected story.');
-        }
-        if ($this->acceptanceCriteria()->count() === 0) {
-            throw new \RuntimeException('Add at least one acceptance criterion before submitting.');
-        }
-        $this->status = StoryStatus::PendingApproval;
-        $this->save();
-        app(ApprovalService::class)->recompute($this);
+        app(StoryApprovalSubmission::class)->submit($this);
     }
 
     public function acceptanceCriteria(): HasMany

--- a/app/Services/Stories/StoryApprovalSubmission.php
+++ b/app/Services/Stories/StoryApprovalSubmission.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Enums\StoryStatus;
+use App\Models\Story;
+use App\Services\ApprovalService;
+use RuntimeException;
+
+class StoryApprovalSubmission
+{
+    public function __construct(private ApprovalService $approvals) {}
+
+    public function submit(Story $story): void
+    {
+        if ($story->status === StoryStatus::Rejected) {
+            throw new RuntimeException('Cannot submit a rejected story.');
+        }
+
+        if (! $story->acceptanceCriteria()->exists()) {
+            throw new RuntimeException('Add at least one acceptance criterion before submitting.');
+        }
+
+        $story->forceFill(['status' => StoryStatus::PendingApproval])->save();
+
+        $this->approvals->recompute($story);
+    }
+}


### PR DESCRIPTION
## Summary
- add `StoryApprovalSubmission` to own Story submission preconditions and approval recompute
- keep `Story::submitForApproval()` as the model-facing delegate
- use an existence check for acceptance criteria instead of counting rows

## Validation
- php artisan test --compact tests/Feature/StorySubmissionGateTest.php tests/Feature/ApprovalTest.php
- vendor/bin/pint --dirty --test
- composer test