### PR TITLE
Make current plan task access explicit

### DIFF
--- a/app/Mcp/Tools/GenerateTasksTool.php
+++ b/app/Mcp/Tools/GenerateTasksTool.php
@@ -48,7 +48,7 @@ class GenerateTasksTool extends Tool
             return Response::error('Story must be Approved before generating a plan.');
         }
 
-        if ($story->tasks()->exists()) {
+        if ($story->currentPlanTasks()->exists()) {
             return Response::error('Story already has Tasks in its current Plan. Use set-tasks / update-task to replace or edit the current Plan.');
         }
 

--- a/app/Mcp/Tools/GetStoryTool.php
+++ b/app/Mcp/Tools/GetStoryTool.php
@@ -44,15 +44,15 @@ class GetStoryTool extends Tool
             'currentPlan',
             'acceptanceCriteria',
             'scenarios:id,story_id,acceptance_criterion_id,position,name,given_text,when_text,then_text,notes',
-            'tasks',
+            'currentPlanTasks',
         ]);
 
-        $taskIdsByCriterion = $story->tasks
+        $taskIdsByCriterion = $story->currentPlanTasks
             ->groupBy('acceptance_criterion_id')
             ->map(fn ($tasks) => $tasks->pluck('id')->values()->all());
 
-        $tasksTotal = $story->tasks->count();
-        $tasksDone = $story->tasks->filter(fn ($t) => $t->status === TaskStatus::Done)->count();
+        $tasksTotal = $story->currentPlanTasks->count();
+        $tasksDone = $story->currentPlanTasks->filter(fn ($t) => $t->status === TaskStatus::Done)->count();
 
         return Response::json([
             'id' => $story->id,

--- a/app/Mcp/Tools/ListRunsTool.php
+++ b/app/Mcp/Tools/ListRunsTool.php
@@ -74,14 +74,14 @@ class ListRunsTool extends Tool
                 }
             });
         } else {
-            $story = Story::query()->with('feature', 'tasks:id,plan_id')->find($storyId);
+            $story = Story::query()->with('feature', 'currentPlanTasks:id,plan_id')->find($storyId);
             if (! $story) {
                 return Response::error('Story not found.');
             }
             if (! $this->canAccessProject($user, (int) $story->feature->project_id)) {
                 return Response::error('Story not accessible.');
             }
-            $taskIds = $story->tasks->pluck('id')->all();
+            $taskIds = $story->currentPlanTasks->pluck('id')->all();
             $subtaskIds = ! empty($taskIds) ? Subtask::query()->whereIn('task_id', $taskIds)->pluck('id')->all() : [];
             $query->where(function ($q) use ($story, $taskIds, $subtaskIds) {
                 $q->where(function ($q) use ($story) {

--- a/app/Mcp/Tools/ListTasksTool.php
+++ b/app/Mcp/Tools/ListTasksTool.php
@@ -41,7 +41,7 @@ class ListTasksTool extends Tool
             return $story;
         }
 
-        $tasks = $story->tasks()
+        $tasks = $story->currentPlanTasks()
             ->with(['acceptanceCriterion:id,position,statement', 'scenario:id,position,name', 'subtasks:id,task_id,status', 'dependencies:id,position'])
             ->orderBy('position')
             ->get();

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -111,7 +111,7 @@ class Story extends Model
         return $this->belongsTo(Plan::class, 'current_plan_id');
     }
 
-    public function tasks(): HasMany
+    public function currentPlanTasks(): HasMany
     {
         return $this->hasMany(Task::class, 'plan_id', 'current_plan_id')
             ->orderBy('position');

--- a/app/Services/Stories/StoryPullRequestProjection.php
+++ b/app/Services/Stories/StoryPullRequestProjection.php
@@ -22,7 +22,7 @@ class StoryPullRequestProjection
      */
     public function all(Story $story): Collection
     {
-        $subtaskIds = $story->tasks()
+        $subtaskIds = $story->currentPlanTasks()
             ->with('subtasks:id,task_id')
             ->get()
             ->flatMap(fn ($task) => $task->subtasks->pluck('id'))

--- a/app/Services/Stories/StoryRunProjection.php
+++ b/app/Services/Stories/StoryRunProjection.php
@@ -34,7 +34,7 @@ class StoryRunProjection
     private function subtaskIdQueryFor(Story $story): Builder
     {
         return Subtask::query()
-            ->whereIn('task_id', $story->tasks()->select('tasks.id'))
+            ->whereIn('task_id', $story->currentPlanTasks()->select('tasks.id'))
             ->select('id');
     }
 }

--- a/app/Services/SubtaskExecutionScheduler.php
+++ b/app/Services/SubtaskExecutionScheduler.php
@@ -116,7 +116,7 @@ class SubtaskExecutionScheduler
      */
     public function nextActionableSubtasks(Story $story): Collection
     {
-        return $story->tasks()
+        return $story->currentPlanTasks()
             ->with(['dependencies:id,status', 'subtasks:id,task_id,position,status'])
             ->get()
             ->filter(fn (Task $task) => $task->dependencies->every(fn (Task $d) => $d->status === TaskStatus::Done))
@@ -232,7 +232,7 @@ class SubtaskExecutionScheduler
             return;
         }
 
-        $remainingTasks = $story->tasks()->where('tasks.status', '!=', TaskStatus::Done->value)->count();
+        $remainingTasks = $story->currentPlanTasks()->where('tasks.status', '!=', TaskStatus::Done->value)->count();
         if ($remainingTasks === 0) {
             if ($story->currentPlan) {
                 $story->currentPlan->forceFill(['status' => PlanStatus::Done->value])->save();

--- a/resources/views/components/story/feature-row.blade.php
+++ b/resources/views/components/story/feature-row.blade.php
@@ -8,7 +8,7 @@
 ])
 
 @php
-    $tasks = $story->relationLoaded('tasks') ? $story->tasks : collect();
+    $tasks = $story->relationLoaded('currentPlanTasks') ? $story->currentPlanTasks : collect();
     $tasksTotal = $tasks->count();
     $tasksDone = $tasks->filter(fn ($task) => $task->status === \App\Enums\TaskStatus::Done)->count();
 @endphp

--- a/resources/views/components/story/summary-card.blade.php
+++ b/resources/views/components/story/summary-card.blade.php
@@ -7,7 +7,7 @@
 ])
 
 @php
-    $tasks = $story->relationLoaded('tasks') ? $story->tasks : collect();
+    $tasks = $story->relationLoaded('currentPlanTasks') ? $story->currentPlanTasks : collect();
     $tasksTotal = $tasks->count();
     $tasksDone = $tasks->filter(fn ($task) => $task->status === \App\Enums\TaskStatus::Done)->count();
 @endphp

--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -94,7 +94,7 @@ new #[Title('Feature')] class extends Component {
     {
         return $this->feature
             ? $this->feature->stories()
-                ->with('creator', 'tasks', 'currentPlan:id,story_id,version,name,status')
+                ->with('creator', 'currentPlanTasks', 'currentPlan:id,story_id,version,name,status')
                 ->orderBy('position')
                 ->orderBy('id')
                 ->get()
@@ -160,9 +160,9 @@ new #[Title('Feature')] class extends Component {
         }
 
         $hasActiveRun = $this->stories->contains(function ($story) {
-            return $story->tasks->isNotEmpty()
+            return $story->currentPlanTasks->isNotEmpty()
                 && $story->status === StoryStatus::Approved
-                && $story->tasks->contains(fn ($t) => $t->status === TaskStatus::InProgress || $t->status === TaskStatus::Pending);
+                && $story->currentPlanTasks->contains(fn ($t) => $t->status === TaskStatus::InProgress || $t->status === TaskStatus::Pending);
         });
         if ($hasActiveRun) {
             return 'running';

--- a/resources/views/pages/stories/⚡index.blade.php
+++ b/resources/views/pages/stories/⚡index.blade.php
@@ -35,7 +35,7 @@ new #[Title('Stories')] class extends Component {
         return Story::query()
             ->whereHas('feature', fn ($q) => $q->whereIn('project_id', $projectIds))
             ->when($this->status, fn ($q, $s) => $q->where('status', $s))
-            ->with(['feature.project', 'creator', 'tasks', 'currentPlan:id,story_id,version,name,status'])
+            ->with(['feature.project', 'creator', 'currentPlanTasks', 'currentPlan:id,story_id,version,name,status'])
             ->latest('updated_at')
             ->paginate(25);
     }

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -229,7 +229,7 @@ new #[Title('Story')] class extends Component {
         $story->submitForApproval();
 
         $fresh = $story->fresh();
-        if ($fresh->status === StoryStatus::Approved && ! $fresh->tasks()->exists()) {
+        if ($fresh->status === StoryStatus::Approved && ! $fresh->currentPlanTasks()->exists()) {
             app(ExecutionService::class)->dispatchTaskGeneration($fresh);
         }
 
@@ -287,7 +287,7 @@ new #[Title('Story')] class extends Component {
         $story = $this->story;
         abort_unless($story, 404);
         abort_unless($story->status === StoryStatus::Approved, 422, 'Story must be Approved.');
-        abort_if($story->tasks()->exists(), 422, 'Plan already exists.');
+        abort_if($story->currentPlanTasks()->exists(), 422, 'Plan already exists.');
         abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
 
         app(ExecutionService::class)->dispatchTaskGeneration($story);
@@ -319,7 +319,7 @@ new #[Title('Story')] class extends Component {
         abort_unless($story->status === StoryStatus::Approved, 422, 'Story must be Approved.');
         abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
 
-        $subtaskIds = Subtask::whereIn('task_id', $story->tasks()->pluck('id'))->pluck('id');
+        $subtaskIds = Subtask::whereIn('task_id', $story->currentPlanTasks()->pluck('id'))->pluck('id');
 
         AgentRun::where('runnable_type', Subtask::class)
             ->whereIn('runnable_id', $subtaskIds)
@@ -343,7 +343,7 @@ new #[Title('Story')] class extends Component {
         $story = $this->story;
         abort_unless($story, 404);
         abort_unless($story->status === StoryStatus::PendingApproval, 422, 'Story is not awaiting approval.');
-        abort_unless($story->tasks()->exists(), 422, 'No plan to execute.');
+        abort_unless($story->currentPlanTasks()->exists(), 422, 'No plan to execute.');
 
         $policy = $story->effectivePolicy();
         abort_unless($policy->auto_approve || $policy->required_approvals === 0, 403, 'Policy requires explicit approvals.');
@@ -526,11 +526,11 @@ new #[Title('Story')] class extends Component {
                 'acceptanceCriteria',
                 'scenarios.acceptanceCriterion',
                 'currentPlan.approvals.approver',
-                'tasks.plan',
-                'tasks.acceptanceCriterion',
-                'tasks.scenario',
-                'tasks.dependencies',
-                'tasks.subtasks.agentRuns.repo',
+                'currentPlanTasks.plan',
+                'currentPlanTasks.acceptanceCriterion',
+                'currentPlanTasks.scenario',
+                'currentPlanTasks.dependencies',
+                'currentPlanTasks.subtasks.agentRuns.repo',
                 'approvals.approver',
             ])
             ->find($this->story_id);
@@ -879,8 +879,8 @@ new #[Title('Story')] class extends Component {
             $autoPromotes = $this->autoPromotes;
             $currentPlan = $story->currentPlan;
             $hasIncompleteWork = $story->status === StoryStatus::Approved
-                && $story->tasks->isNotEmpty()
-                && $story->tasks->flatMap->subtasks->contains(fn ($s) => $s->status !== TaskStatus::Done);
+                && $story->currentPlanTasks->isNotEmpty()
+                && $story->currentPlanTasks->flatMap->subtasks->contains(fn ($s) => $s->status !== TaskStatus::Done);
             $needsApprovalNote = in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true)
                 && $canApprove
                 && ! $blockedBySelfApproval
