### PR TITLE
Remove executor progress capability flag

### DIFF
--- a/app/Jobs/ResolveConflictsJob.php
+++ b/app/Jobs/ResolveConflictsJob.php
@@ -131,7 +131,8 @@ class ResolveConflictsJob implements ShouldQueue
                     $unmerged,
                 );
 
-                $emitter = $executor->supportsProgressEvents() ? tap(new ProgressEmitter($run), fn (ProgressEmitter $e) => $e->setPhase('execute')) : null;
+                $emitter = new ProgressEmitter($run);
+                $emitter->setPhase('execute');
 
                 $result = $executor->execute($subtask, $workingDir, $repo, $branch, null, $emitter, $prompt);
 

--- a/app/Services/Executors/CliExecutor.php
+++ b/app/Services/Executors/CliExecutor.php
@@ -28,11 +28,6 @@ class CliExecutor implements Executor
         return true;
     }
 
-    public function supportsProgressEvents(): bool
-    {
-        return true;
-    }
-
     /**
      * Pipe a prompt to the CLI, run it in `$workingDir`, and report changed files.
      *
@@ -137,8 +132,8 @@ class CliExecutor implements Executor
      * `<<<SPECIFY:already_complete>>>sha1,sha2<<<END>>>` — and return the
      * flag plus the parsed SHA list. ADR-0007.
      *
-     * Free-text CLI agents that don't emit the sentinel keep the legacy
-     * no-diff-as-failure path — opt-in, not magic detection.
+     * CLI agents only mark a Subtask as already complete when they emit this
+     * explicit sentinel; no-diff runs without it still fail.
      *
      * @return array{0: bool, 1: list<string>}
      */

--- a/app/Services/Executors/Executor.php
+++ b/app/Services/Executors/Executor.php
@@ -23,15 +23,6 @@ interface Executor
     public function needsWorkingDirectory(): bool;
 
     /**
-     * Capability flag (ADR-0011). When true, the pipeline constructs a
-     * `ProgressEmitter` for the run and passes it to `execute()`; the
-     * driver emits typed events as work happens. Drivers that return
-     * false receive `null` and do nothing differently — backwards
-     * compatibility for existing impls.
-     */
-    public function supportsProgressEvents(): bool;
-
-    /**
      * Run the executor against a Subtask.
      *
      * `$contextBrief`, when non-null, is a markdown block produced by a
@@ -43,6 +34,10 @@ interface Executor
      * `$promptOverride`, when non-null, replaces the executor's default prompt
      * built from the Subtask (used for merge-conflict resolution and similar).
      * `$contextBrief` is still prepended when both are set.
+     *
+     * `$emitter` records run progress events. Executors that can expose
+     * streaming output should emit through it; executors without useful
+     * progress events may ignore it.
      */
     public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult;
 }

--- a/app/Services/Executors/FakeExecutor.php
+++ b/app/Services/Executors/FakeExecutor.php
@@ -19,11 +19,6 @@ class FakeExecutor implements Executor
         return false;
     }
 
-    public function supportsProgressEvents(): bool
-    {
-        return false;
-    }
-
     public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
     {
         // Pass a real (but throwaway) directory so SubtaskExecutor::tools() can construct

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -26,11 +26,6 @@ class LaravelAiExecutor implements Executor
         return true;
     }
 
