### PR TITLE
Enforce task and subtask ordering invariants

### DIFF
--- a/app/Services/Ordering/ScopedPositionAllocator.php
+++ b/app/Services/Ordering/ScopedPositionAllocator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Ordering;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
+class ScopedPositionAllocator
+{
+    /**
+     * @template TOwner of Model
+     * @template TReturn
+     *
+     * @param  TOwner  $owner
+     * @param  Closure(int, TOwner): TReturn  $callback
+     * @return TReturn
+     */
+    public function withNextPosition(Model $owner, string $relation, Closure $callback): mixed
+    {
+        return DB::transaction(function () use ($owner, $relation, $callback): mixed {
+            /** @var TOwner $lockedOwner */
+            $lockedOwner = $owner->newQuery()
+                ->whereKey($owner->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $nextPosition = ((int) $lockedOwner->{$relation}()->max('position')) + 1;
+
+            return $callback($nextPosition, $lockedOwner);
+        });
+    }
+}

--- a/app/Services/PlanWriter.php
+++ b/app/Services/PlanWriter.php
@@ -11,9 +11,9 @@ use App\Models\Story;
 use App\Models\Subtask;
 use App\Models\Task;
 use App\Services\Executors\ProposedSubtask;
+use App\Services\Ordering\ScopedPositionAllocator;
 use App\Services\Plans\PlanInputNormalizer;
 use App\Services\Plans\PlanVersionAllocator;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 
@@ -29,6 +29,7 @@ class PlanWriter
     public function __construct(
         private PlanInputNormalizer $planInputs,
         private PlanVersionAllocator $planVersions,
+        private ScopedPositionAllocator $positions,
     ) {}
 
     /**
@@ -153,8 +154,7 @@ class PlanWriter
             $proposed = array_slice($proposed, 0, $cap);
         }
 
-        return DB::transaction(function () use ($task, $proposed, $run) {
-            $startPosition = ((int) $task->subtasks()->max('position')) + 1;
+        return $this->positions->withNextPosition($task, 'subtasks', function (int $startPosition, Task $task) use ($proposed, $run): array {
             $created = [];
 
             foreach ($proposed as $i => $entry) {
@@ -182,7 +182,7 @@ class PlanWriter
 
         $taskPositions = array_column($tasks, 'position');
         if (count($taskPositions) !== count(array_unique($taskPositions))) {
-            throw new InvalidArgumentException('Task positions must be unique within a story.');
+            throw new InvalidArgumentException('Task positions must be unique within a plan.');
         }
 
         $allowedAcIds = $story->acceptanceCriteria()->pluck('id')->all();

--- a/app/Services/Stories/AcceptanceCriteriaWriter.php
+++ b/app/Services/Stories/AcceptanceCriteriaWriter.php
@@ -4,19 +4,23 @@ namespace App\Services\Stories;
 
 use App\Models\AcceptanceCriterion;
 use App\Models\Story;
+use App\Services\Ordering\ScopedPositionAllocator;
 use Illuminate\Support\Facades\DB;
 
 class AcceptanceCriteriaWriter
 {
-    public function __construct(private StoryRevisionLifecycle $revisions) {}
+    public function __construct(
+        private StoryRevisionLifecycle $revisions,
+        private ScopedPositionAllocator $positions,
+    ) {}
 
     public function add(Story $story, string $statement, ?int $position = null): AcceptanceCriterion
     {
-        return DB::transaction(function () use ($story, $statement, $position): AcceptanceCriterion {
-            $criterion = AcceptanceCriterion::withoutEvents(function () use ($story, $statement, $position): AcceptanceCriterion {
+        return $this->positions->withNextPosition($story, 'acceptanceCriteria', function (int $nextPosition, Story $story) use ($statement, $position): AcceptanceCriterion {
+            $criterion = AcceptanceCriterion::withoutEvents(function () use ($story, $statement, $position, $nextPosition): AcceptanceCriterion {
                 return $story->acceptanceCriteria()->create([
                     'statement' => $statement,
-                    'position' => $position ?? ((int) ($story->acceptanceCriteria()->max('position') ?? 0) + 1),
+                    'position' => $position ?? $nextPosition,
                 ]);
             });
 

--- a/app/Services/Stories/ScenarioWriter.php
+++ b/app/Services/Stories/ScenarioWriter.php
@@ -4,12 +4,16 @@ namespace App\Services\Stories;
 
 use App\Models\Scenario;
 use App\Models\Story;
+use App\Services\Ordering\ScopedPositionAllocator;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 
 class ScenarioWriter
 {
-    public function __construct(private StoryRevisionLifecycle $revisions) {}
+    public function __construct(
+        private StoryRevisionLifecycle $revisions,
+        private ScopedPositionAllocator $positions,
+    ) {}
 
     /**
      * @param  array{
@@ -24,15 +28,14 @@ class ScenarioWriter
      */
     public function create(Story $story, array $attributes): Scenario
     {
-        return DB::transaction(function () use ($story, $attributes): Scenario {
-            $story = Story::query()->whereKey($story->getKey())->lockForUpdate()->firstOrFail();
+        return $this->positions->withNextPosition($story, 'scenarios', function (int $nextPosition, Story $story) use ($attributes): Scenario {
             $criterionId = $attributes['acceptance_criterion_id'] ?? null;
             $this->ensureCriterionBelongsToStory($story, $criterionId);
 
-            $scenario = Scenario::withoutEvents(function () use ($story, $attributes, $criterionId): Scenario {
+            $scenario = Scenario::withoutEvents(function () use ($story, $attributes, $criterionId, $nextPosition): Scenario {
                 return $story->scenarios()->create([
                     'acceptance_criterion_id' => $criterionId,
-                    'position' => $attributes['position'] ?? ((int) $story->scenarios()->max('position') + 1),
+                    'position' => $attributes['position'] ?? $nextPosition,
                     'name' => $attributes['name'],
                     'given_text' => $attributes['given_text'] ?? null,
                     'when_text' => $attributes['when_text'] ?? null,

--- a/database/factories/AcceptanceCriterionFactory.php
+++ b/database/factories/AcceptanceCriterionFactory.php
@@ -20,7 +20,9 @@ class AcceptanceCriterionFactory extends Factory
     {
         return [
             'story_id' => Story::factory(),
-            'position' => 1,
+            'position' => fn (array $attributes): int => ((int) AcceptanceCriterion::query()
+                ->where('story_id', $attributes['story_id'])
+                ->max('position')) + 1,
             'statement' => fake()->sentence(),
         ];
     }

--- a/database/factories/ScenarioFactory.php
+++ b/database/factories/ScenarioFactory.php
@@ -17,7 +17,9 @@ class ScenarioFactory extends Factory
         return [
             'story_id' => Story::factory(),
             'acceptance_criterion_id' => null,
-            'position' => 1,
+            'position' => fn (array $attributes): int => ((int) Scenario::query()
+                ->where('story_id', $attributes['story_id'])
+                ->max('position')) + 1,
             'name' => fake()->sentence(4),
             'given_text' => fake()->sentence(),
             'when_text' => fake()->sentence(),

--- a/database/factories/SubtaskFactory.php
+++ b/database/factories/SubtaskFactory.php
@@ -19,7 +19,9 @@ class SubtaskFactory extends Factory
     {
         return [
             'task_id' => Task::factory(),
-            'position' => 1,
+            'position' => fn (array $attributes): int => ((int) Subtask::query()
+                ->where('task_id', $attributes['task_id'])
+                ->max('position')) + 1,
             'name' => fake()->sentence(4),
             'description' => fake()->paragraph(),
             'status' => TaskStatus::Pending,

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -52,7 +52,9 @@ class TaskFactory extends Factory
             'plan_id' => Plan::factory(),
             'acceptance_criterion_id' => null,
             'scenario_id' => null,
-            'position' => 1,
+            'position' => fn (array $attributes): int => ((int) Task::query()
+                ->where('plan_id', $attributes['plan_id'])
+                ->max('position')) + 1,
             'name' => fake()->sentence(4),
             'description' => fake()->paragraph(),
             'status' => TaskStatus::Pending,

--- a/database/migrations/2026_04_29_050716_create_tasks_table.php
+++ b/database/migrations/2026_04_29_050716_create_tasks_table.php
@@ -14,11 +14,12 @@ return new class extends Migration
         Schema::create('tasks', function (Blueprint $table) {
             $table->id();
             $table->foreignId('plan_id')->constrained()->cascadeOnDelete();
-            $table->unsignedInteger('position')->default(0);
+            $table->unsignedInteger('position');
             $table->string('name');
             $table->text('description')->nullable();
             $table->string('status')->default('pending');
             $table->timestamps();
+            $table->unique(['plan_id', 'position']);
         });
     }
 

--- a/database/migrations/2026_04_30_092722_drop_plan_attach_tasks_to_stories_add_subtasks.php
+++ b/database/migrations/2026_04_30_092722_drop_plan_attach_tasks_to_stories_add_subtasks.php
@@ -11,13 +11,13 @@ return new class extends Migration
         Schema::create('subtasks', function (Blueprint $table) {
             $table->id();
             $table->foreignId('task_id')->constrained()->cascadeOnDelete();
-            $table->unsignedInteger('position')->default(0);
+            $table->unsignedInteger('position');
             $table->string('name');
             $table->text('description')->nullable();
             $table->string('status')->default('pending');
             $table->timestamps();
 
-            $table->index(['task_id', 'position']);
+            $table->unique(['task_id', 'position']);
         });
     }
 

--- a/tests/Architecture/PlanningModelArchitectureTest.php
+++ b/tests/Architecture/PlanningModelArchitectureTest.php
@@ -5,6 +5,7 @@ use App\Models\Feature;
 use App\Models\Plan;
 use App\Models\Scenario;
 use App\Models\Story;
+use App\Models\Subtask;
 use App\Models\Task;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Schema;
@@ -73,4 +74,65 @@ test('scenario positions are unique within a story', function () {
 
     expect(fn () => Scenario::factory()->for($story)->create(['position' => 1]))
         ->toThrow(QueryException::class);
+});
+
+test('task positions are unique within a plan', function () {
+    $plan = Plan::factory()->create();
+    Task::factory()->for($plan)->create(['position' => 1]);
+
+    Task::factory()->for(Plan::factory())->create(['position' => 1]);
+
+    expect(fn () => Task::factory()->for($plan)->create(['position' => 1]))
+        ->toThrow(QueryException::class);
+});
+
+test('subtask positions are unique within a task', function () {
+    $task = Task::factory()->create();
+    Subtask::factory()->for($task)->create(['position' => 1]);
+
+    Subtask::factory()->for(Task::factory())->create(['position' => 1]);
+
+    expect(fn () => Subtask::factory()->for($task)->create(['position' => 1]))
+        ->toThrow(QueryException::class);
+});
+
+test('task and subtask positions are required', function () {
+    $plan = Plan::factory()->create();
+    $task = Task::factory()->for($plan)->create();
+
+    expect(fn () => Task::create([
+        'plan_id' => $plan->getKey(),
+        'name' => 'Unpositioned task',
+    ]))->toThrow(QueryException::class);
+
+    expect(fn () => Subtask::create([
+        'task_id' => $task->getKey(),
+        'name' => 'Unpositioned subtask',
+    ]))->toThrow(QueryException::class);
+});
+
+test('factories allocate scoped positions by default', function () {
+    $story = Story::factory()->create();
+    $plan = Plan::factory()->for($story)->create();
+    $task = Task::factory()->for($plan)->create();
+
+    expect([
+        AcceptanceCriterion::factory()->for($story)->create()->position,
+        AcceptanceCriterion::factory()->for($story)->create()->position,
+    ])->toBe([1, 2]);
+
+    expect([
+        Scenario::factory()->for($story)->create()->position,
+        Scenario::factory()->for($story)->create()->position,
+    ])->toBe([1, 2]);
+
+    expect([
+        $task->position,
+        Task::factory()->for($plan)->create()->position,
+    ])->toBe([1, 2]);
+
+    expect([
+        Subtask::factory()->for($task)->create()->position,
+        Subtask::factory()->for($task)->create()->position,
+    ])->toBe([1, 2]);
 });


### PR DESCRIPTION
## Summary
- Add DB-level scoped position uniqueness for Tasks within a Plan and Subtasks within a Task.
- Add a shared `ScopedPositionAllocator` and route Acceptance Criteria, Scenario, and proposed Subtask appends through it.
- Update factories so repeated scoped children allocate valid positions by default.
- Expand architecture coverage for product, plan, task, and subtask scoped ordering invariants.

## Tests
- php artisan test --compact tests/Architecture/PlanningModelArchitectureTest.php tests/Feature/StoryAcceptanceCriteriaWriterTest.php tests/Feature/StoryScenarioWriterTest.php tests/Feature/RunningHypothesisPlanTest.php tests/Feature/TaskGenerationTest.php tests/Feature/SubtaskOrderingTest.php tests/Feature/SubtaskExecutionTest.php tests/Feature/PlanApprovalTest.php
- php artisan test --compact tests/Architecture/PlanningModelArchitectureTest.php tests/Feature/FeatureShowTest.php tests/Feature/StoryAcceptanceCriteriaWriterTest.php tests/Feature/StoryScenarioWriterTest.php tests/Feature/RunningHypothesisPlanTest.php tests/Feature/TaskGenerationTest.php tests/Feature/SubtaskOrderingTest.php tests/Feature/SubtaskExecutionTest.php tests/Feature/PlanApprovalTest.php tests/Feature/PlanningArchitectureConformanceTest.php
- vendor/bin/pint --dirty --test
- composer test