@@ -891,14 +891,14 @@ new #[Title('Story')] class extends Component {
                 && ! $planBlockedBySelfApproval
                 && ! $autoPromotes;
             $hasDraftSubmit = $story->status === StoryStatus::Draft && ($isAuthor || $canApprove);
-            $hasAutoStart = $story->status === StoryStatus::PendingApproval && $story->tasks->isNotEmpty() && $autoPromotes && $canApprove;
+            $hasAutoStart = $story->status === StoryStatus::PendingApproval && $story->currentPlanTasks->isNotEmpty() && $autoPromotes && $canApprove;
             $hasApprovalActions = in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true) && $canApprove && ! $blockedBySelfApproval;
-            $hasPlanSubmit = $currentPlan !== null && $currentPlan->status === PlanStatus::Draft && $story->tasks->isNotEmpty() && $canApprovePlan;
+            $hasPlanSubmit = $currentPlan !== null && $currentPlan->status === PlanStatus::Draft && $story->currentPlanTasks->isNotEmpty() && $canApprovePlan;
             $hasPlanApprovalActions = $currentPlan !== null && $currentPlan->status === PlanStatus::PendingApproval && $canApprovePlan && ! $planBlockedBySelfApproval;
             $hasResume = $hasIncompleteWork && $canApprove;
             $hasStartExecution = $story->status === StoryStatus::Approved
                 && $currentPlan?->status === PlanStatus::Approved
