### PR TITLE
Centralize story creation

### DIFF
--- a/app/Mcp/Tools/CreateStoryTool.php
+++ b/app/Mcp/Tools/CreateStoryTool.php
@@ -5,8 +5,8 @@ namespace App\Mcp\Tools;
 use App\Enums\StoryKind;
 use App\Enums\StoryStatus;
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Services\Stories\StoryWriter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Illuminate\Support\Facades\DB;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -25,7 +25,7 @@ class CreateStoryTool extends Tool
     /**
      * Handle the MCP tool invocation.
      */
-    public function handle(Request $request): Response
+    public function handle(Request $request, StoryWriter $stories): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -55,29 +55,17 @@ class CreateStoryTool extends Tool
             return $feature;
         }
 
-        $story = DB::transaction(function () use ($feature, $user, $validated) {
-            $story = $feature->stories()->create([
-                'created_by_id' => $user->id,
-                'name' => $validated['name'],
-                'kind' => isset($validated['kind']) ? StoryKind::from($validated['kind']) : StoryKind::UserStory,
-                'actor' => $validated['actor'] ?? null,
-                'intent' => $validated['intent'] ?? null,
-                'outcome' => $validated['outcome'] ?? null,
-                'description' => $validated['description'] ?? null,
-                'notes' => $validated['notes'] ?? null,
-                'status' => isset($validated['status']) ? StoryStatus::from($validated['status']) : StoryStatus::Draft,
-                'revision' => 1,
-            ]);
-
-            foreach (($validated['acceptance_criteria'] ?? []) as $i => $criterion) {
-                $story->acceptanceCriteria()->create([
-                    'statement' => $criterion,
-                    'position' => $i + 1,
-                ]);
-            }
-
-            return $story;
-        });
+        $story = $stories->create($feature, $user, [
+            'name' => $validated['name'],
+            'kind' => isset($validated['kind']) ? StoryKind::from($validated['kind']) : StoryKind::UserStory,
+            'actor' => $validated['actor'] ?? null,
+            'intent' => $validated['intent'] ?? null,
+            'outcome' => $validated['outcome'] ?? null,
+            'description' => $validated['description'] ?? null,
+            'notes' => $validated['notes'] ?? null,
+            'status' => isset($validated['status']) ? StoryStatus::from($validated['status']) : StoryStatus::Draft,
+            'acceptance_criteria' => $validated['acceptance_criteria'] ?? [],
+        ]);
 
         return Response::json([
             'id' => $story->id,

--- a/app/Services/Stories/StoryWriter.php
+++ b/app/Services/Stories/StoryWriter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Enums\StoryKind;
+use App\Enums\StoryStatus;
+use App\Models\AcceptanceCriterion;
+use App\Models\Feature;
+use App\Models\Story;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class StoryWriter
+{
+    /**
+     * @param  array{
+     *     name: string,
+     *     kind?: StoryKind,
+     *     actor?: string|null,
+     *     intent?: string|null,
+     *     outcome?: string|null,
+     *     description?: string|null,
+     *     notes?: string|null,
+     *     status?: StoryStatus,
+     *     acceptance_criteria?: list<string>
+     * }  $attributes
+     */
+    public function create(Feature $feature, User $creator, array $attributes): Story
+    {
+        return DB::transaction(function () use ($feature, $creator, $attributes): Story {
+            $story = $feature->stories()->create([
+                'created_by_id' => $creator->getKey(),
+                'name' => $attributes['name'],
+                'kind' => $attributes['kind'] ?? StoryKind::UserStory,
+                'actor' => $attributes['actor'] ?? null,
+                'intent' => $attributes['intent'] ?? null,
+                'outcome' => $attributes['outcome'] ?? null,
+                'description' => $attributes['description'] ?? null,
+                'notes' => $attributes['notes'] ?? null,
+                'status' => $attributes['status'] ?? StoryStatus::Draft,
+                'revision' => 1,
+            ]);
+
+            AcceptanceCriterion::withoutEvents(function () use ($story, $attributes): void {
+                foreach (($attributes['acceptance_criteria'] ?? []) as $i => $criterion) {
+                    $story->acceptanceCriteria()->create([
+                        'statement' => $criterion,
+                        'position' => $i + 1,
+                    ]);
+                }
+            });
+
+            return $story;
+        });
+    }
+}

--- a/app/Services/Stories/StoryWriter.php
+++ b/app/Services/Stories/StoryWriter.php
@@ -42,7 +42,7 @@ class StoryWriter
             ]);
 
             AcceptanceCriterion::withoutEvents(function () use ($story, $attributes): void {
-                foreach (($attributes['acceptance_criteria'] ?? []) as $i => $criterion) {
+                foreach (array_values($attributes['acceptance_criteria'] ?? []) as $i => $criterion) {
                     $story->acceptanceCriteria()->create([
                         'statement' => $criterion,
                         'position' => $i + 1,

--- a/tests/Feature/StoryWriterTest.php
+++ b/tests/Feature/StoryWriterTest.php
@@ -41,3 +41,22 @@ test('create story tool writes initial acceptance criteria without extra story r
         ->and($payload['acceptance_criteria'][0]['position'])->toBe(1)
         ->and($payload['acceptance_criteria'][1]['position'])->toBe(2);
 });
+
+test('story writer normalizes keyed initial acceptance criteria before assigning positions', function () {
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $creator = User::factory()->create();
+    $feature = Feature::factory()->for(Project::factory()->for($team))->create();
+
+    $story = app(StoryWriter::class)->create($feature, $creator, [
+        'name' => 'Import customer data',
+        'acceptance_criteria' => [
+            'first' => 'Import accepts CSV files.',
+            'second' => 'Import rejects malformed rows.',
+        ],
+    ]);
+
+    expect($story->fresh()->revision)->toBe(1)
+        ->and($story->acceptanceCriteria()->orderBy('position')->pluck('position')->all())
+        ->toBe([1, 2]);
+});

--- a/tests/Feature/StoryWriterTest.php
+++ b/tests/Feature/StoryWriterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Enums\StoryStatus;
+use App\Mcp\Tools\CreateStoryTool;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\Stories\StoryWriter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+
+uses(RefreshDatabase::class);
+
+test('create story tool writes initial acceptance criteria without extra story revisions', function () {
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+
+    $this->actingAs($user);
+
+    $response = app(CreateStoryTool::class)->handle(new Request([
+        'feature_id' => $feature->getKey(),
+        'name' => 'Export customer data',
+        'acceptance_criteria' => [
+            'CSV includes headers.',
+            'CSV contains active customers only.',
+        ],
+    ]), app(StoryWriter::class));
+
+    $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($response->isError())->toBeFalse()
+        ->and($payload['revision'])->toBe(1)
+        ->and($payload['status'])->toBe(StoryStatus::Draft->value)
+        ->and($payload['acceptance_criteria'])->toHaveCount(2)
+        ->and($payload['acceptance_criteria'][0]['position'])->toBe(1)
+        ->and($payload['acceptance_criteria'][1]['position'])->toBe(2);
+});


### PR DESCRIPTION
## Summary
- add `StoryWriter` to own initial Story creation and initial acceptance criteria persistence
- route `create-story` through the writer instead of creating Story and criteria rows directly
- insert initial acceptance criteria without content-change events so a new Story starts at revision 1
- add MCP coverage for creating a Story with initial criteria and no extra revisions

## Validation
- php artisan test --compact tests/Feature/StoryWriterTest.php tests/Feature/StoryAcceptanceCriteriaWriterTest.php tests/Feature/StoryAuthoringTest.php
- vendor/bin/pint --dirty --test
- composer test