### PR TITLE
Extract plan approval lifecycle

### DIFF
--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use App\Enums\PlanSource;
 use App\Enums\PlanStatus;
-use App\Services\ApprovalService;
+use App\Services\Plans\PlanApprovalLifecycle;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -53,33 +53,11 @@ class Plan extends Model
 
     public function submitForApproval(): void
     {
-        if ($this->status === PlanStatus::Rejected) {
-            throw new \RuntimeException('Cannot submit a rejected plan.');
-        }
-        if ($this->tasks()->count() === 0) {
-            throw new \RuntimeException('Add at least one task before submitting a plan.');
-        }
-
-        $this->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
-        app(ApprovalService::class)->recomputePlan($this->fresh());
+        app(PlanApprovalLifecycle::class)->submit($this);
     }
 
     public function reopenForApproval(): void
     {
-        $nextStatus = match ($this->status) {
-            PlanStatus::Draft => PlanStatus::Draft,
-            PlanStatus::Superseded => PlanStatus::Superseded,
-            PlanStatus::Done => PlanStatus::Done,
-            default => PlanStatus::PendingApproval,
-        };
-
-        $this->forceFill([
-            'revision' => ($this->revision ?? 1) + 1,
-            'status' => $nextStatus->value,
-        ])->save();
-
-        if ($nextStatus !== PlanStatus::Draft && $nextStatus !== PlanStatus::Superseded && $nextStatus !== PlanStatus::Done) {
-            app(ApprovalService::class)->recomputePlan($this->fresh());
-        }
+        app(PlanApprovalLifecycle::class)->reopen($this);
     }
 }

--- a/app/Services/Plans/PlanApprovalLifecycle.php
+++ b/app/Services/Plans/PlanApprovalLifecycle.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services\Plans;
+
+use App\Enums\PlanStatus;
+use App\Models\Plan;
+use App\Services\ApprovalService;
+use RuntimeException;
+
+class PlanApprovalLifecycle
+{
+    public function __construct(private ApprovalService $approvals) {}
+
+    public function submit(Plan $plan): void
+    {
+        if ($plan->status === PlanStatus::Rejected) {
+            throw new RuntimeException('Cannot submit a rejected plan.');
+        }
+
+        if (! $plan->tasks()->exists()) {
+            throw new RuntimeException('Add at least one task before submitting a plan.');
+        }
+
+        $plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
+
+        $this->approvals->recomputePlan($plan->fresh());
+    }
+
+    public function reopen(Plan $plan): void
+    {
+        $nextStatus = match ($plan->status) {
+            PlanStatus::Draft => PlanStatus::Draft,
+            PlanStatus::Superseded => PlanStatus::Superseded,
+            PlanStatus::Done => PlanStatus::Done,
+            default => PlanStatus::PendingApproval,
+        };
+
+        $plan->forceFill([
+            'revision' => ($plan->revision ?? 1) + 1,
+            'status' => $nextStatus->value,
+        ])->save();
+
+        if ($nextStatus === PlanStatus::Draft || $nextStatus === PlanStatus::Superseded || $nextStatus === PlanStatus::Done) {
+            return;
+        }
+
+        $this->approvals->recomputePlan($plan->fresh());
+    }
+}


### PR DESCRIPTION
## Summary
- add `PlanApprovalLifecycle` to own Plan submission and reopen-for-approval transitions
- keep `Plan::submitForApproval()` and `Plan::reopenForApproval()` as model-facing delegates
- use an existence check for the plan task submission guard instead of counting rows

## Validation
- php artisan test --compact tests/Feature/PlanApprovalTest.php tests/Feature/StoryAutoExecutionTest.php tests/Feature/TaskGenerationTest.php
- vendor/bin/pint --dirty --test
- composer test