### PR TITLE
Extract story revision lifecycle

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -6,10 +6,10 @@ use App\Enums\StoryKind;
 use App\Enums\StoryStatus;
 use App\Models\Concerns\HasSlug;
 use App\Services\Approvals\ApprovalPolicyResolver;
-use App\Services\ApprovalService;
 use App\Services\Stories\StoryApprovalSubmission;
 use App\Services\Stories\StoryDependencyGraph;
 use App\Services\Stories\StoryPullRequestProjection;
+use App\Services\Stories\StoryRevisionLifecycle;
 use App\Services\Stories\StoryRunProjection;
 use Database\Factories\StoryFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -48,9 +48,16 @@ class Story extends Model
      */
     public function silentlyForceFill(array $attributes): void
     {
+        self::withoutRevisionBump(function () use ($attributes) {
+            $this->forceFill($attributes)->save();
+        });
+    }
+
+    public static function withoutRevisionBump(callable $callback): void
+    {
         self::$suppressRevisionBump = true;
         try {
-            $this->forceFill($attributes)->save();
+            $callback();
         } finally {
             self::$suppressRevisionBump = false;
         }
@@ -59,48 +66,23 @@ class Story extends Model
     protected static function booted(): void
     {
         static::creating(function (self $story) {
-            if (empty($story->position)) {
-                $max = static::where('feature_id', $story->feature_id)->max('position') ?? 0;
-                $story->position = $max + 1;
-            }
+            app(StoryRevisionLifecycle::class)->assignInitialPosition($story);
         });
 
         static::updating(function (self $story) {
             if (self::$suppressRevisionBump) {
                 return;
             }
-            $watched = ['name', 'kind', 'actor', 'intent', 'outcome', 'description', 'notes'];
-            if (! collect($watched)->contains(fn ($key) => $story->isDirty($key))) {
-                return;
-            }
-            if ($story->isDirty('revision')) {
-                return;
-            }
-            $story->revision = ($story->revision ?? 1) + 1;
+
+            app(StoryRevisionLifecycle::class)->bumpRevisionForWatchedChanges($story);
         });
 
         static::updated(function (self $story) {
             if (self::$suppressRevisionBump) {
                 return;
             }
-            if (! $story->wasChanged('revision')) {
-                return;
-            }
 
-            $currentPlan = $story->currentPlan()->first();
-            if ($currentPlan) {
-                $currentPlan->reopenForApproval();
-            }
-
-            if (in_array($story->status, [StoryStatus::Draft, StoryStatus::Rejected, StoryStatus::Done, StoryStatus::Cancelled], true)) {
-                return;
-            }
-            self::$suppressRevisionBump = true;
-            try {
-                app(ApprovalService::class)->recompute($story);
-            } finally {
-                self::$suppressRevisionBump = false;
-            }
+            app(StoryRevisionLifecycle::class)->handleRevisionChanged($story, self::withoutRevisionBump(...));
         });
     }
 

--- a/app/Services/Stories/StoryRevisionLifecycle.php
+++ b/app/Services/Stories/StoryRevisionLifecycle.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Enums\StoryStatus;
+use App\Models\Story;
+use App\Services\ApprovalService;
+
+class StoryRevisionLifecycle
+{
+    /**
+     * @var list<string>
+     */
+    private const WATCHED_ATTRIBUTES = ['name', 'kind', 'actor', 'intent', 'outcome', 'description', 'notes'];
+
+    public function __construct(private ApprovalService $approvals) {}
+
+    public function assignInitialPosition(Story $story): void
+    {
+        if (! empty($story->position)) {
+            return;
+        }
+
+        $max = Story::query()
+            ->where('feature_id', $story->feature_id)
+            ->max('position') ?? 0;
+
+        $story->position = $max + 1;
+    }
+
+    public function bumpRevisionForWatchedChanges(Story $story): void
+    {
+        if ($story->isDirty('revision')) {
+            return;
+        }
+
+        if (! collect(self::WATCHED_ATTRIBUTES)->contains(fn (string $key) => $story->isDirty($key))) {
+            return;
+        }
+
+        $story->revision = ($story->revision ?? 1) + 1;
+    }
+
+    /**
+     * @param  callable(callable(): void): void  $withoutRevisionBump
+     */
+    public function handleRevisionChanged(Story $story, callable $withoutRevisionBump): void
+    {
+        if (! $story->wasChanged('revision')) {
+            return;
+        }
+
+        $story->currentPlan()->first()?->reopenForApproval();
+
+        if (in_array($story->status, [StoryStatus::Draft, StoryStatus::Rejected, StoryStatus::Done, StoryStatus::Cancelled], true)) {
+            return;
+        }
+
+        $withoutRevisionBump(fn () => $this->approvals->recompute($story));
+    }
+}

--- a/app/Services/Stories/StoryRevisionLifecycle.php
+++ b/app/Services/Stories/StoryRevisionLifecycle.php
@@ -3,8 +3,10 @@
 namespace App\Services\Stories;
 
 use App\Enums\StoryStatus;
+use App\Models\Feature;
 use App\Models\Story;
 use App\Services\ApprovalService;
+use Illuminate\Support\Facades\DB;
 
 class StoryRevisionLifecycle
 {
@@ -21,11 +23,18 @@ class StoryRevisionLifecycle
             return;
         }
 
-        $max = Story::query()
-            ->where('feature_id', $story->feature_id)
-            ->max('position') ?? 0;
+        $story->position = DB::transaction(function () use ($story): int {
+            $feature = Feature::query()
+                ->whereKey($story->feature_id)
+                ->lockForUpdate()
+                ->firstOrFail(['id', 'next_story_position']);
 
-        $story->position = $max + 1;
+            $position = (int) $feature->next_story_position;
+
+            $feature->forceFill(['next_story_position' => $position + 1])->save();
+
+            return $position;
+        });
     }
 
     public function bumpRevisionForWatchedChanges(Story $story): void

--- a/database/migrations/2026_05_04_094500_add_next_story_position_to_features_table.php
+++ b/database/migrations/2026_05_04_094500_add_next_story_position_to_features_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('features', function (Blueprint $table) {
+            $table->unsignedInteger('next_story_position')->default(1)->after('project_id');
+        });
+
+        DB::table('features')
+            ->leftJoin('stories', 'stories.feature_id', '=', 'features.id')
+            ->groupBy('features.id')
+            ->select('features.id', DB::raw('COALESCE(MAX(stories.position), 0) + 1 as next_position'))
+            ->orderBy('features.id')
+            ->get()
+            ->each(function ($feature) {
+                DB::table('features')
+                    ->where('id', $feature->id)
+                    ->update(['next_story_position' => $feature->next_position]);
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('features', function (Blueprint $table) {
+            $table->dropColumn('next_story_position');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add `StoryRevisionLifecycle` for initial positioning, watched-field revision bumps, current-plan reopening, and approval recompute after revision changes
- keep Eloquent model events as the trigger point while moving the lifecycle rules out of `Story`
- expose `Story::withoutRevisionBump()` so suppression is a named operation reused by `silentlyForceFill()` and lifecycle recompute
- reserve new Story positions from a Feature-level counter under row lock instead of deriving `max(position) + 1` during concurrent creates

## Validation
- php artisan test --compact tests/Feature/FeatureShowTest.php tests/Feature/TaskGenerationTest.php tests/Feature/RunningHypothesisPlanTest.php
- vendor/bin/pint --dirty --test
- composer test