-    public function supportsProgressEvents(): bool
-    {
-        return false;
-    }
-
     /**
      * Run the agent loop and translate its final output into an `ExecutionResult`.
      *

--- a/app/Services/SubtaskRunPipeline.php
+++ b/app/Services/SubtaskRunPipeline.php
@@ -59,7 +59,7 @@ class SubtaskRunPipeline
             'executor_driver' => $agentRun->executor_driver,
         ]);
 
-        $emitter = $executor->supportsProgressEvents() ? new ProgressEmitter($agentRun) : null;
+        $emitter = new ProgressEmitter($agentRun);
 
         if ($this->cancelObserved($agentRun, 'before_prepare', $logCtx)) {
             return SubtaskRunOutcome::cancelled();
@@ -73,7 +73,7 @@ class SubtaskRunPipeline
                 throw new RuntimeException('Executor requires a repo, but none is bound to this AgentRun.');
             }
 
-            $emitter?->setPhase('prepare');
+            $emitter->setPhase('prepare');
             $branch = $this->branchFor($agentRun);
             $workingDir = $this->workspace->prepare($repo, $agentRun);
             $this->workspace->checkoutBranch($workingDir, $branch, baseBranch: $repo->default_branch);
@@ -100,7 +100,7 @@ class SubtaskRunPipeline
             ])->save();
         }
 
-        $emitter?->setPhase('execute');
+        $emitter->setPhase('execute');
         $result = $executor->execute($subtask, $workingDir, $repo, $agentRun->working_branch, $contextBrief !== '' ? $contextBrief : null, $emitter, null);
 
         if ($this->cancelObserved($agentRun, 'after_execute', $logCtx)) {
@@ -123,7 +123,7 @@ class SubtaskRunPipeline
             return SubtaskRunOutcome::succeeded($output, $diff);
         }
 
-        $emitter?->setPhase('commit');
+        $emitter->setPhase('commit');
         $commitSha = $this->workspace->commit($workingDir, $result->commitMessage ?: 'specify: agent run');
         $diff = $this->workspace->diff($workingDir);
 
@@ -185,14 +185,14 @@ class SubtaskRunPipeline
                 return SubtaskRunOutcome::cancelled();
             }
 
-            $emitter?->setPhase('push');
+            $emitter->setPhase('push');
             $branch = $this->branchFor($agentRun);
             $this->workspace->push($workingDir, $branch);
             $output['pushed'] = true;
             Log::info('specify.subtask.push', $logCtx);
 
             if (config('specify.workspace.open_pr_after_push', true) && $repo !== null) {
-                $emitter?->setPhase('open_pr');
+                $emitter->setPhase('open_pr');
                 $prResult = $this->openPullRequest($repo, $subtask, $branch, $output, $agentRun->executor_driver);
                 $output = array_merge($output, $prResult);
 

--- a/docs/adr/0011-streaming-progress-events-from-executors.md
+++ b/docs/adr/0011-streaming-progress-events-from-executors.md
@@ -10,7 +10,7 @@ The UI design brief (2026-05-02 draft) ships log streaming via HTTP polling on `
 - **Latency floor.** The fastest a watcher sees a tool call is "next poll cycle." For runs that produce 10+ tool calls per second (large refactors), the user sees jumpy bursts of work, not a live console.
 - **Cost.** Every connected watcher polls; a Story page with N watchers and a long-running run is N requests per second against the runs endpoint, even when nothing has happened.
 
-The honest fix is to push events from the executor as they happen. ADR-0003's follow-ups list capability flags exactly for this case ("supports streaming, supports interactive clarification") — the design grill confirmed they're load-bearing for a real-time console.
+The honest fix is to push events from the executor as they happen. ADR-0003's follow-ups raised streaming as a likely executor concern; the design grill confirmed it is load-bearing for a real-time console.
 
 Two implementation shapes were considered:
 
@@ -21,7 +21,7 @@ We chose **broadcast-direct with HTTP-poll fallback** for late joiners. The poll
 
 ## Decision
 
-**The `Executor` interface gains an optional `ProgressEmitter` argument and a `supportsProgressEvents(): bool` capability. Drivers that opt in emit structured events as they make tool calls; the pipeline persists each event to `agent_run_events` and broadcasts it on `runs.{agent_run_id}.log`. The HTTP-poll endpoint reads from `agent_run_events`; Reverb watchers receive the events live.**
+**The `Executor` interface receives a `ProgressEmitter` argument. Drivers with useful progress output emit structured events as they make tool calls; drivers without useful progress events ignore the emitter. The current implementation persists each event to `agent_run_events`; Reverb broadcast can layer onto the same emitter later. The HTTP-poll endpoint reads from `agent_run_events`.**
 
 Concrete shape:
 
@@ -29,7 +29,7 @@ Concrete shape:
   - `id`, `agent_run_id` FK, `seq` (per-run monotonic), `ts`, `type` (`tool_call|edit|shell|thinking|stdout|stderr|error|sentinel`), `payload` (JSON).
   - Unique index on `(agent_run_id, seq)`.
   - **Append-only**; never updated.
-- `Executor::execute()` signature extends to accept an optional `ProgressEmitter $emitter`:
+- `Executor::execute()` signature accepts a nullable `ProgressEmitter $emitter`. The run pipelines always pass a non-null emitter; the nullable type keeps direct executor invocations simple when no run event stream is being asserted:
   ```php
   public function execute(
       Subtask $subtask,
@@ -39,16 +39,16 @@ Concrete shape:
       ?ProgressEmitter $emitter = null,
   ): ExecutionResult;
   ```
-  Drivers that don't implement progress events ignore the argument; existing executors compile unchanged.
-- `ProgressEmitter` is a thin wrapper around the run's id and a sequence counter. Calls to `emit($type, $payload)` write a row to `agent_run_events` and broadcast on `runs.{id}.log`. Writes are batched per pipeline phase (typed buffer, flushed every 250ms or on phase boundary) to keep DB churn bounded.
-- New capability flag `Executor::supportsProgressEvents(): bool` (default false). The pipeline reads it once at run start and only constructs an emitter for cooperating drivers.
-- **`LaravelAiExecutor`** opts in. Tool-call lifecycle hooks emit `tool_call`, `edit`, `shell`, and `thinking` events; the agent loop already has the introspection points.
-- **`CliExecutor`** opts in for stdout/stderr only. The process pipe is read line-buffered and emitted as `stdout` / `stderr` events; sentinel-block parsing (ADR-0007 `<<<SPECIFY:already_complete>>>`; future: `clarifications`) is detected at emit time and tagged as `sentinel`. Tool-call introspection is not available for opaque CLIs.
-- **`FakeExecutor`** opts in with synthetic events for tests.
+  Drivers that do not expose progress events ignore the argument.
+- `ProgressEmitter` is a thin wrapper around the run's id and a sequence counter. Calls to `emit($type, $payload)` write a row to `agent_run_events`. Broadcast and batching can wrap `emit()` later without changing executor call sites.
+- The pipeline constructs one emitter for the run and passes it to the executor.
+- **`LaravelAiExecutor`** currently ignores the emitter until its agent loop exposes reliable tool-call lifecycle hooks.
+- **`CliExecutor`** emits stdout/stderr only. The process pipe is read line-buffered and emitted as `stdout` / `stderr` events; sentinel-block parsing (ADR-0007 `<<<SPECIFY:already_complete>>>`; future: `clarifications`) is detected at emit time and tagged as `sentinel`. Tool-call introspection is not available for opaque CLIs.
+- **`FakeExecutor`** ignores the emitter; feature tests use `ProgressEmitter` directly when they need synthetic rows.
 - HTTP-poll endpoint `runs/{id}/logs?after={cursor}` reads from `agent_run_events` (`WHERE seq > cursor ORDER BY seq`). Polling and Reverb both read the same table; the broadcast is the live optimisation.
-- The runs page's existing log rendering (Slice 2 of the UI brief) is unchanged: it already consumes the polling endpoint. Reverb support is layered on; on disconnect, the Volt component falls back to polling.
+- The runs page's existing log rendering (Slice 2 of the UI brief) is unchanged: it already consumes the polling endpoint. Reverb support can be layered on later because the persisted event table is already the source of truth.
 
-The interface change to `Executor::execute` is the only ADR-0003 amendment this ADR introduces. Capability flag preserves backwards compatibility — non-cooperating drivers do nothing differently and have no rows in `agent_run_events`.
+The interface change to `Executor::execute` is the only ADR-0003 amendment this ADR introduces.
 
 ## Consequences
 
@@ -63,12 +63,12 @@ The interface change to `Executor::execute` is the only ADR-0003 amendment this 
 
 - **Database write amplification.** A run that previously produced 1 row in `agent_runs` now produces N rows in `agent_run_events`. Mitigation: 250ms emitter batching; partition or prune `agent_run_events` older than M days (config knob) once the table grows.
 - **Reverb fanout cost** scales with watchers per run. Mitigation: events are private-channel; only authorised watchers join. For pathologically chatty runs, the batching window absorbs most of the cost.
-- **Broadcast/persist ordering**: events must persist before broadcast (otherwise a Reverb-only watcher could see an event that's not in the poll endpoint). Mitigation: emitter writes the row, then broadcasts; on broadcast failure, the row stays — eventual consistency holds via polling.
+- **Broadcast/persist ordering**: when Reverb broadcast is added, events must persist before broadcast (otherwise a Reverb-only watcher could see an event that's not in the poll endpoint). Mitigation: emitter writes the row first; on broadcast failure, the row stays — eventual consistency holds via polling.
 
 ### Neutral
 
 - ADR-0001 / ADR-0008: unchanged. Streaming is a transport concern; approval and review-response semantics don't move.
-- ADR-0003: amended in place to record the optional `ProgressEmitter` argument and the `supportsProgressEvents` capability. Existing drivers compile unchanged.
+- ADR-0003: amended in place to record the optional `ProgressEmitter` argument.
 - ADR-0007: the `<<<SPECIFY:already_complete>>>` sentinel becomes a typed `sentinel` event in addition to its end-of-run parse. Both paths converge on the same evidence list.
 
 ## Open questions

--- a/tests/Feature/ProgressEventsTest.php
+++ b/tests/Feature/ProgressEventsTest.php
@@ -14,8 +14,6 @@ use App\Models\Workspace;
 use App\Services\ExecutionService;
 use App\Services\Executors\CliExecutor;
 use App\Services\Executors\Executor;
-use App\Services\Executors\FakeExecutor;
-use App\Services\Executors\LaravelAiExecutor;
 use App\Services\Progress\ProgressEmitter;
 use App\Services\WorkspaceRunner;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -113,12 +111,6 @@ test('CliExecutor emits stdout / stderr / sentinel events when an emitter is pas
     expect($stdoutLines)->toContain('hello');
     expect($events->where('type', 'stderr')->pluck('payload.line')->all())->toContain('oops');
     expect($events->where('type', 'sentinel')->first()->payload)->toBe(['name' => 'already_complete']);
-});
-
-test('CliExecutor.supportsProgressEvents()=true; LaravelAi/Fake=false', function () {
-    expect((new CliExecutor(['/bin/true']))->supportsProgressEvents())->toBeTrue();
-    expect((new LaravelAiExecutor)->supportsProgressEvents())->toBeFalse();
-    expect((new FakeExecutor)->supportsProgressEvents())->toBeFalse();
 });
 
 test('SubtaskRunPipeline tags events with the current phase and writes them under the run', function () {

--- a/tests/Feature/RunningHypothesisPlanTest.php
+++ b/tests/Feature/RunningHypothesisPlanTest.php
@@ -155,11 +155,6 @@ test('SubtaskRunPipeline does NOT append proposed subtasks when the run ends in 
             return true;
         }
 
-        public function supportsProgressEvents(): bool
-        {
-            return false;
-        }
-
         public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(
@@ -222,11 +217,6 @@ test('alreadyComplete returns the Succeeded-class outcome when evidence SHAs are
         public function needsWorkingDirectory(): bool
         {
             return true;
-        }
-
-        public function supportsProgressEvents(): bool
-        {
-            return false;
         }
 
         public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
@@ -297,11 +287,6 @@ test('alreadyComplete falls through to noDiff when evidence is empty (ADR-0007 s
             return true;
         }
 
-        public function supportsProgressEvents(): bool
-        {
-            return false;
-        }
-
         public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
         {
             return new ExecutionResult(
@@ -364,11 +349,6 @@ test('alreadyComplete falls through to noDiff when ANY cited SHA is unreachable,
         public function needsWorkingDirectory(): bool
         {
             return true;
-        }
-
-        public function supportsProgressEvents(): bool
-        {
-            return false;
         }
 
         public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
@@ -435,11 +415,6 @@ test('alreadyComplete falls through to noDiff when none of the cited SHAs are re
         public function needsWorkingDirectory(): bool
         {
             return true;
-        }
-
-        public function supportsProgressEvents(): bool
-        {
-            return false;
         }
 
         public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult
@@ -527,11 +502,6 @@ test('context_brief is persisted on AgentRun.output even when the run ends in no
         public function needsWorkingDirectory(): bool
         {
             return true;
-        }
-
-        public function supportsProgressEvents(): bool
-        {
-            return false;
         }
 
         public function execute(Subtask $subtask, ?string $workingDir, ?Repo $repo, ?string $workingBranch, ?string $contextBrief = null, ?ProgressEmitter $emitter = null, ?string $promptOverride = null): ExecutionResult


### PR DESCRIPTION
## Summary
- Remove `Executor::supportsProgressEvents()` and always pass a run `ProgressEmitter` through the executor contract.
- Let executors that do not emit progress ignore the emitter instead of advertising a compatibility capability.
- Update ADR-0011 and progress tests to match the simplified contract.

## Tests
- php artisan test --compact tests/Feature/ProgressEventsTest.php tests/Feature/RunningHypothesisPlanTest.php tests/Feature/SubtaskExecutionTest.php
- vendor/bin/pint --dirty --test
- composer test