### PR TITLE
Centralize story content revision resets

### DIFF
--- a/app/Models/AcceptanceCriterion.php
+++ b/app/Models/AcceptanceCriterion.php
@@ -2,9 +2,8 @@
 
 namespace App\Models;
 
-use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
-use App\Services\ApprovalService;
+use App\Services\Stories\StoryRevisionLifecycle;
 use Database\Factories\AcceptanceCriterionFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -32,18 +31,7 @@ class AcceptanceCriterion extends Model
                 return;
             }
 
-            $story->silentlyForceFill([
-                'status' => $story->status === StoryStatus::Draft
-                    ? StoryStatus::Draft->value
-                    : StoryStatus::PendingApproval->value,
-                'revision' => ($story->revision ?? 1) + 1,
-            ]);
-
-            if ($story->currentPlan) {
-                $story->currentPlan->reopenForApproval();
-            }
-
-            app(ApprovalService::class)->recompute($story->fresh());
+            app(StoryRevisionLifecycle::class)->recordContentArtifactChanged($story);
         };
 
         static::created($reopen);

--- a/app/Models/Scenario.php
+++ b/app/Models/Scenario.php
@@ -2,8 +2,7 @@
 
 namespace App\Models;
 
-use App\Enums\StoryStatus;
-use App\Services\ApprovalService;
+use App\Services\Stories\StoryRevisionLifecycle;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -23,18 +22,7 @@ class Scenario extends Model
                 return;
             }
 
-            $story->silentlyForceFill([
-                'status' => $story->status === StoryStatus::Draft
-                    ? StoryStatus::Draft->value
-                    : StoryStatus::PendingApproval->value,
-                'revision' => ($story->revision ?? 1) + 1,
-            ]);
-
-            if ($story->currentPlan) {
-                $story->currentPlan->reopenForApproval();
-            }
-
-            app(ApprovalService::class)->recompute($story->fresh());
+            app(StoryRevisionLifecycle::class)->recordContentArtifactChanged($story);
         };
 
         static::created($reopen);

--- a/app/Services/Stories/StoryRevisionLifecycle.php
+++ b/app/Services/Stories/StoryRevisionLifecycle.php
@@ -50,6 +50,22 @@ class StoryRevisionLifecycle
         $story->revision = ($story->revision ?? 1) + 1;
     }
 
+    public function recordContentArtifactChanged(Story $story): void
+    {
+        Story::withoutRevisionBump(function () use ($story): void {
+            $story->forceFill([
+                'status' => $story->status === StoryStatus::Draft
+                    ? StoryStatus::Draft
+                    : StoryStatus::PendingApproval,
+                'revision' => ($story->revision ?? 1) + 1,
+            ])->save();
+        });
+
+        $story->currentPlan()->first()?->reopenForApproval();
+
+        $this->approvals->recompute($story->fresh());
+    }
+
     /**
      * @param  callable(callable(): void): void  $withoutRevisionBump
      */


### PR DESCRIPTION
## Summary
- move AcceptanceCriterion and Scenario revision-reset side effects into `StoryRevisionLifecycle`
- keep child model events as triggers while centralizing Story status, revision, current-plan reopening, and approval recompute semantics
- remove duplicated approval lifecycle imports and closures from product artifact models

## Validation
- php artisan test --compact tests/Feature/ApprovalTest.php tests/Feature/StoryShowPageTest.php tests/Feature/TaskGenerationTest.php tests/Feature/RunningHypothesisPlanTest.php
- vendor/bin/pint --dirty --test
- composer test