### PR TITLE
Centralize acceptance criteria writes

### DIFF
--- a/app/Mcp/Tools/AddAcceptanceCriterionTool.php
+++ b/app/Mcp/Tools/AddAcceptanceCriterionTool.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Stories\AcceptanceCriteriaWriter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -22,7 +23,7 @@ class AddAcceptanceCriterionTool extends Tool
     /**
      * Handle the MCP tool invocation.
      */
-    public function handle(Request $request): Response
+    public function handle(Request $request, AcceptanceCriteriaWriter $criteria): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -45,13 +46,7 @@ class AddAcceptanceCriterionTool extends Tool
             return $story;
         }
 
-        $position = $validated['position']
-            ?? (int) ($story->acceptanceCriteria()->max('position') ?? 0) + 1;
-
-        $ac = $story->acceptanceCriteria()->create([
-            'statement' => $statement,
-            'position' => $position,
-        ]);
+        $ac = $criteria->add($story, $statement, $validated['position'] ?? null);
 
         return Response::json([
             'id' => $ac->id,

--- a/app/Mcp/Tools/AddAcceptanceCriterionTool.php
+++ b/app/Mcp/Tools/AddAcceptanceCriterionTool.php
@@ -33,7 +33,7 @@ class AddAcceptanceCriterionTool extends Tool
         $validated = $request->validate([
             'story_id' => ['required', 'integer'],
             'statement' => ['required', 'string', 'max:1000'],
-            'position' => ['nullable', 'integer'],
+            'position' => ['nullable', 'integer', 'min:1'],
         ]);
 
         $statement = trim($validated['statement']);
@@ -65,7 +65,7 @@ class AddAcceptanceCriterionTool extends Tool
         return [
             'story_id' => $schema->integer()->description('Story to add the criterion to.')->required(),
             'statement' => $schema->string()->description('Observable behaviour the story must satisfy. Use one atomic rule statement, not a full Given/When/Then scenario.')->required(),
-            'position' => $schema->integer()->description('Position in the list. Defaults to last + 1.'),
+            'position' => $schema->integer()->description('1-based position in the list. Defaults to last + 1.'),
         ];
     }
 }

--- a/app/Mcp/Tools/UpdateStoryTool.php
+++ b/app/Mcp/Tools/UpdateStoryTool.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Tools;
 use App\Enums\StoryKind;
 use App\Enums\StoryStatus;
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Stories\AcceptanceCriteriaWriter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\DB;
 use Laravel\Mcp\Request;
@@ -25,7 +26,7 @@ class UpdateStoryTool extends Tool
     /**
      * Handle the MCP tool invocation.
      */
-    public function handle(Request $request): Response
+    public function handle(Request $request, AcceptanceCriteriaWriter $criteria): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -68,21 +69,17 @@ class UpdateStoryTool extends Tool
             return Response::error('Provide at least one of: name, kind, actor, intent, outcome, description, notes, status, acceptance_criteria.');
         }
 
