### PR TITLE
Centralize story contract updates

### DIFF
--- a/app/Mcp/Tools/UpdateStoryTool.php
+++ b/app/Mcp/Tools/UpdateStoryTool.php
@@ -5,10 +5,8 @@ namespace App\Mcp\Tools;
 use App\Enums\StoryKind;
 use App\Enums\StoryStatus;
 use App\Mcp\Concerns\ResolvesProjectAccess;
-use App\Models\Story;
-use App\Services\Stories\AcceptanceCriteriaWriter;
+use App\Services\Stories\StoryWriter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Illuminate\Support\Facades\DB;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -27,7 +25,7 @@ class UpdateStoryTool extends Tool
     /**
      * Handle the MCP tool invocation.
      */
-    public function handle(Request $request, AcceptanceCriteriaWriter $criteria): Response
+    public function handle(Request $request, StoryWriter $stories): Response
     {
         $user = $this->resolveUser($request);
         if ($user instanceof Response) {
@@ -70,21 +68,11 @@ class UpdateStoryTool extends Tool
             return Response::error('Provide at least one of: name, kind, actor, intent, outcome, description, notes, status, acceptance_criteria.');
         }
 
-        DB::transaction(function () use ($story, $changes, $validated, $hasCriteriaUpdate, $criteria) {
-            if ($changes) {
-                if ($hasCriteriaUpdate) {
-                    Story::withoutRevisionBump(function () use ($story, $changes): void {
-                        $story->fill($changes)->save();
-                    });
-                } else {
-                    $story->fill($changes)->save();
-                }
-            }
-
-            if ($hasCriteriaUpdate) {
-                $criteria->replace($story, $validated['acceptance_criteria']);
-            }
-        });
+        $stories->update(
+            $story,
+            $changes,
+            $hasCriteriaUpdate ? $validated['acceptance_criteria'] : null,
+        );
 
         $story->refresh();
 

--- a/app/Services/Stories/AcceptanceCriteriaWriter.php
+++ b/app/Services/Stories/AcceptanceCriteriaWriter.php
@@ -36,18 +36,26 @@ class AcceptanceCriteriaWriter
     public function replace(Story $story, array $statements): void
     {
         DB::transaction(function () use ($story, $statements): void {
-            AcceptanceCriterion::withoutEvents(function () use ($story, $statements): void {
-                $story->acceptanceCriteria()->delete();
-
-                foreach ($statements as $i => $statement) {
-                    $story->acceptanceCriteria()->create([
-                        'statement' => $statement,
-                        'position' => $i + 1,
-                    ]);
-                }
-            });
-
-            $this->revisions->recordContentArtifactChanged($story);
+            $this->replaceInsideTransaction($story, $statements);
         });
+    }
+
+    /**
+     * @param  list<string>  $statements
+     */
+    public function replaceInsideTransaction(Story $story, array $statements): void
+    {
+        AcceptanceCriterion::withoutEvents(function () use ($story, $statements): void {
+            $story->acceptanceCriteria()->delete();
+
+            foreach ($statements as $i => $statement) {
+                $story->acceptanceCriteria()->create([
+                    'statement' => $statement,
+                    'position' => $i + 1,
+                ]);
+            }
+        });
+
+        $this->revisions->recordContentArtifactChanged($story);
     }
 }

--- a/app/Services/Stories/StoryWriter.php
+++ b/app/Services/Stories/StoryWriter.php
@@ -78,7 +78,7 @@ class StoryWriter
             }
 
             if ($acceptanceCriteria !== null) {
-                $this->criteria->replace($story, $acceptanceCriteria);
+                $this->criteria->replaceInsideTransaction($story, $acceptanceCriteria);
             }
         });
     }

--- a/app/Services/Stories/StoryWriter.php
+++ b/app/Services/Stories/StoryWriter.php
@@ -12,6 +12,10 @@ use Illuminate\Support\Facades\DB;
 
 class StoryWriter
 {
+    public function __construct(
+        private readonly AcceptanceCriteriaWriter $criteria,
+    ) {}
+
     /**
      * @param  array{
      *     name: string,
@@ -41,16 +45,56 @@ class StoryWriter
                 'revision' => 1,
             ]);
 
-            AcceptanceCriterion::withoutEvents(function () use ($story, $attributes): void {
-                foreach (array_values($attributes['acceptance_criteria'] ?? []) as $i => $criterion) {
-                    $story->acceptanceCriteria()->create([
-                        'statement' => $criterion,
-                        'position' => $i + 1,
-                    ]);
-                }
-            });
+            $this->createInitialAcceptanceCriteria($story, $attributes['acceptance_criteria'] ?? []);
 
             return $story;
+        });
+    }
+
+    /**
+     * @param  array{
+     *     name?: string,
+     *     kind?: StoryKind,
+     *     actor?: string|null,
+     *     intent?: string|null,
+     *     outcome?: string|null,
+     *     description?: string|null,
+     *     notes?: string|null,
+     *     status?: StoryStatus
+     * }  $changes
+     * @param  list<string>|null  $acceptanceCriteria
+     */
+    public function update(Story $story, array $changes = [], ?array $acceptanceCriteria = null): void
+    {
+        DB::transaction(function () use ($story, $changes, $acceptanceCriteria): void {
+            if ($changes !== []) {
+                if ($acceptanceCriteria !== null) {
+                    Story::withoutRevisionBump(function () use ($story, $changes): void {
+                        $story->fill($changes)->save();
+                    });
+                } else {
+                    $story->fill($changes)->save();
+                }
+            }
+
+            if ($acceptanceCriteria !== null) {
+                $this->criteria->replace($story, $acceptanceCriteria);
+            }
+        });
+    }
+
+    /**
+     * @param  array<int|string, string>  $criteria
+     */
+    private function createInitialAcceptanceCriteria(Story $story, array $criteria): void
+    {
+        AcceptanceCriterion::withoutEvents(function () use ($story, $criteria): void {
+            foreach (array_values($criteria) as $i => $criterion) {
+                $story->acceptanceCriteria()->create([
+                    'statement' => $criterion,
+                    'position' => $i + 1,
+                ]);
+            }
         });
     }
 }

