### PR TITLE
Enforce scoped product positions

### DIFF
--- a/database/migrations/2026_04_29_051134_create_acceptance_criteria_table.php
+++ b/database/migrations/2026_04_29_051134_create_acceptance_criteria_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->unsignedInteger('position')->default(0);
             $table->text('statement');
             $table->timestamps();
+            $table->unique(['story_id', 'position']);
         });
     }
 

--- a/database/migrations/2026_05_03_053325_add_position_to_stories_table.php
+++ b/database/migrations/2026_05_03_053325_add_position_to_stories_table.php
@@ -24,11 +24,16 @@ return new class extends Migration
                     DB::table('stories')->where('id', $row->id)->update(['position' => $i + 1]);
                 });
             });
+
+        Schema::table('stories', function (Blueprint $table) {
+            $table->unique(['feature_id', 'position']);
+        });
     }
 
     public function down(): void
     {
         Schema::table('stories', function (Blueprint $table) {
+            $table->dropUnique(['feature_id', 'position']);
             $table->dropColumn('position');
         });
     }

--- a/database/migrations/2026_05_03_120000_restructure_story_planning_model.php
+++ b/database/migrations/2026_05_03_120000_restructure_story_planning_model.php
@@ -27,7 +27,7 @@ return new class extends Migration
             $table->text('notes')->nullable();
             $table->timestamps();
 
-            $table->index(['story_id', 'position']);
+            $table->unique(['story_id', 'position']);
         });
 
         Schema::table('plans', function (Blueprint $table) {

--- a/resources/views/pages/features/⚡show.blade.php
+++ b/resources/views/pages/features/⚡show.blade.php
@@ -121,6 +121,12 @@ new #[Title('Feature')] class extends Component {
         }
 
         DB::transaction(function () use ($clean) {
+            $offset = count($clean) + 1;
+
+            foreach ($clean as $i => $id) {
+                DB::table('stories')->where('id', $id)->update(['position' => $offset + $i]);
+            }
+
             foreach ($clean as $i => $id) {
                 DB::table('stories')->where('id', $id)->update(['position' => $i + 1]);
             }

--- a/tests/Architecture/PlanningModelArchitectureTest.php
+++ b/tests/Architecture/PlanningModelArchitectureTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Models\AcceptanceCriterion;
+use App\Models\Feature;
 use App\Models\Plan;
+use App\Models\Scenario;
 use App\Models\Story;
 use App\Models\Task;
 use Illuminate\Database\QueryException;
@@ -40,5 +42,35 @@ test('plan versions are unique within a story', function () {
     Plan::factory()->for(Story::factory())->create(['version' => 1]);
 
     expect(fn () => Plan::factory()->for($story)->create(['version' => 1]))
+        ->toThrow(QueryException::class);
+});
+
+test('story positions are unique within a feature', function () {
+    $feature = Feature::factory()->create();
+    Story::factory()->for($feature)->create(['position' => 1]);
+
+    Story::factory()->for(Feature::factory())->create(['position' => 1]);
+
+    expect(fn () => Story::factory()->for($feature)->create(['position' => 1]))
+        ->toThrow(QueryException::class);
+});
+
+test('acceptance criterion positions are unique within a story', function () {
+    $story = Story::factory()->create();
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 1]);
+
+    AcceptanceCriterion::factory()->for(Story::factory())->create(['position' => 1]);
+
+    expect(fn () => AcceptanceCriterion::factory()->for($story)->create(['position' => 1]))
+        ->toThrow(QueryException::class);
+});
+
+test('scenario positions are unique within a story', function () {
+    $story = Story::factory()->create();
+    Scenario::factory()->for($story)->create(['position' => 1]);
+
+    Scenario::factory()->for(Story::factory())->create(['position' => 1]);
+
+    expect(fn () => Scenario::factory()->for($story)->create(['position' => 1]))
         ->toThrow(QueryException::class);
 });


### PR DESCRIPTION
## Summary
- Enforce scoped position uniqueness for Stories within a Feature, Acceptance Criteria within a Story, and Scenarios within a Story.
- Update Story reordering to move rows through temporary positions so swaps do not violate the new `(feature_id, position)` invariant.
- Add architecture regression coverage for all scoped position constraints.

## Tests
- php artisan test --compact tests/Architecture/PlanningModelArchitectureTest.php tests/Feature/FeatureShowTest.php tests/Feature/StoryAcceptanceCriteriaWriterTest.php tests/Feature/StoryScenarioWriterTest.php
- vendor/bin/pint --dirty --test
- composer test