### PR TITLE
Tighten approval target boundaries

### DIFF
--- a/app/Mcp/Concerns/RecordsApprovalDecisions.php
+++ b/app/Mcp/Concerns/RecordsApprovalDecisions.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Mcp\Concerns;
+
+use App\Enums\ApprovalDecision;
+use App\Models\Plan;
+use App\Models\PlanApproval;
+use App\Models\Story;
+use App\Models\StoryApproval;
+use App\Models\User;
+use Laravel\Mcp\Response;
+
+trait RecordsApprovalDecisions
+{
+    protected function resolveStoryForApproval(int $storyId, User $user): Story|Response
+    {
+        $story = $this->resolveAccessibleStory($storyId, $user);
+        if ($story instanceof Response) {
+            return $story;
+        }
+
+        $story->loadMissing('feature.project');
+
+        if (! $user->canApproveInProject($story->feature->project)) {
+            return Response::error('You do not have approver rights in this project.');
+        }
+
+        return $story;
+    }
+
+    protected function resolveCurrentPlanForApproval(int $planId, User $user): Plan|Response
+    {
+        $plan = $this->resolveAccessiblePlan($planId, $user);
+        if ($plan instanceof Response) {
+            return $plan;
+        }
+
+        $plan->loadMissing('story.feature.project');
+
+        if (! $plan->isCurrent()) {
+            return Response::error('Only the story\'s current plan can receive approval decisions.');
+        }
+
+        if (! $user->canApproveInProject($plan->story->feature->project)) {
+            return Response::error('You do not have approver rights in this project.');
+        }
+
+        return $plan;
+    }
+
+    protected function storyApprovalResponse(Story $story, StoryApproval $approval, ApprovalDecision $decision): Response
+    {
+        $story->refresh();
+
+        return Response::json([
+            'approval_id' => $approval->id,
+            'story_id' => $story->id,
+            'story_status' => $story->status?->value,
+            'decision' => $decision->value,
+        ]);
+    }
+
+    protected function planApprovalResponse(Plan $plan, PlanApproval $approval, ApprovalDecision $decision): Response
+    {
+        $plan->refresh();
+
+        return Response::json([
+            'approval_id' => $approval->id,
+            'plan_id' => $plan->id,
+            'story_id' => $plan->story_id,
+            'plan_status' => $plan->status?->value,
+            'decision' => $decision->value,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/ApprovePlanTool.php
+++ b/app/Mcp/Tools/ApprovePlanTool.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Tools;
 
 use App\Enums\ApprovalDecision;
+use App\Mcp\Concerns\RecordsApprovalDecisions;
 use App\Mcp\Concerns\ResolvesProjectAccess;
 use App\Services\ApprovalService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -11,9 +12,10 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tool;
 
-#[Description('Record an Approve decision on a plan. Authorisation: user must have approver rights in the plan’s project. Notes optional.')]
+#[Description('Record an Approve decision on the story’s current plan. Authorisation: user must have approver rights in the plan’s project. Notes optional.')]
 class ApprovePlanTool extends Tool
 {
+    use RecordsApprovalDecisions;
     use ResolvesProjectAccess;
 
     protected string $name = 'approve-plan';
@@ -30,37 +32,25 @@ class ApprovePlanTool extends Tool
             'notes' => ['nullable', 'string'],
         ]);
 
-        $plan = $this->resolveAccessiblePlan($validated['plan_id'], $user);
+        $plan = $this->resolveCurrentPlanForApproval($validated['plan_id'], $user);
         if ($plan instanceof Response) {
             return $plan;
         }
 
-        $project = $plan->story?->feature?->project;
-        if (! $project || ! $user->canApproveInProject($project)) {
-            return Response::error('You do not have approver rights in this project.');
-        }
-
         try {
-            $approval = $approvals->recordPlanDecision($plan, $user, ApprovalDecision::Approve, $validated['notes'] ?? null);
+            $decision = ApprovalDecision::Approve;
+            $approval = $approvals->recordPlanDecision($plan, $user, $decision, $validated['notes'] ?? null);
         } catch (\Throwable $e) {
             return Response::error($e->getMessage());
         }
 
-        $plan->refresh();
-
-        return Response::json([
-            'approval_id' => $approval->id,
-            'plan_id' => $plan->id,
-            'story_id' => $plan->story_id,
-            'plan_status' => $plan->status?->value,
-            'decision' => 'approve',
-        ]);
+        return $this->planApprovalResponse($plan, $approval, $decision);
     }
 
     public function schema(JsonSchema $schema): array
     {
         return [
-            'plan_id' => $schema->integer()->description('Plan to approve.')->required(),
+            'plan_id' => $schema->integer()->description('Current plan to approve.')->required(),
             'notes' => $schema->string()->description('Optional approval notes.'),
         ];
     }

--- a/app/Mcp/Tools/ApproveStoryTool.php
+++ b/app/Mcp/Tools/ApproveStoryTool.php
@@ -3,8 +3,8 @@
 namespace App\Mcp\Tools;
 
 use App\Enums\ApprovalDecision;
+use App\Mcp\Concerns\RecordsApprovalDecisions;
 use App\Mcp\Concerns\ResolvesProjectAccess;
-use App\Models\Story;
 use App\Services\ApprovalService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -15,9 +15,10 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: approve-story
  */
-#[Description('Record an Approve decision on a story. Authorisation: user must have approver rights in the story’s project. Notes optional.')]
+#[Description('Record an Approve decision on a story product contract. Authorisation: user must have approver rights in the story’s project. Notes optional.')]
 class ApproveStoryTool extends Tool
 {
+    use RecordsApprovalDecisions;
     use ResolvesProjectAccess;
 
     protected string $name = 'approve-story';
@@ -37,30 +38,19 @@ class ApproveStoryTool extends Tool
             'notes' => ['nullable', 'string'],
         ]);
 
-        $story = Story::query()->with('feature.project')->find($validated['story_id']);
-        if (! $story) {
-            return Response::error('Story not found.');
-        }
-
-        $project = $story->feature->project;
-        if (! $project || ! $user->canApproveInProject($project)) {
-            return Response::error('You do not have approver rights in this project.');
+        $story = $this->resolveStoryForApproval($validated['story_id'], $user);
+        if ($story instanceof Response) {
+            return $story;
         }
 
         try {
-            $approval = $approvals->recordDecision($story, $user, ApprovalDecision::Approve, $validated['notes'] ?? null);
+            $decision = ApprovalDecision::Approve;
+            $approval = $approvals->recordDecision($story, $user, $decision, $validated['notes'] ?? null);
         } catch (\Throwable $e) {
             return Response::error($e->getMessage());
         }
 
-        $story->refresh();
-
-        return Response::json([
-            'approval_id' => $approval->id,
-            'story_id' => $story->id,
-            'story_status' => $story->status?->value,
-            'decision' => 'approve',
-        ]);
+        return $this->storyApprovalResponse($story, $approval, $decision);
     }
 
     /**
@@ -69,7 +59,7 @@ class ApproveStoryTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'story_id' => $schema->integer()->description('Story to approve.')->required(),
+            'story_id' => $schema->integer()->description('Story product contract to approve.')->required(),
             'notes' => $schema->string()->description('Optional approval notes.'),
         ];
     }

--- a/app/Mcp/Tools/RejectPlanTool.php
+++ b/app/Mcp/Tools/RejectPlanTool.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Tools;
 
 use App\Enums\ApprovalDecision;
+use App\Mcp\Concerns\RecordsApprovalDecisions;
 use App\Mcp\Concerns\ResolvesProjectAccess;
 use App\Services\ApprovalService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -11,9 +12,10 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tool;
 
-#[Description('Reject a plan. Terminal — no further decisions accepted on this plan revision.')]
+#[Description('Reject the story’s current plan. Terminal — no further decisions accepted on this plan revision.')]
 class RejectPlanTool extends Tool
 {
+    use RecordsApprovalDecisions;
     use ResolvesProjectAccess;
 
     protected string $name = 'reject-plan';
@@ -30,37 +32,25 @@ class RejectPlanTool extends Tool
             'notes' => ['required', 'string'],
         ]);
 
-        $plan = $this->resolveAccessiblePlan($validated['plan_id'], $user);
+        $plan = $this->resolveCurrentPlanForApproval($validated['plan_id'], $user);
         if ($plan instanceof Response) {
             return $plan;
         }
 
-        $project = $plan->story?->feature?->project;
-        if (! $project || ! $user->canApproveInProject($project)) {
-            return Response::error('You do not have approver rights in this project.');
-        }
-
         try {
-            $approval = $approvals->recordPlanDecision($plan, $user, ApprovalDecision::Reject, $validated['notes']);
+            $decision = ApprovalDecision::Reject;
+            $approval = $approvals->recordPlanDecision($plan, $user, $decision, $validated['notes']);
         } catch (\Throwable $e) {
             return Response::error($e->getMessage());
         }
 
-        $plan->refresh();
-
-        return Response::json([
-            'approval_id' => $approval->id,
-            'plan_id' => $plan->id,
-            'story_id' => $plan->story_id,
-            'plan_status' => $plan->status?->value,
-            'decision' => 'reject',
-        ]);
+        return $this->planApprovalResponse($plan, $approval, $decision);
     }
 
     public function schema(JsonSchema $schema): array
     {
         return [
-            'plan_id' => $schema->integer()->description('Plan to reject.')->required(),
+            'plan_id' => $schema->integer()->description('Current plan to reject.')->required(),
             'notes' => $schema->string()->description('Reason for rejection. Required.')->required(),
         ];
     }

--- a/app/Mcp/Tools/RejectStoryTool.php
+++ b/app/Mcp/Tools/RejectStoryTool.php
@@ -3,8 +3,8 @@
 namespace App\Mcp\Tools;
 
 use App\Enums\ApprovalDecision;
+use App\Mcp\Concerns\RecordsApprovalDecisions;
 use App\Mcp\Concerns\ResolvesProjectAccess;
-use App\Models\Story;
 use App\Services\ApprovalService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -15,9 +15,10 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: reject-story
  */
-#[Description('Reject a story. Terminal — no further decisions accepted on this story revision.')]
+#[Description('Reject a story product contract. Terminal — no further decisions accepted on this story revision.')]
 class RejectStoryTool extends Tool
 {
+    use RecordsApprovalDecisions;
     use ResolvesProjectAccess;
 
     protected string $name = 'reject-story';
@@ -37,30 +38,19 @@ class RejectStoryTool extends Tool
             'notes' => ['required', 'string'],
         ]);
 
