### PR TITLE
Centralize scenario writes

### DIFF
--- a/app/Mcp/Tools/CreateScenarioTool.php
+++ b/app/Mcp/Tools/CreateScenarioTool.php
@@ -3,7 +3,9 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Stories\ScenarioWriter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use InvalidArgumentException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -16,7 +18,7 @@ class CreateScenarioTool extends Tool
 
     protected string $name = 'create-scenario';
 
-    public function handle(Request $request): Response
+    public function handle(Request $request, ScenarioWriter $scenarios): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -39,23 +41,11 @@ class CreateScenarioTool extends Tool
             return $story;
         }
 
-        $criterionId = $validated['acceptance_criterion_id'] ?? null;
-        if ($criterionId !== null && ! $story->acceptanceCriteria()->whereKey($criterionId)->exists()) {
-            return Response::error("acceptance_criterion_id {$criterionId} does not belong to this story.");
+        try {
+            $scenario = $scenarios->create($story, $validated);
+        } catch (InvalidArgumentException $e) {
+            return Response::error($e->getMessage());
         }
-
-        $position = $validated['position']
-            ?? ((int) $story->scenarios()->max('position') + 1);
-
-        $scenario = $story->scenarios()->create([
-            'acceptance_criterion_id' => $criterionId,
-            'position' => $position,
-            'name' => $validated['name'],
-            'given_text' => $validated['given_text'] ?? null,
-            'when_text' => $validated['when_text'] ?? null,
-            'then_text' => $validated['then_text'] ?? null,
-            'notes' => $validated['notes'] ?? null,
-        ]);
 
         return Response::json([
             'id' => $scenario->id,

--- a/app/Mcp/Tools/UpdateScenarioTool.php
+++ b/app/Mcp/Tools/UpdateScenarioTool.php
@@ -3,7 +3,9 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Stories\ScenarioWriter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use InvalidArgumentException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -16,7 +18,7 @@ class UpdateScenarioTool extends Tool
 
     protected string $name = 'update-scenario';
 
-    public function handle(Request $request): Response
+    public function handle(Request $request, ScenarioWriter $scenarios): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -47,18 +49,19 @@ class UpdateScenarioTool extends Tool
         }
 
         if (array_key_exists('acceptance_criterion_id', $validated)) {
-            $criterionId = $validated['acceptance_criterion_id'];
-            if ($criterionId !== null && ! $scenario->story->acceptanceCriteria()->whereKey($criterionId)->exists()) {
-                return Response::error("acceptance_criterion_id {$criterionId} does not belong to this story.");
-            }
-            $changes['acceptance_criterion_id'] = $criterionId;
+            $changes['acceptance_criterion_id'] = $validated['acceptance_criterion_id'];
         }
 
         if ($changes === []) {
             return Response::error('Provide at least one field to update.');
         }
 
-        $scenario->forceFill($changes)->save();
+        try {
+            $scenarios->update($scenario, $changes);
+        } catch (InvalidArgumentException $e) {
+            return Response::error($e->getMessage());
+        }
+
         $scenario->refresh();
 
         return Response::json([

--- a/app/Services/Stories/ScenarioWriter.php
+++ b/app/Services/Stories/ScenarioWriter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Models\Scenario;
+use App\Models\Story;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+class ScenarioWriter
+{
+    public function __construct(private StoryRevisionLifecycle $revisions) {}
+
+    /**
+     * @param  array{
+     *     acceptance_criterion_id?: int|null,
+     *     position?: int|null,
+     *     name: string,
+     *     given_text?: string|null,
+     *     when_text?: string|null,
+     *     then_text?: string|null,
+     *     notes?: string|null
+     * }  $attributes
+     */
+    public function create(Story $story, array $attributes): Scenario
+    {
+        return DB::transaction(function () use ($story, $attributes): Scenario {
+            $criterionId = $attributes['acceptance_criterion_id'] ?? null;
+            $this->ensureCriterionBelongsToStory($story, $criterionId);
+
+            $scenario = Scenario::withoutEvents(function () use ($story, $attributes, $criterionId): Scenario {
+                return $story->scenarios()->create([
+                    'acceptance_criterion_id' => $criterionId,
+                    'position' => $attributes['position'] ?? ((int) $story->scenarios()->max('position') + 1),
+                    'name' => $attributes['name'],
+                    'given_text' => $attributes['given_text'] ?? null,
+                    'when_text' => $attributes['when_text'] ?? null,
+                    'then_text' => $attributes['then_text'] ?? null,
+                    'notes' => $attributes['notes'] ?? null,
+                ]);
+            });
+
+            $this->revisions->recordContentArtifactChanged($story);
+
+            return $scenario;
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $changes
+     */
+    public function update(Scenario $scenario, array $changes): void
+    {
+        DB::transaction(function () use ($scenario, $changes): void {
+            $story = $scenario->story()->firstOrFail();
+
+            if (array_key_exists('acceptance_criterion_id', $changes)) {
+                $this->ensureCriterionBelongsToStory($story, $changes['acceptance_criterion_id']);
+            }
+
+            Scenario::withoutEvents(function () use ($scenario, $changes): void {
+                $scenario->forceFill($changes)->save();
+            });
+
+            $this->revisions->recordContentArtifactChanged($story);
+        });
+    }
+
+    private function ensureCriterionBelongsToStory(Story $story, mixed $criterionId): void
+    {
+        if ($criterionId === null) {
+            return;
+        }
+
+        if (! $story->acceptanceCriteria()->whereKey($criterionId)->exists()) {
+            throw new InvalidArgumentException("acceptance_criterion_id {$criterionId} does not belong to this story.");
+        }
+    }
+}

--- a/app/Services/Stories/ScenarioWriter.php
+++ b/app/Services/Stories/ScenarioWriter.php
@@ -25,6 +25,7 @@ class ScenarioWriter
     public function create(Story $story, array $attributes): Scenario
     {
         return DB::transaction(function () use ($story, $attributes): Scenario {
+            $story = Story::query()->whereKey($story->getKey())->lockForUpdate()->firstOrFail();
             $criterionId = $attributes['acceptance_criterion_id'] ?? null;
             $this->ensureCriterionBelongsToStory($story, $criterionId);
 
@@ -58,9 +59,21 @@ class ScenarioWriter
                 $this->ensureCriterionBelongsToStory($story, $changes['acceptance_criterion_id']);
             }
 
-            Scenario::withoutEvents(function () use ($scenario, $changes): void {
-                $scenario->forceFill($changes)->save();
+            $changed = Scenario::withoutEvents(function () use ($scenario, $changes): bool {
+                $scenario->forceFill($changes);
+
+                if (! $scenario->isDirty()) {
+                    return false;
+                }
+
+                $scenario->save();
+
+                return true;
             });
+
+            if (! $changed) {
+                return;
+            }
 
             $this->revisions->recordContentArtifactChanged($story);
         });

--- a/tests/Feature/StoryScenarioWriterTest.php
+++ b/tests/Feature/StoryScenarioWriterTest.php
@@ -70,6 +70,46 @@ test('update scenario tool records one story content revision', function () {
         ->and($fresh->scenarios()->sole()->name)->toBe('Updated scenario');
 });
 
+test('update scenario tool does not revise the story for a no-op update', function () {
+    ['user' => $user, 'story' => $story, 'criterion' => $criterion] = scenarioWriterScene();
+    $scenario = Scenario::withoutEvents(fn () => Scenario::factory()->for($story)->create([
+        'acceptance_criterion_id' => $criterion->getKey(),
+        'position' => 1,
+        'name' => 'Existing scenario',
+    ]));
+    $this->actingAs($user);
+
+    $response = app(UpdateScenarioTool::class)->handle(new Request([
+        'scenario_id' => $scenario->getKey(),
+        'name' => 'Existing scenario',
+        'acceptance_criterion_id' => $criterion->getKey(),
+    ]), app(ScenarioWriter::class));
+
+    expect($response->isError())->toBeFalse()
+        ->and($story->fresh()->revision)->toBe(1);
+});
+
+test('update scenario tool rejects acceptance criteria from another story', function () {
+    ['user' => $user, 'story' => $story, 'criterion' => $criterion] = scenarioWriterScene();
+    $scenario = Scenario::withoutEvents(fn () => Scenario::factory()->for($story)->create([
+        'acceptance_criterion_id' => $criterion->getKey(),
+        'position' => 1,
+        'name' => 'Scenario',
+    ]));
+    $otherCriterion = AcceptanceCriterion::factory()->create();
+    $this->actingAs($user);
+
+    $response = app(UpdateScenarioTool::class)->handle(new Request([
+        'scenario_id' => $scenario->getKey(),
+        'acceptance_criterion_id' => $otherCriterion->getKey(),
+    ]), app(ScenarioWriter::class));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('does not belong to this story')
+        ->and($story->fresh()->revision)->toBe(1)
+        ->and($scenario->fresh()->acceptance_criterion_id)->toBe($criterion->getKey());
+});
+
 test('scenario writer rejects acceptance criteria from another story', function () {
     ['user' => $user, 'story' => $story] = scenarioWriterScene();
     $otherCriterion = AcceptanceCriterion::factory()->create();

--- a/tests/Feature/StoryScenarioWriterTest.php
+++ b/tests/Feature/StoryScenarioWriterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Enums\StoryStatus;
+use App\Mcp\Tools\CreateScenarioTool;
+use App\Mcp\Tools\UpdateScenarioTool;
+use App\Models\AcceptanceCriterion;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Scenario;
+use App\Models\Story;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\Stories\ScenarioWriter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+
+uses(RefreshDatabase::class);
+
+function scenarioWriterScene(): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved, 'revision' => 1]);
+    $criterion = AcceptanceCriterion::withoutEvents(
+        fn () => AcceptanceCriterion::factory()->for($story)->create(['position' => 1])
+    );
+
+    return compact('user', 'story', 'criterion');
+}
+
+test('create scenario tool records one story content revision', function () {
+    ['user' => $user, 'story' => $story, 'criterion' => $criterion] = scenarioWriterScene();
+    $this->actingAs($user);
+
+    $response = app(CreateScenarioTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'acceptance_criterion_id' => $criterion->getKey(),
+        'name' => 'CSV export includes headers',
+    ]), app(ScenarioWriter::class));
+
+    expect($response->isError())->toBeFalse()
+        ->and($story->fresh()->revision)->toBe(2)
+        ->and($story->scenarios()->count())->toBe(1);
+});
+
+test('update scenario tool records one story content revision', function () {
+    ['user' => $user, 'story' => $story, 'criterion' => $criterion] = scenarioWriterScene();
+    $scenario = Scenario::withoutEvents(fn () => Scenario::factory()->for($story)->create([
+        'acceptance_criterion_id' => $criterion->getKey(),
+        'position' => 1,
+        'name' => 'Old scenario',
+    ]));
+    $this->actingAs($user);
+
+    $response = app(UpdateScenarioTool::class)->handle(new Request([
+        'scenario_id' => $scenario->getKey(),
+        'name' => 'Updated scenario',
+        'given_text' => 'Given an export exists',
+    ]), app(ScenarioWriter::class));
+
+    $fresh = $story->fresh();
+
+    expect($response->isError())->toBeFalse()
+        ->and($fresh->revision)->toBe(2)
+        ->and($fresh->scenarios()->sole()->name)->toBe('Updated scenario');
+});
+
+test('scenario writer rejects acceptance criteria from another story', function () {
+    ['user' => $user, 'story' => $story] = scenarioWriterScene();
+    $otherCriterion = AcceptanceCriterion::factory()->create();
+    $this->actingAs($user);
+
+    $response = app(CreateScenarioTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'acceptance_criterion_id' => $otherCriterion->getKey(),
+        'name' => 'Wrong criterion',
+    ]), app(ScenarioWriter::class));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('does not belong to this story')
+        ->and($story->fresh()->revision)->toBe(1);
+});


### PR DESCRIPTION
## Summary
- add `ScenarioWriter` to own Scenario create/update writes, acceptance criterion ownership checks, and Story content revision recording
- route `create-scenario` and `update-scenario` through the writer instead of writing Scenario rows directly
- add MCP coverage for one-revision create/update behavior and wrong-story criterion rejection

## Validation
- php artisan test --compact tests/Feature/StoryScenarioWriterTest.php tests/Feature/StoryShowPageTest.php tests/Feature/PlanningArchitectureConformanceTest.php
- vendor/bin/pint --dirty --test
- composer test