-        DB::transaction(function () use ($story, $changes, $validated, $hasCriteriaUpdate) {
+        DB::transaction(function () use ($story, $changes, $validated, $hasCriteriaUpdate, $criteria) {
             if ($changes) {
                 $story->fill($changes)->save();
             }
 
             if ($hasCriteriaUpdate) {
-                $story->acceptanceCriteria()->delete();
-                foreach ($validated['acceptance_criteria'] as $i => $criterion) {
-                    $story->acceptanceCriteria()->create([
-                        'statement' => $criterion,
-                        'position' => $i + 1,
-                    ]);
-                }
+                $criteria->replace($story, $validated['acceptance_criteria']);
             }
         });
+
+        $story->refresh();
 
         return Response::json([
             'id' => $story->id,

--- a/app/Mcp/Tools/UpdateStoryTool.php
+++ b/app/Mcp/Tools/UpdateStoryTool.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Tools;
 use App\Enums\StoryKind;
 use App\Enums\StoryStatus;
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Models\Story;
 use App\Services\Stories\AcceptanceCriteriaWriter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\DB;
@@ -71,7 +72,13 @@ class UpdateStoryTool extends Tool
 
         DB::transaction(function () use ($story, $changes, $validated, $hasCriteriaUpdate, $criteria) {
             if ($changes) {
-                $story->fill($changes)->save();
+                if ($hasCriteriaUpdate) {
+                    Story::withoutRevisionBump(function () use ($story, $changes): void {
+                        $story->fill($changes)->save();
+                    });
+                } else {
+                    $story->fill($changes)->save();
+                }
             }
 
             if ($hasCriteriaUpdate) {

--- a/app/Services/Stories/AcceptanceCriteriaWriter.php
+++ b/app/Services/Stories/AcceptanceCriteriaWriter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Models\AcceptanceCriterion;
+use App\Models\Story;
+use Illuminate\Support\Facades\DB;
+
+class AcceptanceCriteriaWriter
+{
+    public function __construct(private StoryRevisionLifecycle $revisions) {}
+
+    public function add(Story $story, string $statement, ?int $position = null): AcceptanceCriterion
+    {
+        return DB::transaction(function () use ($story, $statement, $position): AcceptanceCriterion {
+            $criterion = AcceptanceCriterion::withoutEvents(function () use ($story, $statement, $position): AcceptanceCriterion {
+                return $story->acceptanceCriteria()->create([
+                    'statement' => $statement,
+                    'position' => $position ?? ((int) ($story->acceptanceCriteria()->max('position') ?? 0) + 1),
+                ]);
+            });
+
+            $this->revisions->recordContentArtifactChanged($story);
+
+            return $criterion;
+        });
+    }
+
+    /**
+     * @param  list<string>  $statements
+     */
+    public function replace(Story $story, array $statements): void
+    {
+        DB::transaction(function () use ($story, $statements): void {
+            AcceptanceCriterion::withoutEvents(function () use ($story, $statements): void {
+                $story->acceptanceCriteria()->delete();
+
+                foreach ($statements as $i => $statement) {
+                    $story->acceptanceCriteria()->create([
+                        'statement' => $statement,
+                        'position' => $i + 1,
+                    ]);
+                }
+            });
+
+            $this->revisions->recordContentArtifactChanged($story);
+        });
+    }
+}

--- a/tests/Feature/StoryAcceptanceCriteriaWriterTest.php
+++ b/tests/Feature/StoryAcceptanceCriteriaWriterTest.php
@@ -4,6 +4,7 @@ use App\Enums\StoryStatus;
 use App\Mcp\Tools\AddAcceptanceCriterionTool;
 use App\Mcp\Tools\UpdateStoryTool;
 use App\Models\AcceptanceCriterion;
+use App\Models\ApprovalPolicy;
 use App\Models\Feature;
 use App\Models\Project;
 use App\Models\Story;
@@ -62,4 +63,34 @@ test('update story tool replaces acceptance criteria as one story content revisi
         ->and($story->fresh()->revision)->toBe(2)
         ->and($story->acceptanceCriteria()->orderBy('position')->pluck('statement')->all())
         ->toBe(['New one', 'New two', 'New three']);
+});
+
+test('update story tool combines story fields and acceptance criteria into one story content revision', function () {
+    ['user' => $user, 'story' => $story] = storyCriteriaScene();
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_PROJECT,
+        'scope_id' => $story->feature->project_id,
+        'required_approvals' => 1,
+    ]);
+
+    AcceptanceCriterion::withoutEvents(function () use ($story): void {
+        AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'Old one']);
+    });
+
+    $this->actingAs($user);
+
+    $response = app(UpdateStoryTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'name' => 'Renamed story',
+        'acceptance_criteria' => ['New one'],
+    ]), app(AcceptanceCriteriaWriter::class));
+
+    $fresh = $story->fresh();
+
+    expect($response->isError())->toBeFalse()
+        ->and($fresh->name)->toBe('Renamed story')
+        ->and($fresh->revision)->toBe(2)
+        ->and($fresh->status)->toBe(StoryStatus::PendingApproval)
+        ->and($fresh->acceptanceCriteria()->orderBy('position')->pluck('statement')->all())
+        ->toBe(['New one']);
 });

--- a/tests/Feature/StoryAcceptanceCriteriaWriterTest.php
+++ b/tests/Feature/StoryAcceptanceCriteriaWriterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Enums\StoryStatus;
+use App\Mcp\Tools\AddAcceptanceCriterionTool;
+use App\Mcp\Tools\UpdateStoryTool;
+use App\Models\AcceptanceCriterion;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\Stories\AcceptanceCriteriaWriter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+
+uses(RefreshDatabase::class);
+
+function storyCriteriaScene(): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved, 'revision' => 1]);
+
+    return compact('user', 'story');
+}
+
+test('add acceptance criterion tool records one story content revision', function () {
+    ['user' => $user, 'story' => $story] = storyCriteriaScene();
+    $this->actingAs($user);
+
+    $response = app(AddAcceptanceCriterionTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'statement' => 'Exports include a header row.',
+    ]), app(AcceptanceCriteriaWriter::class));
+
+    expect($response->isError())->toBeFalse()
+        ->and($story->fresh()->revision)->toBe(2)
+        ->and($story->acceptanceCriteria()->count())->toBe(1);
+});
+
+test('update story tool replaces acceptance criteria as one story content revision', function () {
+    ['user' => $user, 'story' => $story] = storyCriteriaScene();
+
+    AcceptanceCriterion::withoutEvents(function () use ($story): void {
+        AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'Old one']);
+        AcceptanceCriterion::factory()->for($story)->create(['position' => 2, 'statement' => 'Old two']);
+    });
+
+    $this->actingAs($user);
+
+    $response = app(UpdateStoryTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'acceptance_criteria' => ['New one', 'New two', 'New three'],
+    ]), app(AcceptanceCriteriaWriter::class));
+
+    expect($response->isError())->toBeFalse()
+        ->and($story->fresh()->revision)->toBe(2)
+        ->and($story->acceptanceCriteria()->orderBy('position')->pluck('statement')->all())
+        ->toBe(['New one', 'New two', 'New three']);
+});


### PR DESCRIPTION
## Summary
- add `AcceptanceCriteriaWriter` to own acceptance criterion add/replace writes and record one Story content revision per logical edit
- route `add-acceptance-criterion` through the writer instead of creating criteria directly
- route `update-story` criteria replacement through the writer and refresh the Story before response serialization
- add MCP coverage for single-revision add and replace behavior

## Validation
- php artisan test --compact tests/Feature/StoryAcceptanceCriteriaWriterTest.php tests/Feature/StorySubmissionGateTest.php tests/Feature/StoryShowPageTest.php
- vendor/bin/pint --dirty --test
- composer test