### PR TITLE
Centralize plan version allocation

### DIFF
--- a/app/Jobs/GenerateTasksJob.php
+++ b/app/Jobs/GenerateTasksJob.php
@@ -48,7 +48,6 @@ class GenerateTasksJob implements ShouldQueue
 
             $tasks = $planInputs->fromGeneratedTasks($story, $output['tasks'] ?? []);
             $result = $planWriter->replacePlan($story, $tasks, [
-                'name' => 'AI plan v'.(((int) $story->plans()->max('version')) + 1),
                 'summary' => $output['summary'] ?? null,
                 'source' => PlanSource::Ai,
                 'source_label' => 'TasksGenerator',

--- a/app/Mcp/Tools/CreatePlanTool.php
+++ b/app/Mcp/Tools/CreatePlanTool.php
@@ -5,7 +5,9 @@ namespace App\Mcp\Tools;
 use App\Enums\PlanSource;
 use App\Enums\PlanStatus;
 use App\Mcp\Concerns\ResolvesProjectAccess;
+use App\Models\Story;
 use App\Services\Plans\CurrentPlanSelector;
+use App\Services\Plans\PlanVersionAllocator;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -19,7 +21,7 @@ class CreatePlanTool extends Tool
 
     protected string $name = 'create-plan';
 
-    public function handle(Request $request, CurrentPlanSelector $currentPlans): Response
+    public function handle(Request $request, CurrentPlanSelector $currentPlans, PlanVersionAllocator $planVersions): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -45,23 +47,27 @@ class CreatePlanTool extends Tool
             return $story;
         }
 
-        $plan = $story->plans()->create([
-            'version' => ((int) $story->plans()->max('version')) + 1,
-            'revision' => 1,
-            'name' => $validated['name'],
-            'summary' => $validated['summary'] ?? null,
-            'design_notes' => $validated['design_notes'] ?? null,
-            'implementation_notes' => $validated['implementation_notes'] ?? null,
-            'risks' => $validated['risks'] ?? null,
-            'assumptions' => $validated['assumptions'] ?? null,
-            'source' => isset($validated['source']) ? PlanSource::from($validated['source']) : PlanSource::Human,
-            'source_label' => $validated['source_label'] ?? null,
-            'status' => isset($validated['status']) ? PlanStatus::from($validated['status']) : PlanStatus::Draft,
-        ]);
+        $plan = $planVersions->withNextVersion($story, function (int $nextVersion, Story $story) use ($validated, $currentPlans) {
+            $plan = $story->plans()->create([
+                'version' => $nextVersion,
+                'revision' => 1,
+                'name' => $validated['name'],
+                'summary' => $validated['summary'] ?? null,
+                'design_notes' => $validated['design_notes'] ?? null,
+                'implementation_notes' => $validated['implementation_notes'] ?? null,
+                'risks' => $validated['risks'] ?? null,
+                'assumptions' => $validated['assumptions'] ?? null,
+                'source' => isset($validated['source']) ? PlanSource::from($validated['source']) : PlanSource::Human,
+                'source_label' => $validated['source_label'] ?? null,
+                'status' => isset($validated['status']) ? PlanStatus::from($validated['status']) : PlanStatus::Draft,
+            ]);
 
-        if (($validated['set_current'] ?? false) === true) {
-            $currentPlans->setCurrent($story, $plan);
-        }
+            if (($validated['set_current'] ?? false) === true) {
+                $currentPlans->setCurrent($story, $plan);
+            }
+
+            return $plan;
+        });
 
         return Response::json([
             'id' => $plan->id,

--- a/app/Services/PlanWriter.php
+++ b/app/Services/PlanWriter.php
@@ -12,6 +12,7 @@ use App\Models\Subtask;
 use App\Models\Task;
 use App\Services\Executors\ProposedSubtask;
 use App\Services\Plans\PlanInputNormalizer;
+use App\Services\Plans\PlanVersionAllocator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
@@ -25,7 +26,10 @@ use InvalidArgumentException;
  */
 class PlanWriter
 {
-    public function __construct(private PlanInputNormalizer $planInputs) {}
+    public function __construct(
+        private PlanInputNormalizer $planInputs,
+        private PlanVersionAllocator $planVersions,
+    ) {}
 
     /**
      * @param  list<array{
@@ -46,20 +50,18 @@ class PlanWriter
 
         $this->validate($story, $tasks);
 
-        $result = DB::transaction(function () use ($story, $tasks, $attributes) {
+        $result = $this->planVersions->withNextVersion($story, function (int $nextVersion, Story $story) use ($tasks, $attributes) {
             $previousPlan = $story->currentPlan;
 
             if ($previousPlan) {
                 $previousPlan->forceFill(['status' => PlanStatus::Superseded])->save();
             }
 
-            $nextVersion = ((int) $story->plans()->max('version')) + 1;
-
             $plan = Plan::create([
                 'story_id' => $story->getKey(),
                 'version' => $nextVersion,
                 'revision' => 1,
-                'name' => $attributes['name'] ?? 'Plan v'.$nextVersion,
+                'name' => $attributes['name'] ?? $this->defaultPlanName($attributes['source'] ?? PlanSource::Human, $nextVersion),
                 'summary' => $attributes['summary'] ?? null,
                 'source' => $attributes['source'] ?? PlanSource::Human,
                 'source_label' => $attributes['source_label'] ?? null,
@@ -113,6 +115,14 @@ class PlanWriter
         });
 
         return $result;
+    }
+
+    private function defaultPlanName(PlanSource $source, int $version): string
+    {
+        return match ($source) {
+            PlanSource::Ai => 'AI plan v'.$version,
+            default => 'Plan v'.$version,
+        };
     }
 
     /**

--- a/app/Services/Plans/PlanVersionAllocator.php
+++ b/app/Services/Plans/PlanVersionAllocator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\Plans;
+
+use App\Models\Story;
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+class PlanVersionAllocator
+{
+    /**
+     * @template TReturn
+     *
+     * @param  Closure(int, Story): TReturn  $callback
+     * @return TReturn
+     */
+    public function withNextVersion(Story $story, Closure $callback): mixed
+    {
+        return DB::transaction(function () use ($story, $callback): mixed {
+            $lockedStory = Story::query()
+                ->whereKey($story->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $nextVersion = ((int) $lockedStory->plans()->max('version')) + 1;
+
+            return $callback($nextVersion, $lockedStory);
+        });
+    }
+}

--- a/database/migrations/2026_04_29_050715_create_plans_table.php
+++ b/database/migrations/2026_04_29_050715_create_plans_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->unsignedInteger('version')->default(1);
             $table->text('summary')->nullable();
             $table->timestamps();
+            $table->unique(['story_id', 'version']);
         });
 
         Schema::table('stories', function (Blueprint $table) {

--- a/tests/Architecture/PlanningModelArchitectureTest.php
+++ b/tests/Architecture/PlanningModelArchitectureTest.php
@@ -2,7 +2,9 @@
 
 use App\Models\AcceptanceCriterion;
 use App\Models\Plan;
+use App\Models\Story;
 use App\Models\Task;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Schema;
 
 arch('tasks are owned by plans')
@@ -24,4 +26,14 @@ test('acceptance criteria persist statement content', function () {
         ->and($columns)->not->toContain($retiredContentColumn)
         ->and((new AcceptanceCriterion)->getFillable())->toContain('statement')
         ->and((new AcceptanceCriterion)->getFillable())->not->toContain($retiredContentColumn);
+});
+
+test('plan versions are unique within a story', function () {
+    $story = Story::factory()->create();
+    Plan::factory()->for($story)->create(['version' => 1]);
+
+    Plan::factory()->for(Story::factory())->create(['version' => 1]);
+
+    expect(fn () => Plan::factory()->for($story)->create(['version' => 1]))
+        ->toThrow(QueryException::class);
 });

--- a/tests/Feature/CurrentPlanProjectionTest.php
+++ b/tests/Feature/CurrentPlanProjectionTest.php
@@ -23,6 +23,7 @@ test('acceptance criterion met only reflects done tasks in the current plan', fu
 
     $newPlan = Plan::factory()->create([
         'story_id' => $story->id,
+        'version' => 2,
         'status' => PlanStatus::PendingApproval,
     ]);
     $newTask = Task::factory()->create([

--- a/tests/Feature/CurrentPlanSelectionTest.php
+++ b/tests/Feature/CurrentPlanSelectionTest.php
@@ -10,6 +10,7 @@ use App\Models\Team;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Plans\CurrentPlanSelector;
+use App\Services\Plans\PlanVersionAllocator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Mcp\Request;
 
@@ -36,13 +37,30 @@ test('create plan tool can set the new plan as current', function () {
         'story_id' => $story->getKey(),
         'name' => 'Implementation option A',
         'set_current' => true,
-    ]), app(CurrentPlanSelector::class));
+    ]), app(CurrentPlanSelector::class), app(PlanVersionAllocator::class));
 
     $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
 
     expect($response->isError())->toBeFalse()
         ->and($payload['is_current'])->toBeTrue()
+        ->and($payload['version'])->toBe(1)
         ->and($story->fresh()->current_plan_id)->toBe($payload['id']);
+});
+
+test('create plan tool assigns the next story plan version', function () {
+    ['user' => $user, 'story' => $story] = currentPlanScene();
+    Plan::factory()->for($story)->create(['version' => 1]);
+    $this->actingAs($user);
+
+    $response = app(CreatePlanTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+        'name' => 'Implementation option B',
+    ]), app(CurrentPlanSelector::class), app(PlanVersionAllocator::class));
+
+    $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($response->isError())->toBeFalse()
+        ->and($payload['version'])->toBe(2);
 });
 
 test('set current plan tool rejects a plan from another story', function () {

--- a/tests/Feature/StoryRunProjectionTest.php
+++ b/tests/Feature/StoryRunProjectionTest.php
@@ -14,7 +14,7 @@ test('story run projection detects active subtask runs under the current plan', 
     $task = Task::factory()->forCurrentPlanOf($story)->create();
     $subtask = Subtask::factory()->for($task)->create();
 
-    $oldPlan = Plan::factory()->for($story)->create(['version' => 1]);
+    $oldPlan = Plan::factory()->for($story)->create(['version' => 2]);
     $oldTask = Task::factory()->for($oldPlan)->create();
     $oldSubtask = Subtask::factory()->for($oldTask)->create();
 

--- a/tests/Feature/TaskGenerationTest.php
+++ b/tests/Feature/TaskGenerationTest.php
@@ -89,7 +89,9 @@ test('regeneration replaces the prior task list', function () {
     app(ExecutionService::class)->dispatchTaskGeneration($story);
     $tasks = $story->fresh()->tasks;
     expect($tasks)->toHaveCount(1)
-        ->and($tasks[0]->name)->toBe('task-v2');
+        ->and($tasks[0]->name)->toBe('task-v2')
+        ->and($story->fresh()->currentPlan->version)->toBe(2)
+        ->and($story->fresh()->currentPlan->name)->toBe('AI plan v2');
 });
 
 test('task generation allows cross-cutting tasks without a single acceptance criterion', function () {


### PR DESCRIPTION
## Summary
- Add a PlanVersionAllocator that locks the Story while assigning the next Plan version.
- Route PlanWriter and create-plan through the allocator instead of each caller computing max(version).
- Let PlanWriter derive AI default plan names from the allocated version, so task generation no longer predicts the version before the write.

## Tests
- php artisan test --compact tests/Feature/CurrentPlanSelectionTest.php
- php artisan test --compact tests/Feature/TaskGenerationTest.php
- php artisan test --compact tests/Feature/PlanApprovalTest.php tests/Feature/RunningHypothesisPlanTest.php tests/Feature/PlanInputNormalizerTest.php
- vendor/bin/pint --dirty --test
- composer test