-                && $story->tasks->isNotEmpty()
+                && $story->currentPlanTasks->isNotEmpty()
                 && ! $this->hasActiveSubtaskRun
                 && $canApprove;
             $hasAnyDecisionAction = $hasDraftSubmit || $hasAutoStart || $hasApprovalActions || $hasPlanSubmit || $hasPlanApprovalActions || $hasResume || $hasStartExecution;
@@ -908,12 +908,12 @@ new #[Title('Story')] class extends Component {
         @unless ($editing)
             {{-- ── Plan: ACs → Tasks → Subtasks → runs (AC-led) ────────────── --}}
             @php
-                $tasksByAc = $story->tasks->groupBy('acceptance_criterion_id');
+                $tasksByAc = $story->currentPlanTasks->groupBy('acceptance_criterion_id');
                 $unmappedTasks = $tasksByAc->get(null, collect())->sortBy('position')->values();
                 $acs = $story->acceptanceCriteria->sortBy('position')->values();
-                $subtaskCount = $story->tasks->reduce(fn ($acc, $task) => $acc + $task->subtasks->count(), 0);
+                $subtaskCount = $story->currentPlanTasks->reduce(fn ($acc, $task) => $acc + $task->subtasks->count(), 0);
                 $shouldRunMode = $this->hasActiveSubtaskRun;