--- a/tests/Feature/StoryAcceptanceCriteriaWriterTest.php
+++ b/tests/Feature/StoryAcceptanceCriteriaWriterTest.php
@@ -12,6 +12,7 @@ use App\Models\Team;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Stories\AcceptanceCriteriaWriter;
+use App\Services\Stories\StoryWriter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Mcp\Request;
 
@@ -57,7 +58,7 @@ test('update story tool replaces acceptance criteria as one story content revisi
     $response = app(UpdateStoryTool::class)->handle(new Request([
         'story_id' => $story->getKey(),
         'acceptance_criteria' => ['New one', 'New two', 'New three'],
-    ]), app(AcceptanceCriteriaWriter::class));
+    ]), app(StoryWriter::class));
 
     expect($response->isError())->toBeFalse()
         ->and($story->fresh()->revision)->toBe(2)
@@ -83,7 +84,7 @@ test('update story tool combines story fields and acceptance criteria into one s
         'story_id' => $story->getKey(),
         'name' => 'Renamed story',
         'acceptance_criteria' => ['New one'],
-    ]), app(AcceptanceCriteriaWriter::class));
+    ]), app(StoryWriter::class));
 
     $fresh = $story->fresh();
 

--- a/tests/Feature/StoryWriterTest.php
+++ b/tests/Feature/StoryWriterTest.php
@@ -1,9 +1,13 @@
 <?php
 
+use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
 use App\Mcp\Tools\CreateStoryTool;
+use App\Models\ApprovalPolicy;
 use App\Models\Feature;
+use App\Models\Plan;
 use App\Models\Project;
+use App\Models\Story;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Workspace;
@@ -59,4 +63,59 @@ test('story writer normalizes keyed initial acceptance criteria before assigning
     expect($story->fresh()->revision)->toBe(1)
         ->and($story->acceptanceCriteria()->orderBy('position')->pluck('position')->all())
         ->toBe([1, 2]);
+});
+
+test('story writer updates story contract fields as one content revision', function () {
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $story = Story::factory()
+        ->for(Feature::factory()->for(Project::factory()->for($team)))
+        ->create(['status' => StoryStatus::Approved, 'revision' => 1]);
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_PROJECT,
+        'scope_id' => $story->feature->project_id,
+        'required_approvals' => 1,
+    ]);
+    $plan = Plan::factory()->for($story)->create(['status' => PlanStatus::Approved]);
+    $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
+
+    app(StoryWriter::class)->update($story, [
+        'name' => 'Renamed story',
+        'description' => 'Updated product contract.',
+    ]);
+
+    $fresh = $story->fresh()->load('currentPlan');
+
+    expect($fresh->name)->toBe('Renamed story')
+        ->and($fresh->description)->toBe('Updated product contract.')
+        ->and($fresh->revision)->toBe(2)
+        ->and($fresh->status)->toBe(StoryStatus::PendingApproval)
+        ->and($fresh->currentPlan->status)->toBe(PlanStatus::PendingApproval);
+});
+
+test('story writer combines field updates and criteria replacement into one content revision', function () {
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $story = Story::factory()
+        ->for(Feature::factory()->for(Project::factory()->for($team)))
+        ->create(['status' => StoryStatus::Approved, 'revision' => 1]);
+    ApprovalPolicy::create([
+        'scope_type' => ApprovalPolicy::SCOPE_PROJECT,
+        'scope_id' => $story->feature->project_id,
+        'required_approvals' => 1,
+    ]);
+
+    app(StoryWriter::class)->update(
+        $story,
+        ['name' => 'Renamed story'],
+        ['New one', 'New two'],
+    );
+
+    $fresh = $story->fresh();
+
+    expect($fresh->name)->toBe('Renamed story')
+        ->and($fresh->revision)->toBe(2)
+        ->and($fresh->status)->toBe(StoryStatus::PendingApproval)
+        ->and($fresh->acceptanceCriteria()->orderBy('position')->pluck('statement')->all())
+        ->toBe(['New one', 'New two']);
 });


### PR DESCRIPTION
## Summary
- move combined Story field + acceptance-criteria update choreography into `StoryWriter`
- keep `UpdateStoryTool` focused on access, validation, and response shaping
- add service-level coverage for single-revision Story contract updates and current Plan approval reopening

## Architecture Notes
This continues the grouped cleanup after the planning hierarchy work. Story product-contract mutation now has a clearer service boundary: MCP tools no longer own transaction/revision suppression details for replacing criteria alongside Story field edits.

`StoryWriter` now owns the semantic operation of updating the Story contract, including the case where field edits and acceptance criteria replacement must count as one content revision.

## Verification
- `php -l app/Services/Stories/StoryWriter.php`
- `php -l app/Mcp/Tools/UpdateStoryTool.php`
- `php -l tests/Feature/StoryWriterTest.php`
- `php -l tests/Feature/StoryAcceptanceCriteriaWriterTest.php`
- `php artisan test --compact tests/Feature/StoryWriterTest.php tests/Feature/StoryAcceptanceCriteriaWriterTest.php tests/Feature/StoryAuthoringTest.php tests/Feature/StorySubmissionGateTest.php tests/Feature/StoryShowPageTest.php`
- `vendor/bin/pint --dirty --test`
- `composer test`