-        $story = Story::query()->with('feature.project')->find($validated['story_id']);
-        if (! $story) {
-            return Response::error('Story not found.');
-        }
-
-        $project = $story->feature->project;
-        if (! $project || ! $user->canApproveInProject($project)) {
-            return Response::error('You do not have approver rights in this project.');
+        $story = $this->resolveStoryForApproval($validated['story_id'], $user);
+        if ($story instanceof Response) {
+            return $story;
         }
 
         try {
-            $approval = $approvals->recordDecision($story, $user, ApprovalDecision::Reject, $validated['notes']);
+            $decision = ApprovalDecision::Reject;
+            $approval = $approvals->recordDecision($story, $user, $decision, $validated['notes']);
         } catch (\Throwable $e) {
             return Response::error($e->getMessage());
         }
 
-        $story->refresh();
-
-        return Response::json([
-            'approval_id' => $approval->id,
-            'story_id' => $story->id,
-            'story_status' => $story->status?->value,
-            'decision' => 'reject',
-        ]);
+        return $this->storyApprovalResponse($story, $approval, $decision);
     }
 
     /**
@@ -69,7 +59,7 @@ class RejectStoryTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'story_id' => $schema->integer()->description('Story to reject.')->required(),
+            'story_id' => $schema->integer()->description('Story product contract to reject.')->required(),
             'notes' => $schema->string()->description('Reason for rejection. Required.')->required(),
         ];
     }

--- a/app/Mcp/Tools/RequestPlanChangesTool.php
+++ b/app/Mcp/Tools/RequestPlanChangesTool.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Tools;
 
 use App\Enums\ApprovalDecision;
+use App\Mcp\Concerns\RecordsApprovalDecisions;
 use App\Mcp\Concerns\ResolvesProjectAccess;
 use App\Services\ApprovalService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -11,9 +12,10 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tool;
 
-#[Description('Request changes on a plan. Resets prior effective plan approvals and keeps the plan pending approval.')]
+#[Description('Request changes on the story’s current plan. Resets prior effective plan approvals and keeps the plan pending approval.')]
 class RequestPlanChangesTool extends Tool
 {
+    use RecordsApprovalDecisions;
     use ResolvesProjectAccess;
 
     protected string $name = 'request-plan-changes';
@@ -30,37 +32,25 @@ class RequestPlanChangesTool extends Tool
             'notes' => ['required', 'string'],
         ]);
 
-        $plan = $this->resolveAccessiblePlan($validated['plan_id'], $user);
+        $plan = $this->resolveCurrentPlanForApproval($validated['plan_id'], $user);
         if ($plan instanceof Response) {
             return $plan;
         }
 
-        $project = $plan->story?->feature?->project;
-        if (! $project || ! $user->canApproveInProject($project)) {
-            return Response::error('You do not have approver rights in this project.');
-        }
-
         try {
-            $approval = $approvals->recordPlanDecision($plan, $user, ApprovalDecision::ChangesRequested, $validated['notes']);
+            $decision = ApprovalDecision::ChangesRequested;
+            $approval = $approvals->recordPlanDecision($plan, $user, $decision, $validated['notes']);
         } catch (\Throwable $e) {
             return Response::error($e->getMessage());
         }
 
-        $plan->refresh();
-
-        return Response::json([
-            'approval_id' => $approval->id,
-            'plan_id' => $plan->id,
-            'story_id' => $plan->story_id,
-            'plan_status' => $plan->status?->value,
-            'decision' => 'changes_requested',
-        ]);
+        return $this->planApprovalResponse($plan, $approval, $decision);
     }
 
     public function schema(JsonSchema $schema): array
     {
         return [
-            'plan_id' => $schema->integer()->description('Plan to request changes on.')->required(),
+            'plan_id' => $schema->integer()->description('Current plan to request changes on.')->required(),
             'notes' => $schema->string()->description('What needs to change. Required.')->required(),
         ];
     }

--- a/app/Mcp/Tools/RequestStoryChangesTool.php
+++ b/app/Mcp/Tools/RequestStoryChangesTool.php
@@ -3,8 +3,8 @@
 namespace App\Mcp\Tools;
 
 use App\Enums\ApprovalDecision;
+use App\Mcp\Concerns\RecordsApprovalDecisions;
 use App\Mcp\Concerns\ResolvesProjectAccess;
-use App\Models\Story;
 use App\Services\ApprovalService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -15,9 +15,10 @@ use Laravel\Mcp\Server\Tool;
 /**
  * MCP tool: request-story-changes
  */