-                $latestRun = $story->tasks->flatMap->subtasks->flatMap->agentRuns->sortByDesc('id')->first();
+                $latestRun = $story->currentPlanTasks->flatMap->subtasks->flatMap->agentRuns->sortByDesc('id')->first();
                 $branch = $latestRun?->working_branch;
                 $repo = $latestRun?->repo;
                 $planGenRuns = $this->planGenerationRuns;

--- a/resources/views/partials/story-show/plan.blade.php
+++ b/resources/views/partials/story-show/plan.blade.php
@@ -3,7 +3,7 @@
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
             <flux:heading size="lg">{{ __('Current plan') }}</flux:heading>
             <flux:text class="text-xs text-zinc-500">
-                {{ $acs->count() }} {{ __('ACs') }} · {{ $story->tasks->count() }} {{ __('current-plan tasks') }} · {{ $subtaskCount }} {{ __('subtasks') }}
+                {{ $acs->count() }} {{ __('ACs') }} · {{ $story->currentPlanTasks->count() }} {{ __('current-plan tasks') }} · {{ $subtaskCount }} {{ __('subtasks') }}
                 @if ($story->currentPlan)
                     · {{ __('current') }} {{ $story->currentPlan->name ?? ('v'.$story->currentPlan->version) }}
                 @endif
@@ -41,7 +41,7 @@
                 </div>
             @endif
 
-            @if ($story->status === \App\Enums\StoryStatus::Approved && $story->tasks->isEmpty() && ! $this->pendingPlanRun && $this->canApproveStory)
+            @if ($story->status === \App\Enums\StoryStatus::Approved && $story->currentPlanTasks->isEmpty() && ! $this->pendingPlanRun && $this->canApproveStory)
                 <flux:button wire:click="generatePlan" wire:target="generatePlan" wire:loading.attr="disabled" variant="primary">
                     <span wire:loading.remove wire:target="generatePlan">{{ __('Generate plan') }}</span>
                     <span wire:loading wire:target="generatePlan">{{ __('Working…') }}</span>
