### PR TITLE
Extract current plan selector

### DIFF
--- a/app/Mcp/Tools/CreatePlanTool.php
+++ b/app/Mcp/Tools/CreatePlanTool.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Tools;
 use App\Enums\PlanSource;
 use App\Enums\PlanStatus;
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Plans\CurrentPlanSelector;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -18,7 +19,7 @@ class CreatePlanTool extends Tool
 
     protected string $name = 'create-plan';
 
-    public function handle(Request $request): Response
+    public function handle(Request $request, CurrentPlanSelector $currentPlans): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -59,7 +60,7 @@ class CreatePlanTool extends Tool
         ]);
 
         if (($validated['set_current'] ?? false) === true) {
-            $story->forceFill(['current_plan_id' => $plan->id])->save();
+            $currentPlans->setCurrent($story, $plan);
         }
 
         return Response::json([

--- a/app/Mcp/Tools/SetCurrentPlanTool.php
+++ b/app/Mcp/Tools/SetCurrentPlanTool.php
@@ -3,7 +3,9 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Plans\CurrentPlanSelector;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use InvalidArgumentException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -16,7 +18,7 @@ class SetCurrentPlanTool extends Tool
 
     protected string $name = 'set-current-plan';
 
-    public function handle(Request $request): Response
+    public function handle(Request $request, CurrentPlanSelector $currentPlans): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -38,11 +40,12 @@ class SetCurrentPlanTool extends Tool
             return $plan;
         }
 
-        if ((int) $plan->story_id !== (int) $story->id) {
-            return Response::error('Plan does not belong to this story.');
+        try {
+            $currentPlans->setCurrent($story, $plan);
+        } catch (InvalidArgumentException $e) {
+            return Response::error($e->getMessage());
         }
 
-        $story->forceFill(['current_plan_id' => $plan->id])->save();
         $story->refresh();
 
         return Response::json([

--- a/app/Services/Plans/CurrentPlanSelector.php
+++ b/app/Services/Plans/CurrentPlanSelector.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Plans;
+
+use App\Models\Plan;
+use App\Models\Story;
+use InvalidArgumentException;
+
+class CurrentPlanSelector
+{
+    public function setCurrent(Story $story, Plan $plan): void
+    {
+        if ((int) $plan->story_id !== (int) $story->getKey()) {
+            throw new InvalidArgumentException('Plan does not belong to this story.');
+        }
+
+        $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
+    }
+}

--- a/tests/Feature/CurrentPlanSelectionTest.php
+++ b/tests/Feature/CurrentPlanSelectionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Mcp\Tools\CreatePlanTool;
+use App\Mcp\Tools\SetCurrentPlanTool;
+use App\Models\Feature;
+use App\Models\Plan;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\Plans\CurrentPlanSelector;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+
+uses(RefreshDatabase::class);
+
+function currentPlanScene(): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+
+    return compact('user', 'story');
+}
+
+test('create plan tool can set the new plan as current', function () {
+    ['user' => $user, 'story' => $story] = currentPlanScene();
+    $this->actingAs($user);
+
+    $response = app(CreatePlanTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'name' => 'Implementation option A',
+        'set_current' => true,
+    ]), app(CurrentPlanSelector::class));
+
+    $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($response->isError())->toBeFalse()
+        ->and($payload['is_current'])->toBeTrue()
+        ->and($story->fresh()->current_plan_id)->toBe($payload['id']);
+});
+
+test('set current plan tool rejects a plan from another story', function () {
+    ['user' => $user, 'story' => $story] = currentPlanScene();
+    $otherStory = Story::factory()->for($story->feature)->create();
+    $otherPlan = Plan::factory()->for($otherStory)->create();
+    $this->actingAs($user);
+
+    $response = app(SetCurrentPlanTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'plan_id' => $otherPlan->getKey(),
+    ]), app(CurrentPlanSelector::class));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('Plan does not belong to this story')
+        ->and($story->fresh()->current_plan_id)->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add `CurrentPlanSelector` to own current-plan assignment and same-story validation
- route `create-plan` with `set_current` and `set-current-plan` through the selector instead of writing `current_plan_id` directly
- add MCP coverage for creating a current plan and rejecting a plan from another story

## Validation
- php artisan test --compact tests/Feature/CurrentPlanSelectionTest.php tests/Feature/CurrentPlanProjectionTest.php tests/Feature/PlanningArchitectureConformanceTest.php
- vendor/bin/pint --dirty --test
- composer test