### PR TITLE
Extract task dependency graph

### DIFF
--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\TaskStatus;
+use App\Services\Tasks\TaskDependencyGraph;
 use Database\Factories\TaskFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -10,7 +11,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use InvalidArgumentException;
 
 /**
  * Actionable work item under a Plan.
@@ -60,49 +60,16 @@ class Task extends Model
 
     public function addDependency(self $other): void
     {
-        if ($this->is($other)) {
-            throw new InvalidArgumentException('A task cannot depend on itself.');
-        }
-
-        if ($this->plan_id !== $other->plan_id) {
-            throw new InvalidArgumentException('Task dependencies must live in the same plan.');
-        }
-
-        if ($other->dependsOnTransitively($this)) {
-            throw new InvalidArgumentException('Adding this dependency would create a cycle.');
-        }
-
-        $this->dependencies()->syncWithoutDetaching([$other->getKey()]);
+        app(TaskDependencyGraph::class)->addDependency($this, $other);
     }
 
     public function dependsOnTransitively(self $candidate): bool
     {
-        $visited = [];
-        $stack = [$this->getKey()];
-
-        while ($stack !== []) {
-            $id = array_pop($stack);
-            if (isset($visited[$id])) {
-                continue;
-            }
-            $visited[$id] = true;
-
-            $deps = self::find($id)?->dependencies()->pluck('tasks.id')->all() ?? [];
-            foreach ($deps as $depId) {
-                if ($depId === $candidate->getKey()) {
-                    return true;
-                }
-                $stack[] = $depId;
-            }
-        }
-
-        return false;
+        return app(TaskDependencyGraph::class)->dependsOnTransitively($this, $candidate);
     }
 
     public function isReady(): bool
     {
-        return $this->dependencies()
-            ->where('status', '!=', TaskStatus::Done->value)
-            ->doesntExist();
+        return app(TaskDependencyGraph::class)->isReady($this);
     }
 }

--- a/app/Services/Tasks/TaskDependencyGraph.php
+++ b/app/Services/Tasks/TaskDependencyGraph.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services\Tasks;
+
+use App\Enums\TaskStatus;
+use App\Models\Task;
+use InvalidArgumentException;
+
+class TaskDependencyGraph
+{
+    public function addDependency(Task $task, Task $dependency): void
+    {
+        if ($task->is($dependency)) {
+            throw new InvalidArgumentException('A task cannot depend on itself.');
+        }
+
+        if ((int) $task->plan_id !== (int) $dependency->plan_id) {
+            throw new InvalidArgumentException('Task dependencies must live in the same plan.');
+        }
+
+        if ($this->dependsOnTransitively($dependency, $task)) {
+            throw new InvalidArgumentException('Adding this dependency would create a cycle.');
+        }
+
+        $task->dependencies()->syncWithoutDetaching([$dependency->getKey()]);
+    }
+
+    public function dependsOnTransitively(Task $task, Task $candidate): bool
+    {
+        $visited = [];
+        $stack = [$task->getKey()];
+
+        while ($stack !== []) {
+            $id = array_pop($stack);
+            if (isset($visited[$id])) {
+                continue;
+            }
+            $visited[$id] = true;
+
+            $deps = Task::find($id)?->dependencies()->pluck('tasks.id')->all() ?? [];
+            foreach ($deps as $depId) {
+                if ($depId === $candidate->getKey()) {
+                    return true;
+                }
+                $stack[] = $depId;
+            }
+        }
+
+        return false;
+    }
+
+    public function isReady(Task $task): bool
+    {
+        return $task->dependencies()
+            ->where('status', '!=', TaskStatus::Done->value)
+            ->doesntExist();
+    }
+}


### PR DESCRIPTION
## Summary
- add `TaskDependencyGraph` to own Task dependency invariants and readiness checks
- keep `Task::addDependency()`, `Task::dependsOnTransitively()`, and `Task::isReady()` as model-facing delegates
- align Task dependency architecture with the Story dependency graph extraction

## Validation
- php artisan test --compact tests/Feature/DependenciesTest.php tests/Feature/TaskDependencyConstraintTest.php tests/Feature/SubtaskOrderingTest.php tests/Feature/SubtaskExecutionTest.php
- vendor/bin/pint --dirty --test
- composer test