@@ -98,11 +98,11 @@
         </flux:card>
     @endif
 
-    @if ($acs->isEmpty() && $story->tasks->isEmpty() && ! $this->pendingPlanRun && $story->status !== \App\Enums\StoryStatus::Approved)
+    @if ($acs->isEmpty() && $story->currentPlanTasks->isEmpty() && ! $this->pendingPlanRun && $story->status !== \App\Enums\StoryStatus::Approved)
         <flux:text class="text-zinc-500">{{ __('Current plan is generated once the story contract is approved.') }}</flux:text>
     @endif
 
-    @if ($story->currentPlan && $story->currentPlan->status !== \App\Enums\PlanStatus::Approved && $story->tasks->isNotEmpty())
+    @if ($story->currentPlan && $story->currentPlan->status !== \App\Enums\PlanStatus::Approved && $story->currentPlanTasks->isNotEmpty())
         <div class="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200" data-section="plan-approval-note">
             {{ __('Execution is blocked until the current plan is approved.') }}
         </div>

--- a/tests/Architecture/PlanningModelArchitectureTest.php
+++ b/tests/Architecture/PlanningModelArchitectureTest.php
@@ -12,6 +12,11 @@ arch('tasks are owned by plans')
     ->toHaveMethod('plan')
     ->not->toHaveMethod('st'.'ory');
 