-#[Description('Request changes on a story. Resets prior approvals and moves the story to ChangesRequested.')]
+#[Description('Request changes on a story product contract. Resets prior approvals and moves the story to ChangesRequested.')]
 class RequestStoryChangesTool extends Tool
 {
+    use RecordsApprovalDecisions;
     use ResolvesProjectAccess;
 
     protected string $name = 'request-story-changes';
@@ -37,30 +38,19 @@ class RequestStoryChangesTool extends Tool
             'notes' => ['required', 'string'],
         ]);
 
-        $story = Story::query()->with('feature.project')->find($validated['story_id']);
-        if (! $story) {
-            return Response::error('Story not found.');
-        }
-
-        $project = $story->feature->project;
-        if (! $project || ! $user->canApproveInProject($project)) {
-            return Response::error('You do not have approver rights in this project.');
+        $story = $this->resolveStoryForApproval($validated['story_id'], $user);
+        if ($story instanceof Response) {
+            return $story;
         }
 
         try {
-            $approval = $approvals->recordDecision($story, $user, ApprovalDecision::ChangesRequested, $validated['notes']);
+            $decision = ApprovalDecision::ChangesRequested;
+            $approval = $approvals->recordDecision($story, $user, $decision, $validated['notes']);
         } catch (\Throwable $e) {
             return Response::error($e->getMessage());
         }
 
-        $story->refresh();
-
-        return Response::json([
-            'approval_id' => $approval->id,
-            'story_id' => $story->id,
-            'story_status' => $story->status?->value,
-            'decision' => 'changes_requested',
-        ]);
+        return $this->storyApprovalResponse($story, $approval, $decision);
     }
 
     /**
@@ -69,7 +59,7 @@ class RequestStoryChangesTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'story_id' => $schema->integer()->description('Story to request changes on.')->required(),
+            'story_id' => $schema->integer()->description('Story product contract to request changes on.')->required(),
             'notes' => $schema->string()->description('What needs to change. Required.')->required(),
         ];
     }

--- a/app/Mcp/Tools/SubmitPlanTool.php
+++ b/app/Mcp/Tools/SubmitPlanTool.php
@@ -9,7 +9,7 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tool;
 
-#[Description('Submit a plan for approval (Draft → PendingApproval). Errors if the plan has been rejected or has no tasks.')]
+#[Description('Submit the story’s current plan for approval (Draft → PendingApproval). Errors if the plan is not current, has been rejected, or has no tasks.')]
 class SubmitPlanTool extends Tool
 {
     use ResolvesProjectAccess;

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -53,9 +53,11 @@ class Plan extends Model
 
     public function isCurrent(): bool
     {
-        $this->loadMissing('story');
+        if (! $this->exists) {
+            return false;
+        }
 
-        return (int) $this->story?->current_plan_id === (int) $this->getKey();
+        return (int) $this->story()->value('current_plan_id') === (int) $this->getKey();
     }
 
     public function submitForApproval(): void

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -51,6 +51,13 @@ class Plan extends Model
         return $this->status === PlanStatus::Approved;
     }
 
+    public function isCurrent(): bool
+    {
+        $this->loadMissing('story');
+
+        return (int) $this->story?->current_plan_id === (int) $this->getKey();
+    }
+
     public function submitForApproval(): void
     {
         app(PlanApprovalLifecycle::class)->submit($this);

--- a/app/Services/ApprovalService.php
+++ b/app/Services/ApprovalService.php
@@ -72,6 +72,9 @@ class ApprovalService
         ApprovalDecision $decision,
         ?string $notes = null,
     ): PlanApproval {
+        if (! $target->isCurrent()) {
+            throw new RuntimeException('Only the story\'s current plan can receive approval decisions.');
+        }
         if ($target->status === PlanStatus::Draft) {
             throw new RuntimeException('Plan must be submitted before review decisions can be recorded.');
         }

--- a/app/Services/Plans/PlanApprovalLifecycle.php
+++ b/app/Services/Plans/PlanApprovalLifecycle.php
@@ -13,6 +13,10 @@ class PlanApprovalLifecycle
 
     public function submit(Plan $plan): void
     {
+        if (! $plan->isCurrent()) {
+            throw new RuntimeException('Only the story\'s current plan can be submitted for approval.');
+        }
+
         if ($plan->status === PlanStatus::Rejected) {
             throw new RuntimeException('Cannot submit a rejected plan.');
         }

--- a/tests/Feature/ApprovalMcpToolsTest.php
+++ b/tests/Feature/ApprovalMcpToolsTest.php
@@ -4,6 +4,11 @@ use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
 use App\Enums\TeamRole;
 use App\Mcp\Tools\ApprovePlanTool;
+use App\Mcp\Tools\ApproveStoryTool;
+use App\Mcp\Tools\RejectPlanTool;
+use App\Mcp\Tools\RejectStoryTool;
+use App\Mcp\Tools\RequestPlanChangesTool;
+use App\Mcp\Tools\RequestStoryChangesTool;
 use App\Mcp\Tools\SubmitPlanTool;
 use App\Models\Feature;
 use App\Models\Plan;
@@ -62,4 +67,79 @@ test('approve plan tool rejects non-current plans', function () {
 
     expect($response->isError())->toBeTrue()
         ->and((string) $response->content())->toContain('current plan');
+});
+
+test('plan approval tools share current plan resolution and response shape', function (
+    string $tool,
+    array $extraPayload,
+    string $decision,
+    string $expectedStatus,
+) {
+    ['user' => $user, 'story' => $story] = approvalToolScene();
+    $plan = Plan::query()->findOrFail($story->current_plan_id);
+    $plan->forceFill(['status' => PlanStatus::PendingApproval])->save();
+    $this->actingAs($user);
+
+    $response = app($tool)->handle(new Request(array_merge([
+        'plan_id' => $plan->getKey(),
+    ], $extraPayload)), app(ApprovalService::class));
+    $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($response->isError())->toBeFalse()
+        ->and($payload)->toHaveKeys(['approval_id', 'plan_id', 'story_id', 'plan_status', 'decision'])
+        ->and($payload['plan_id'])->toBe($plan->getKey())
+        ->and($payload['story_id'])->toBe($story->getKey())
+        ->and($payload['decision'])->toBe($decision)
+        ->and($payload['plan_status'])->toBe($expectedStatus);
+})->with([
+    'approve current plan' => [ApprovePlanTool::class, [], 'approve', PlanStatus::Approved->value],
+    'reject current plan' => [RejectPlanTool::class, ['notes' => 'Not acceptable.'], 'reject', PlanStatus::Rejected->value],
+    'request current plan changes' => [RequestPlanChangesTool::class, ['notes' => 'Needs smaller subtasks.'], 'changes_requested', PlanStatus::PendingApproval->value],
+]);
+
+test('story approval tools share story contract resolution and response shape', function (
+    string $tool,
+    array $extraPayload,
+    string $decision,
+    string $expectedStatus,
+) {
+    ['user' => $user, 'story' => $story] = approvalToolScene();
+    $story->forceFill(['status' => StoryStatus::PendingApproval])->save();
+    $this->actingAs($user);
+
+    $response = app($tool)->handle(new Request(array_merge([
+        'story_id' => $story->getKey(),
+    ], $extraPayload)), app(ApprovalService::class));
+    $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($response->isError())->toBeFalse()
+        ->and($payload)->toHaveKeys(['approval_id', 'story_id', 'story_status', 'decision'])
+        ->and($payload['story_id'])->toBe($story->getKey())
+        ->and($payload['decision'])->toBe($decision)
+        ->and($payload['story_status'])->toBe($expectedStatus);
+})->with([
+    'approve story contract' => [ApproveStoryTool::class, [], 'approve', StoryStatus::Approved->value],
+    'reject story contract' => [RejectStoryTool::class, ['notes' => 'Not acceptable.'], 'reject', StoryStatus::Rejected->value],
+    'request story contract changes' => [RequestStoryChangesTool::class, ['notes' => 'Clarify acceptance criteria.'], 'changes_requested', StoryStatus::ChangesRequested->value],
+]);
+
+test('shared approval resolver rejects users without approver rights', function () {
+    ['story' => $story] = approvalToolScene();
+    $member = User::factory()->create();
+    $story->feature->project->team->addMember($member, TeamRole::Member);
+    $plan = Plan::query()->findOrFail($story->current_plan_id);
+    $plan->forceFill(['status' => PlanStatus::PendingApproval])->save();
+    $this->actingAs($member);
+
+    $storyResponse = app(ApproveStoryTool::class)->handle(new Request([
+        'story_id' => $story->getKey(),
+    ]), app(ApprovalService::class));
+    $planResponse = app(ApprovePlanTool::class)->handle(new Request([
+        'plan_id' => $plan->getKey(),
+    ]), app(ApprovalService::class));
+
+    expect($storyResponse->isError())->toBeTrue()
+        ->and((string) $storyResponse->content())->toContain('approver rights')
+        ->and($planResponse->isError())->toBeTrue()
+        ->and((string) $planResponse->content())->toContain('approver rights');
 });

--- a/tests/Feature/ApprovalMcpToolsTest.php
+++ b/tests/Feature/ApprovalMcpToolsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Enums\PlanStatus;
+use App\Enums\StoryStatus;
+use App\Enums\TeamRole;
+use App\Mcp\Tools\ApprovePlanTool;
+use App\Mcp\Tools\SubmitPlanTool;
+use App\Models\Feature;
+use App\Models\Plan;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\ApprovalService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+
+uses(RefreshDatabase::class);
+
+function approvalToolScene(): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Admin);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create(['status' => StoryStatus::Approved]);
+    $currentTask = Task::factory()->forCurrentPlanOf($story)->create(['position' => 1]);
+    $story->forceFill(['current_plan_id' => $currentTask->plan_id])->save();
+
+    return compact('user', 'story');
+}
+
+test('submit plan tool rejects non-current plans', function () {
+    ['user' => $user, 'story' => $story] = approvalToolScene();
+    $otherPlan = Plan::factory()->for($story)->create(['version' => 2]);
+    Task::factory()->for($otherPlan)->create(['position' => 1]);
+    $this->actingAs($user);
+
+    $response = app(SubmitPlanTool::class)->handle(new Request([
+        'plan_id' => $otherPlan->getKey(),
+    ]));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('current plan');
+});
+
+test('approve plan tool rejects non-current plans', function () {
+    ['user' => $user, 'story' => $story] = approvalToolScene();
+    $otherPlan = Plan::factory()->for($story)->create([
+        'version' => 2,
+        'status' => PlanStatus::PendingApproval,
+    ]);
+    $this->actingAs($user);
+
+    $response = app(ApprovePlanTool::class)->handle(new Request([
+        'plan_id' => $otherPlan->getKey(),
+    ]), app(ApprovalService::class));
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('current plan');
+});

--- a/tests/Feature/PlanApprovalTest.php
+++ b/tests/Feature/PlanApprovalTest.php
@@ -130,6 +130,19 @@ test('only the current plan can receive approval decisions', function () {
         ->toThrow(RuntimeException::class, 'current plan');
 });
 
+test('plan currentness is checked against the database instead of a stale loaded story relation', function () {
+    $currentPlan = makePlan();
+    $currentPlan->load('story');
+    $otherPlan = Plan::factory()->for($currentPlan->story)->create(['version' => 2]);
+
+    Story::query()
+        ->whereKey($currentPlan->story_id)
+        ->update(['current_plan_id' => $otherPlan->getKey()]);
+
+    expect($currentPlan->story->current_plan_id)->toBe($currentPlan->getKey())
+        ->and($currentPlan->isCurrent())->toBeFalse();
+});
+
 test('plan approval rows are immutable', function () {
     $plan = makePlan();
     policyForPlan(ApprovalPolicy::SCOPE_PROJECT, $plan->story->feature->project_id, ['required_approvals' => 1]);

--- a/tests/Feature/PlanApprovalTest.php
+++ b/tests/Feature/PlanApprovalTest.php
@@ -109,6 +109,27 @@ test('draft plans cannot be pre-approved before submission', function () {
         ->toThrow(RuntimeException::class, 'submitted');
 });
 
+test('only the current plan can be submitted for approval', function () {
+    $currentPlan = makePlan();
+    $otherPlan = Plan::factory()->for($currentPlan->story)->create(['version' => 2]);
+    Task::factory()->for($otherPlan)->create(['position' => 1]);
+
+    expect(fn () => $otherPlan->submitForApproval())
+        ->toThrow(RuntimeException::class, 'current plan');
+});
+
+test('only the current plan can receive approval decisions', function () {
+    $currentPlan = makePlan();
+    $otherPlan = Plan::factory()->for($currentPlan->story)->create([
+        'version' => 2,
+        'status' => PlanStatus::PendingApproval,
+    ]);
+    $approver = User::factory()->create();
+
+    expect(fn () => app(ApprovalService::class)->recordPlanDecision($otherPlan, $approver, ApprovalDecision::Approve))
+        ->toThrow(RuntimeException::class, 'current plan');
+});
+
 test('plan approval rows are immutable', function () {
     $plan = makePlan();
     policyForPlan(ApprovalPolicy::SCOPE_PROJECT, $plan->story->feature->project_id, ['required_approvals' => 1]);

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -2,11 +2,17 @@
 
 use App\Enums\PlanStatus;
 use App\Mcp\Servers\SpecifyServer;
+use App\Mcp\Tools\ApprovePlanTool;
+use App\Mcp\Tools\ApproveStoryTool;
 use App\Mcp\Tools\GenerateTasksTool;
 use App\Mcp\Tools\GetStoryTool;
 use App\Mcp\Tools\GetTaskTool;
 use App\Mcp\Tools\ListTasksTool;
+use App\Mcp\Tools\RejectPlanTool;
+use App\Mcp\Tools\RequestPlanChangesTool;
+use App\Mcp\Tools\RequestStoryChangesTool;
 use App\Mcp\Tools\SetTasksTool;
+use App\Mcp\Tools\SubmitPlanTool;
 use App\Models\Feature;
 use App\Models\Plan;
 use App\Models\PlanApproval;
@@ -71,6 +77,12 @@ test('mcp instructions and planning tool descriptions speak in current-plan term
         ListTasksTool::class => descriptionFor(ListTasksTool::class),
         GetTaskTool::class => descriptionFor(GetTaskTool::class),
         GetStoryTool::class => descriptionFor(GetStoryTool::class),
+        SubmitPlanTool::class => descriptionFor(SubmitPlanTool::class),
+        ApprovePlanTool::class => descriptionFor(ApprovePlanTool::class),
+        RejectPlanTool::class => descriptionFor(RejectPlanTool::class),
+        RequestPlanChangesTool::class => descriptionFor(RequestPlanChangesTool::class),
+        ApproveStoryTool::class => descriptionFor(ApproveStoryTool::class),
+        RequestStoryChangesTool::class => descriptionFor(RequestStoryChangesTool::class),
     ];
 
     expect($descriptions[GenerateTasksTool::class])->toContain('fresh current Plan')
@@ -81,7 +93,13 @@ test('mcp instructions and planning tool descriptions speak in current-plan term
         ->and($descriptions[GetTaskTool::class])->toContain('Plan-owned Task')
         ->and($descriptions[GetStoryTool::class])->toContain('current Plan metadata')
         ->and($descriptions[SetTasksTool::class])->toContain('may link to an optional acceptance_criterion_id and/or scenario_id')
-        ->and($descriptions[ListTasksTool::class])->toContain('Each entry includes plan_id');
+        ->and($descriptions[ListTasksTool::class])->toContain('Each entry includes plan_id')
+        ->and($descriptions[SubmitPlanTool::class])->toContain('current plan for approval')
+        ->and($descriptions[ApprovePlanTool::class])->toContain('current plan')
+        ->and($descriptions[RejectPlanTool::class])->toContain('current plan')
+        ->and($descriptions[RequestPlanChangesTool::class])->toContain('current plan')
+        ->and($descriptions[ApproveStoryTool::class])->toContain('story product contract')
+        ->and($descriptions[RequestStoryChangesTool::class])->toContain('story product contract');
 });
 
 test('list-tasks exposes current plan ownership on every task row', function () {


### PR DESCRIPTION
## Summary
- enforce that only a Story's current Plan can be submitted for approval or receive PlanApproval decisions
- centralize MCP approval target resolution and response shaping across story/plan approval tools
- update approval tool descriptions and architecture tests to distinguish Story product contract approval from current Plan approval

## Architecture Notes
This is the grouped Approval Tool + Policy cleanup slice. The load-bearing boundary is now enforced below the tool layer: StoryApproval belongs to the Story product contract, while PlanApproval belongs only to the current Plan that gates execution.

The MCP approval tools now share `RecordsApprovalDecisions`, so they all resolve accessible targets, enforce approver rights, and return consistent approval payloads through one path instead of six local copies.

## Verification
- `php -l app/Mcp/Concerns/RecordsApprovalDecisions.php`
- `php -l app/Services/ApprovalService.php`
- `php -l app/Services/Plans/PlanApprovalLifecycle.php`
- `php -l app/Models/Plan.php`
- `php -l tests/Feature/ApprovalMcpToolsTest.php`
- `php artisan test --compact tests/Feature/PlanApprovalTest.php tests/Feature/ApprovalMcpToolsTest.php tests/Feature/PlanningArchitectureConformanceTest.php tests/Feature/TriageTest.php tests/Feature/ApprovalsIndexTest.php tests/Feature/StoryShowPageTest.php`
- `vendor/bin/pint --dirty --test`
- `composer test`
