### PR TITLE
Route task dependency updates through graph

### DIFF
--- a/app/Mcp/Tools/UpdateTaskTool.php
+++ b/app/Mcp/Tools/UpdateTaskTool.php
@@ -5,8 +5,10 @@ namespace App\Mcp\Tools;
 use App\Enums\TaskStatus;
 use App\Mcp\Concerns\ResolvesProjectAccess;
 use App\Models\Task;
+use App\Services\Tasks\TaskDependencyGraph;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -25,7 +27,7 @@ class UpdateTaskTool extends Tool
     /**
      * Handle the MCP tool invocation.
      */
-    public function handle(Request $request): Response
+    public function handle(Request $request, TaskDependencyGraph $dependencies): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -54,64 +56,65 @@ class UpdateTaskTool extends Tool
 
         $structuralChange = false;
 
-        DB::transaction(function () use ($task, $validated, &$structuralChange) {
-            $updates = [];
+        try {
+            DB::transaction(function () use ($task, $validated, $dependencies, &$structuralChange) {
+                $updates = [];
 
-            if (array_key_exists('name', $validated) && $validated['name'] !== null) {
-                $updates['name'] = $validated['name'];
-                $structuralChange = true;
-            }
-            if (array_key_exists('description', $validated)) {
-                $updates['description'] = $validated['description'];
-                $structuralChange = true;
-            }
-            if (array_key_exists('status', $validated) && $validated['status'] !== null) {
-                $status = TaskStatus::tryFrom($validated['status']);
-                if ($status === null) {
-                    throw new \RuntimeException("Unknown status '{$validated['status']}'.");
+                if (array_key_exists('name', $validated) && $validated['name'] !== null) {
+                    $updates['name'] = $validated['name'];
+                    $structuralChange = true;
                 }
-                $updates['status'] = $status->value;
-            }
-            if (array_key_exists('acceptance_criterion_id', $validated)) {
-                $acId = $validated['acceptance_criterion_id'];
-                if ($acId !== null && ! $task->plan->story->acceptanceCriteria->contains('id', $acId)) {
-                    throw new \RuntimeException("acceptance_criterion_id {$acId} does not belong to this story.");
+                if (array_key_exists('description', $validated)) {
+                    $updates['description'] = $validated['description'];
+                    $structuralChange = true;
                 }
-                $updates['acceptance_criterion_id'] = $acId;
-                $structuralChange = true;
-            }
-            if (array_key_exists('scenario_id', $validated)) {
-                $scenarioId = $validated['scenario_id'];
-                if ($scenarioId !== null && ! $task->plan->story->scenarios->contains('id', $scenarioId)) {
-                    throw new \RuntimeException("scenario_id {$scenarioId} does not belong to this story.");
-                }
-                $updates['scenario_id'] = $scenarioId;
-                $structuralChange = true;
-            }
-
-            if (! empty($updates)) {
-                $task->forceFill($updates)->save();
-            }
-
-            if (array_key_exists('depends_on_positions', $validated) && is_array($validated['depends_on_positions'])) {
-                $byPosition = Task::query()
-                    ->where('plan_id', $task->plan_id)
-                    ->get(['id', 'position'])
-                    ->keyBy('position');
-                $depIds = [];
-                foreach ($validated['depends_on_positions'] as $pos) {
-                    if ((int) $pos === (int) $task->position) {
-                        continue;
+                if (array_key_exists('status', $validated) && $validated['status'] !== null) {
+                    $status = TaskStatus::tryFrom($validated['status']);
+                    if ($status === null) {
+                        throw new \RuntimeException("Unknown status '{$validated['status']}'.");
                     }
-                    $dep = $byPosition[$pos] ?? null;
-                    if ($dep) {
-                        $depIds[] = $dep->id;
-                    }
+                    $updates['status'] = $status->value;
                 }
-                $task->dependencies()->sync($depIds);
-                $structuralChange = true;
-            }
-        });
+                if (array_key_exists('acceptance_criterion_id', $validated)) {
+                    $acId = $validated['acceptance_criterion_id'];
+                    if ($acId !== null && ! $task->plan->story->acceptanceCriteria->contains('id', $acId)) {
+                        throw new \RuntimeException("acceptance_criterion_id {$acId} does not belong to this story.");
+                    }
+                    $updates['acceptance_criterion_id'] = $acId;
+                    $structuralChange = true;
+                }
+                if (array_key_exists('scenario_id', $validated)) {
+                    $scenarioId = $validated['scenario_id'];
+                    if ($scenarioId !== null && ! $task->plan->story->scenarios->contains('id', $scenarioId)) {
+                        throw new \RuntimeException("scenario_id {$scenarioId} does not belong to this story.");
+                    }
+                    $updates['scenario_id'] = $scenarioId;
+                    $structuralChange = true;
+                }
+
+                if (! empty($updates)) {
+                    $task->forceFill($updates)->save();
+                }
+
+                if (array_key_exists('depends_on_positions', $validated) && is_array($validated['depends_on_positions'])) {
+                    $byPosition = Task::query()
+                        ->where('plan_id', $task->plan_id)
+                        ->get(['id', 'plan_id', 'position'])
+                        ->keyBy('position');
+                    $replacements = [];
+                    foreach ($validated['depends_on_positions'] as $pos) {
+                        $dep = $byPosition[$pos] ?? null;
+                        if ($dep) {
+                            $replacements[] = $dep;
+                        }
+                    }
+                    $dependencies->replaceDependencies($task, $replacements);
+                    $structuralChange = true;
+                }
+            });
+        } catch (InvalidArgumentException $e) {
+            return Response::error($e->getMessage());
+        }
 
         if ($structuralChange && $task->plan) {
             $task->plan->reopenForApproval();

--- a/app/Services/Tasks/TaskDependencyGraph.php
+++ b/app/Services/Tasks/TaskDependencyGraph.php
@@ -10,6 +10,28 @@ class TaskDependencyGraph
 {
     public function addDependency(Task $task, Task $dependency): void
     {
+        $this->ensureCanDependOn($task, $dependency);
+
+        $task->dependencies()->syncWithoutDetaching([$dependency->getKey()]);
+    }
+
+    /**
+     * @param  iterable<Task>  $dependencies
+     */
+    public function replaceDependencies(Task $task, iterable $dependencies): void
+    {
+        $ids = [];
+
+        foreach ($dependencies as $dependency) {
+            $this->ensureCanDependOn($task, $dependency);
+            $ids[] = $dependency->getKey();
+        }
+
+        $task->dependencies()->sync(array_values(array_unique($ids)));
+    }
+
+    private function ensureCanDependOn(Task $task, Task $dependency): void
+    {
         if ($task->is($dependency)) {
             throw new InvalidArgumentException('A task cannot depend on itself.');
         }
@@ -21,8 +43,6 @@ class TaskDependencyGraph
         if ($this->dependsOnTransitively($dependency, $task)) {
             throw new InvalidArgumentException('Adding this dependency would create a cycle.');
         }
-
-        $task->dependencies()->syncWithoutDetaching([$dependency->getKey()]);
     }
 
     public function dependsOnTransitively(Task $task, Task $candidate): bool

--- a/tests/Feature/DependenciesTest.php
+++ b/tests/Feature/DependenciesTest.php
@@ -3,6 +3,7 @@
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Mcp\Tools\AddStoryDependencyTool;
+use App\Mcp\Tools\UpdateTaskTool;
 use App\Models\Feature;
 use App\Models\Project;
 use App\Models\Story;
@@ -11,6 +12,7 @@ use App\Models\Team;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Stories\StoryDependencyGraph;
+use App\Services\Tasks\TaskDependencyGraph;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Mcp\Request;
 
@@ -156,6 +158,30 @@ test('add story dependency tool rejects cycles', function () {
         'story_id' => $a->id,
         'depends_on_story_id' => $b->id,
     ]), app(StoryDependencyGraph::class));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('cycle')
+        ->and($a->fresh()->dependencies()->whereKey($b->id)->exists())->toBeFalse();
+});
+
+test('update task tool rejects dependency cycles', function () {
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $a = Task::factory()->forCurrentPlanOf($story)->create(['position' => 1]);
+    $b = Task::factory()->for($a->plan)->create(['position' => 2]);
+
+    $b->addDependency($a);
+    $this->actingAs($user);
+
+    $response = app(UpdateTaskTool::class)->handle(new Request([
+        'task_id' => $a->id,
+        'depends_on_positions' => [2],
+    ]), app(TaskDependencyGraph::class));
 
     expect($response->isError())->toBeTrue()
         ->and((string) $response->content())->toContain('cycle')


### PR DESCRIPTION
## Summary
- add `TaskDependencyGraph::replaceDependencies()` so replacement writes use the same invariant checks as single dependency adds
- route `UpdateTaskTool` dependency replacement through `TaskDependencyGraph` instead of syncing the pivot directly
- add an MCP regression test proving dependency replacement rejects cycles

## Validation
- php artisan test --compact tests/Feature/DependenciesTest.php tests/Feature/TaskDependencyConstraintTest.php
- vendor/bin/pint --dirty --test
- composer test