+arch('stories expose current plan tasks explicitly')
+    ->expect(Story::class)
+    ->toHaveMethod('currentPlanTasks')
+    ->not->toHaveMethod('tasks');
+
 test('tasks table stores plan ownership only', function () {
     expect(Schema::hasColumn('tasks', 'plan_id'))->toBeTrue()
         ->and(Schema::hasColumn('tasks', 'st'.'ory_id'))->toBeFalse()

--- a/tests/Feature/AgentRunCancelTest.php
+++ b/tests/Feature/AgentRunCancelTest.php
@@ -65,7 +65,7 @@ test('cancelRun on a terminal run is a no-op', function () {
 
 test('SubtaskRunPipeline observes cancel_requested mid-execute and marks the run Cancelled', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     SubtaskExecutor::fake(function () use ($subtask) {
         AgentRun::query()
@@ -123,7 +123,7 @@ test('cancelSubtask cancels every still-open AgentRun on the Subtask', function 
 
 test('Run console exposes a Cancel button while the run is open', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -142,7 +142,7 @@ test('Run console exposes a Cancel button while the run is open', function () {
 
 test('Run console hides the Cancel button on terminal runs', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -161,7 +161,7 @@ test('Run console hides the Cancel button on terminal runs', function () {
 
 test('Queued run cancelled before the worker picks up the job stays Cancelled', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     // Construct a Queued run as if dispatch happened on a queued worker that
     // hasn't picked it up. Cancel before invoking the job manually.

--- a/tests/Feature/AgentRunPrRetryTest.php
+++ b/tests/Feature/AgentRunPrRetryTest.php
@@ -60,7 +60,7 @@ test('retryPullRequestOpen dispatches the OpenPullRequestJob end-to-end', functi
         'url' => 'https://github.com/o/r',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -96,7 +96,7 @@ test('OpenPullRequestJob bails inside the lock when a concurrent retry already s
         'url' => 'https://github.com/o/r',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -129,7 +129,7 @@ test('OpenPullRequestJob records find() exceptions as pull_request_error instead
         'url' => 'not-a-valid-url',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -170,7 +170,7 @@ test('OpenPullRequestJob opens a fresh PR and stamps the run output', function (
         'url' => 'https://github.com/o/r',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -211,7 +211,7 @@ test('OpenPullRequestJob adopts an existing open PR rather than opening a duplic
         'url' => 'https://github.com/o/r',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -245,7 +245,7 @@ test('OpenPullRequestJob records pull_request_error on provider failure', functi
         'url' => 'https://github.com/o/r',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -268,7 +268,7 @@ test('OpenPullRequestJob records pull_request_error on provider failure', functi
 
 test('Run console exposes Retry PR on Succeeded runs with pull_request_error', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $repo = $story->feature->project->primaryRepo();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -332,7 +332,7 @@ test('GithubPullRequestProvider::findOpenPullRequest skips fork PRs whose head.r
         'url' => 'https://github.com/o/r',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -383,7 +383,7 @@ test('GithubPullRequestProvider::findOpenPullRequest follows Link rel="next" pag
         'url' => 'https://github.com/o/r',
         'default_branch' => 'main',
     ])->save();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,

--- a/tests/Feature/AgentRunRetryTest.php
+++ b/tests/Feature/AgentRunRetryTest.php
@@ -23,7 +23,7 @@ beforeEach(function () {
 
 test('retrySubtaskExecution dispatches a fresh AgentRun pointing at the prior run', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     $first = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
@@ -48,7 +48,7 @@ test('retrySubtaskExecution dispatches a fresh AgentRun pointing at the prior ru
 
 test('retry refuses an in-flight run', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $running = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -61,7 +61,7 @@ test('retry refuses an in-flight run', function () {
 
 test('retry refuses when the Story is no longer Approved', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $failed = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -76,7 +76,7 @@ test('retry refuses when the Story is no longer Approved', function () {
 
 test('Run console exposes a Retry button on terminal failure runs', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -96,7 +96,7 @@ test('Run console exposes a Retry button on terminal failure runs', function () 
 
 test('Run console hides Retry on Succeeded runs', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -115,7 +115,7 @@ test('Run console hides Retry on Succeeded runs', function () {
 
 test('Run console hides Retry on RespondToReview runs (re-fires automatically)', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -135,7 +135,7 @@ test('Run console hides Retry on RespondToReview runs (re-fires automatically)',
 
 test('retry on a RespondToReview run is rejected by the service', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -154,7 +154,7 @@ test('retrySubtaskExecution rejects Succeeded runs at the service layer', functi
     // Subtask and double-open PRs.
     $story = approvedStoryInProjectWithRepo();
     $story->forceFill(['status' => StoryStatus::Approved->value])->save();
-    $subtask = $story->fresh()->tasks()->first()->subtasks()->first();
+    $subtask = $story->fresh()->currentPlanTasks()->first()->subtasks()->first();
     $run = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,
@@ -167,7 +167,7 @@ test('retrySubtaskExecution rejects Succeeded runs at the service layer', functi
 
 test('Run console links a retry back to its origin run', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $origin = AgentRun::factory()->create([
         'runnable_type' => Subtask::class,
         'runnable_id' => $subtask->id,

--- a/tests/Feature/MultiExecutorRaceTest.php
+++ b/tests/Feature/MultiExecutorRaceTest.php
@@ -44,7 +44,7 @@ function approvedSubtaskForRace(): Subtask
     $story->forceFill(['status' => StoryStatus::Draft->value])->save();
     $story->fresh()->submitForApproval();
 
-    return $story->fresh()->tasks()->first()->subtasks()->first();
+    return $story->fresh()->currentPlanTasks()->first()->subtasks()->first();
 }
 
 beforeEach(function () {

--- a/tests/Feature/PlanApprovalTest.php
+++ b/tests/Feature/PlanApprovalTest.php
@@ -92,7 +92,7 @@ test('editing the current plan invalidates prior plan approvals but leaves story
     expect($plan->fresh()->status)->toBe(PlanStatus::Approved)
         ->and($story->fresh()->status)->toBe(StoryStatus::Approved);
 
-    $task = $story->tasks()->firstOrFail();
+    $task = $story->currentPlanTasks()->firstOrFail();
     $task->update(['name' => 'renamed task']);
     $task->plan->reopenForApproval();
 

--- a/tests/Feature/SubtaskExecutionTest.php
+++ b/tests/Feature/SubtaskExecutionTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
 
 test('subtask execution job runs the agent and marks subtask Done', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     SubtaskExecutor::fake(fn () => [
         'summary' => 'edited two files',
@@ -52,7 +52,7 @@ test('subtask execution job runs the agent and marks subtask Done', function () 
 
 test('dispatch picks the project primary repo by default and sets working_branch', function () {
     $story = approvedStoryInProjectWithRepo();
-    $task = $story->tasks()->first();
+    $task = $story->currentPlanTasks()->first();
     $subtask = $task->subtasks()->first();
     $primary = $story->feature->project->primaryRepo();
 
@@ -68,7 +68,7 @@ test('dispatch picks the project primary repo by default and sets working_branch
 
 test('dispatch accepts an explicit repo override', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
     $project = $story->feature->project;
     $workspace = $project->team->workspace;
     $other = Repo::factory()->for($workspace)->create();
@@ -84,7 +84,7 @@ test('dispatch accepts an explicit repo override', function () {
 
 test('agent failure marks subtask Blocked and run Failed', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     SubtaskExecutor::fake(function () {
         throw new RuntimeException('rate limited');
@@ -140,7 +140,7 @@ test('full story execution: subtasks succeed and story flips to Done', function 
 
 test('agent prompt includes repo URL and working branch', function () {
     $story = approvedStoryInProjectWithRepo();
-    $subtask = $story->tasks()->first()->subtasks()->first();
+    $subtask = $story->currentPlanTasks()->first()->subtasks()->first();
 
     app(ExecutionService::class)->dispatchSubtaskExecution($subtask);
 

--- a/tests/Feature/TaskGenerationTest.php
+++ b/tests/Feature/TaskGenerationTest.php
@@ -52,7 +52,7 @@ test('dispatching task generation runs the job, creates Tasks linked to ACs with
     $run->refresh();
     expect($run->status)->toBe(AgentRunStatus::Succeeded);
 
-    $tasks = $story->fresh()->tasks()->orderBy('position')->get();
+    $tasks = $story->fresh()->currentPlanTasks()->orderBy('position')->get();
     expect($tasks)->toHaveCount(2)
         ->and($tasks[0]->acceptance_criterion_id)->toBe($ac1->id)
         ->and($tasks[1]->acceptance_criterion_id)->toBe($ac2->id)
@@ -75,7 +75,7 @@ test('regeneration replaces the prior task list', function () {
     ]);
 
     app(ExecutionService::class)->dispatchTaskGeneration($story);
-    expect($story->fresh()->tasks()->count())->toBe(1);
+    expect($story->fresh()->currentPlanTasks()->count())->toBe(1);
 
     TasksGenerator::fake(fn () => [
         'summary' => 'v2',
@@ -87,7 +87,7 @@ test('regeneration replaces the prior task list', function () {
     ]);
 
     app(ExecutionService::class)->dispatchTaskGeneration($story);
-    $tasks = $story->fresh()->tasks;
+    $tasks = $story->fresh()->currentPlanTasks;
     expect($tasks)->toHaveCount(1)
         ->and($tasks[0]->name)->toBe('task-v2')
         ->and($story->fresh()->currentPlan->version)->toBe(2)
@@ -110,7 +110,7 @@ test('task generation allows cross-cutting tasks without a single acceptance cri
 
     app(ExecutionService::class)->dispatchTaskGeneration($story);
 
-    $task = $story->fresh()->tasks()->sole();
+    $task = $story->fresh()->currentPlanTasks()->sole();
     expect($task->acceptance_criterion_id)->toBeNull()
         ->and($task->subtasks()->count())->toBe(1);
 });


### PR DESCRIPTION
## Summary
- Replace the remaining `Story::tasks()` relation with `Story::currentPlanTasks()` so Story no longer reads as the owner of Tasks.
- Update services, MCP tools, Story UI components/pages, and tests to use explicit current-Plan task access.
- Add architecture coverage that Stories expose current Plan Tasks explicitly and do not reintroduce a generic `tasks` relation.

## Tests
- php artisan test --compact tests/Architecture/PlanningModelArchitectureTest.php tests/Feature/TaskGenerationTest.php tests/Feature/PlanApprovalTest.php tests/Feature/SubtaskExecutionTest.php tests/Feature/AgentRunRetryTest.php tests/Feature/AgentRunPrRetryTest.php tests/Feature/AgentRunCancelTest.php tests/Feature/MultiExecutorRaceTest.php
- php artisan test --compact tests/Feature/PlanningArchitectureConformanceTest.php tests/Feature/StoryShowTest.php tests/Feature/StoryShowPageTest.php tests/Feature/CurrentPlanProjectionTest.php tests/Feature/StoryPullRequestsTest.php tests/Feature/StoryRunProjectionTest.php tests/Feature/StoriesIndexTest.php tests/Feature/FeatureShowTest.php
- vendor/bin/pint --dirty --test
- composer test