### PR TITLE
Align MCP and prompts with plan-owned tasks

### DIFF
--- a/app/Ai/Agents/ReviewResponder.php
+++ b/app/Ai/Agents/ReviewResponder.php
@@ -90,10 +90,18 @@ class ReviewResponder implements Agent, HasStructuredOutput, HasTools
     {
         $subtask = $this->subtask->loadMissing('task.plan.story.feature.project', 'task.acceptanceCriterion');
         $task = $subtask->task;
+        $plan = $task?->plan;
         $story = $task?->plan?->story;
         $criterion = $task?->acceptanceCriterion?->statement;
 
         $criterionBlock = $criterion ? "Acceptance Criterion: {$criterion}\n\n" : '';
+        $planBlock = $plan ? <<<PLAN
+Current Plan #{$plan->id} (version {$plan->version}, status {$plan->status?->value})
+Plan name: {$plan->name}
+Plan summary:
+{$plan->summary}
+
+PLAN : '';
         $taskBlock = $task ? "Parent Task #{$task->position}: {$task->name}\n" : '';
 
         $reviewBlock = trim($this->reviewSummary) === ''
@@ -119,7 +127,7 @@ Story: {$story?->name}
 Description:
 {$story?->description}
 
-{$criterionBlock}{$taskBlock}Subtask #{$subtask->position}: {$subtask->name}
+{$planBlock}{$criterionBlock}{$taskBlock}Subtask #{$subtask->position}: {$subtask->name}
 
 Subtask description:
 {$subtask->description}

--- a/app/Ai/Agents/TasksGenerator.php
+++ b/app/Ai/Agents/TasksGenerator.php
@@ -29,13 +29,31 @@ class TasksGenerator implements Agent, HasStructuredOutput
 
     public function buildPrompt(): string
     {
-        $story = $this->story->loadMissing('feature.project', 'acceptanceCriteria');
+        $story = $this->story->loadMissing('feature.project', 'acceptanceCriteria', 'scenarios.acceptanceCriterion');
 
         $criteria = $story->acceptanceCriteria
             ->sortBy('position')
             ->values()
             ->map(fn ($ac, $i) => "{$ac->position}. {$ac->statement}")
             ->implode("\n");
+
+        $scenarios = $story->scenarios
+            ->sortBy('position')
+            ->values()
+            ->map(function ($scenario) {
+                $criterion = $scenario->acceptanceCriterion
+                    ? " (AC #{$scenario->acceptanceCriterion->position})"
+                    : '';
+
+                return <<<SCENARIO
+{$scenario->position}. {$scenario->name}{$criterion}
+Given: {$scenario->given_text}
+When: {$scenario->when_text}
+Then: {$scenario->then_text}
+Notes: {$scenario->notes}
+SCENARIO;
+            })
+            ->implode("\n\n");
 
         return <<<PROMPT
 Project: {$story->feature->project->name}
@@ -48,7 +66,10 @@ Description:
 Acceptance Criteria (position. text):
 {$criteria}
 
-Generate an implementation plan that fully satisfies the acceptance criteria above. Shape Tasks around coherent implementation work that may span acceptance criteria, scenarios, or shared enabling work. Each Task must have one or more Subtasks.
+Scenarios (position. Given / When / Then):
+{$scenarios}
+
+Generate an implementation plan that fully satisfies the acceptance criteria and scenarios above. Shape Tasks around coherent implementation work that may span acceptance criteria, scenarios, or shared enabling work. Each Task must have one or more Subtasks.
 PROMPT;
     }
 

--- a/app/Mcp/Servers/SpecifyServer.php
+++ b/app/Mcp/Servers/SpecifyServer.php
@@ -21,7 +21,7 @@ use App\Mcp\Tools\GetRepoTool;
 use App\Mcp\Tools\GetRunTool;
 use App\Mcp\Tools\GetStoryTool;
 use App\Mcp\Tools\GetTaskTool;
-use App\Mcp\Tools\ListEventsTool;
+use App\Mcp\Tools\ListActivityTool;
 use App\Mcp\Tools\ListFeaturesTool;
 use App\Mcp\Tools\ListPlansTool;
 use App\Mcp\Tools\ListProjectsTool;
@@ -124,7 +124,7 @@ class SpecifyServer extends Server
         StartRunTool::class,
         ListReposTool::class,
         GetRepoTool::class,
-        ListEventsTool::class,
+        ListActivityTool::class,
     ];
 
     protected array $resources = [

--- a/app/Mcp/Tools/CreateStoryTool.php
+++ b/app/Mcp/Tools/CreateStoryTool.php
@@ -109,8 +109,8 @@ class CreateStoryTool extends Tool
             'actor' => $schema->string()->description('Optional "As a ..." actor or role.'),
             'intent' => $schema->string()->description('Optional "I want ..." intent statement.'),
             'outcome' => $schema->string()->description('Optional "So that / in order to ..." outcome statement.'),
-            'description' => $schema->string()->description('Product-owner framing and extra context for the unit of value. No schemas, classes, file paths, or implementation steps — those go in tasks/subtasks via set-tasks. Markdown supported.'),
-            'notes' => $schema->string()->description('Anything that doesn’t fit the user-story format — caveats, links, scope reminders. Implementation steps belong in tasks/subtasks. Markdown supported.'),
+            'description' => $schema->string()->description('Product-owner framing and extra context for the unit of value. No schemas, classes, file paths, or implementation steps — those belong in Plans, Tasks, and Subtasks. Markdown supported.'),
+            'notes' => $schema->string()->description('Anything that doesn’t fit the user-story format — caveats, links, scope reminders. Implementation steps belong in Plans, Tasks, and Subtasks. Markdown supported.'),
             'status' => $schema->string()
                 ->description('Story status. Defaults to "draft". One of: '.implode(', ', $statuses)),
             'acceptance_criteria' => $schema->array()

--- a/app/Mcp/Tools/ListActivityTool.php
+++ b/app/Mcp/Tools/ListActivityTool.php
@@ -12,14 +12,14 @@ use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tool;
 
 /**
- * MCP tool: list-events
+ * MCP tool: list-activity
  */
-#[Description('List recent webhook events. Filter by repo_id (required unless project_id given). Newest first.')]
-class ListEventsTool extends Tool
+#[Description('List recent project activity from webhook deliveries. Filter by repo_id or project_id. Newest first.')]
+class ListActivityTool extends Tool
 {
     use ResolvesProjectAccess;
 
-    protected string $name = 'list-events';
+    protected string $name = 'list-activity';
 
     /**
      * Handle the MCP tool invocation.
@@ -61,18 +61,18 @@ class ListEventsTool extends Tool
         }
 
         if (empty($repoIds)) {
-            return Response::json(['count' => 0, 'events' => []]);
+            return Response::json(['count' => 0, 'activity' => []]);
         }
 
-        $events = WebhookEvent::query()
+        $activity = WebhookEvent::query()
             ->whereIn('repo_id', $repoIds)
             ->latest('id')
             ->limit($limit)
             ->get(['id', 'repo_id', 'provider', 'event', 'action', 'signature_valid', 'matched_run_id', 'created_at']);
 
         return Response::json([
-            'count' => $events->count(),
-            'events' => $events->map(fn (WebhookEvent $e) => [
+            'count' => $activity->count(),
+            'activity' => $activity->map(fn (WebhookEvent $e) => [
                 'id' => $e->id,
                 'repo_id' => $e->repo_id,
                 'provider' => $e->provider,
@@ -91,9 +91,9 @@ class ListEventsTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'repo_id' => $schema->integer()->description('Repo to list events for.'),
-            'project_id' => $schema->integer()->description('Or, list events across all repos in this project.'),
-            'limit' => $schema->integer()->description('Max number of events (1–200, default 25).'),
+            'repo_id' => $schema->integer()->description('Repo to list activity for.'),
+            'project_id' => $schema->integer()->description('Or, list activity across all repos in this project.'),
+            'limit' => $schema->integer()->description('Max number of activity entries (1–200, default 25).'),
         ];
     }
 }

--- a/app/Mcp/Tools/UpdateStoryTool.php
+++ b/app/Mcp/Tools/UpdateStoryTool.php
@@ -114,8 +114,8 @@ class UpdateStoryTool extends Tool
             'actor' => $schema->string()->description('New "As a ..." actor or role.'),
             'intent' => $schema->string()->description('New "I want ..." intent statement.'),
             'outcome' => $schema->string()->description('New "So that / in order to ..." outcome statement.'),
-            'description' => $schema->string()->description('Product-owner framing and context. No implementation detail (schemas, classes, file paths). Markdown supported.'),
-            'notes' => $schema->string()->description('Caveats, links, scope reminders. Markdown supported.'),
+            'description' => $schema->string()->description('Product-owner framing and context. No implementation detail (schemas, classes, file paths, or implementation steps). Implementation belongs in Plans, Tasks, and Subtasks. Markdown supported.'),
+            'notes' => $schema->string()->description('Caveats, links, scope reminders. Implementation steps belong in Plans, Tasks, and Subtasks. Markdown supported.'),
             'status' => $schema->string()
                 ->description('New status. One of: '.implode(', ', $statuses)),
             'acceptance_criteria' => $schema->array()

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -8,6 +8,7 @@ name.
 |------|-----------|---------|
 | `subtask-executor.md` | `App\Ai\Agents\SubtaskExecutor::instructions()` | System prompt for the per-Subtask execution agent. |
 | `tasks-generator.md`  | `App\Ai\Agents\TasksGenerator::instructions()`  | System prompt for the planning agent that drafts a current Plan from a Story. |
+| `review-responder.md` | `App\Ai\Agents\ReviewResponder::instructions()` | System prompt for the PR review-response agent. |
 
 Both are loaded via `App\Services\Prompts\PromptLoader`, which caches contents
 within a single PHP request. Edit the markdown directly — there is no build

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -7,7 +7,7 @@ name.
 | File | Loaded by | Purpose |
 |------|-----------|---------|
 | `subtask-executor.md` | `App\Ai\Agents\SubtaskExecutor::instructions()` | System prompt for the per-Subtask execution agent. |
-| `tasks-generator.md`  | `App\Ai\Agents\TasksGenerator::instructions()`  | System prompt for the planning agent that drafts a task list from a Story. |
+| `tasks-generator.md`  | `App\Ai\Agents\TasksGenerator::instructions()`  | System prompt for the planning agent that drafts a current Plan from a Story. |
 
 Both are loaded via `App\Services\Prompts\PromptLoader`, which caches contents
 within a single PHP request. Edit the markdown directly — there is no build

--- a/prompts/review-responder.md
+++ b/prompts/review-responder.md
@@ -15,8 +15,9 @@ these tools — use them to inspect and modify the working tree:
 - Ls(path?, limit?)
 
 Workflow:
-1. Read the originating Subtask spec and the existing diff on this branch
-   so you understand what was already done.
+1. Read the originating Subtask spec from its parent Task and current Plan,
+   plus the existing diff on this branch, so you understand what was already
+   done.
 2. Read each review comment carefully. Each comment names a file and a
    line; treat that as the focal point but read enough surrounding code
    to make a good fix.

--- a/prompts/subtask-executor.md
+++ b/prompts/subtask-executor.md
@@ -1,6 +1,7 @@
 You are the execution agent for Specify. A human has approved a Story and its
-task list; your job is to execute one Subtask against the working copy of the
-repository that has already been checked out for you on the working branch.
+current Plan; your job is to execute one Subtask from that Plan against the
+working copy of the repository that has already been checked out for you on the
+working branch.
 
 You have these tools — use them to inspect and modify the working tree:
 

--- a/prompts/tasks-generator.md
+++ b/prompts/tasks-generator.md
@@ -1,11 +1,14 @@
 You are the planning agent for Specify, a system where humans approve AI actions
-before they are executed. Your job is to take a Story (the spec) and produce an
-implementation Plan: ordered Tasks, each broken down into 1+ ordered
-Subtasks that the executor will run one at a time.
+before they are executed. Your job is to take a Story product contract and
+produce its implementation Plan: ordered Plan-owned Tasks, each broken down
+into 1+ ordered Subtasks that the executor will run one at a time.
 
 Constraints:
 - Shape Tasks around coherent implementation work. A Task may satisfy one
   criterion, multiple criteria, a scenario path, or shared enabling work.
+- Tasks belong to the generated Plan, not directly to the Story. The Story owns
+  product framing, Acceptance Criteria, and Scenarios; the Plan owns the
+  delivery breakdown.
 - When a Task directly satisfies a specific Acceptance Criterion, reference that
   criterion by the exact position number shown next to it in the prompt, using
   `acceptance_criterion_position`. Leave it absent when the Task is cross-cutting

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -4,30 +4,37 @@ use App\Enums\PlanStatus;
 use App\Mcp\Servers\SpecifyServer;
 use App\Mcp\Tools\ApprovePlanTool;
 use App\Mcp\Tools\ApproveStoryTool;
+use App\Mcp\Tools\CreateStoryTool;
 use App\Mcp\Tools\GenerateTasksTool;
 use App\Mcp\Tools\GetStoryTool;
 use App\Mcp\Tools\GetTaskTool;
+use App\Mcp\Tools\ListActivityTool;
 use App\Mcp\Tools\ListTasksTool;
 use App\Mcp\Tools\RejectPlanTool;
 use App\Mcp\Tools\RequestPlanChangesTool;
 use App\Mcp\Tools\RequestStoryChangesTool;
 use App\Mcp\Tools\SetTasksTool;
 use App\Mcp\Tools\SubmitPlanTool;
+use App\Mcp\Tools\UpdateStoryTool;
 use App\Models\Feature;
 use App\Models\Plan;
 use App\Models\PlanApproval;
 use App\Models\Project;
+use App\Models\Repo;
 use App\Models\Story;
 use App\Models\StoryApproval;
 use App\Models\Subtask;
 use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
+use App\Models\WebhookEvent;
 use App\Models\Workspace;
 use App\Services\ExecutionService;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Tool;
 
 test('agent run authorization keeps story generation and plan execution distinct', function () {
     $taskGeneration = new ReflectionMethod(ExecutionService::class, 'dispatchTaskGeneration');
@@ -62,6 +69,21 @@ test('task generation prompt allows cross-cutting plan tasks', function () {
         ->and($agent)->toContain('may span acceptance criteria, scenarios, or shared enabling work')
         ->and($agent)->toContain("'acceptance_criterion_position' =>")
         ->and($agent)->not->toContain("'acceptance_criterion_position' => \$schema->integer()->min(1)->required()");
+});
+
+test('agent prompts describe current plan ownership', function () {
+    $tasksGenerator = file_get_contents(base_path('prompts/tasks-generator.md'));
+    $subtaskExecutor = file_get_contents(base_path('prompts/subtask-executor.md'));
+    $reviewResponder = file_get_contents(base_path('prompts/review-responder.md'));
+
+    expect($tasksGenerator)->toContain('Story product contract')
+        ->and($tasksGenerator)->toContain('Plan-owned Tasks')
+        ->and($tasksGenerator)->toContain('Tasks belong to the generated Plan, not directly to the Story')
+        ->and($subtaskExecutor)->toContain('approved a Story and its')
+        ->and($subtaskExecutor)->toContain('current Plan; your job is to execute one Subtask from that Plan')
+        ->and($subtaskExecutor)->toContain('execute one Subtask from that Plan')
+        ->and($reviewResponder)->toContain('parent Task and current Plan')
+        ->and($subtaskExecutor)->not->toContain('task'.' list');
 });
 
 test('mcp instructions and planning tool descriptions speak in current-plan terms', function () {
@@ -100,6 +122,60 @@ test('mcp instructions and planning tool descriptions speak in current-plan term
         ->and($descriptions[RequestPlanChangesTool::class])->toContain('current plan')
         ->and($descriptions[ApproveStoryTool::class])->toContain('story product contract')
         ->and($descriptions[RequestStoryChangesTool::class])->toContain('story product contract');
+});
+
+test('mcp story schemas reserve implementation detail for plans tasks and subtasks', function () {
+    $createStorySchema = schemaDescriptionsFor(CreateStoryTool::class);
+    $updateStorySchema = schemaDescriptionsFor(UpdateStoryTool::class);
+
+    expect($createStorySchema['description'])->toContain('Plans, Tasks, and Subtasks')
+        ->and($createStorySchema['notes'])->toContain('Plans, Tasks, and Subtasks')
+        ->and($updateStorySchema['description'])->toContain('Plans, Tasks, and Subtasks')
+        ->and($updateStorySchema['notes'])->toContain('Plans, Tasks, and Subtasks')
+        ->and($createStorySchema['description'])->not->toContain('tasks/'.'subtasks')
+        ->and($createStorySchema['notes'])->not->toContain('tasks/'.'subtasks');
+});
+
+test('mcp activity tool is the public project activity surface', function () {
+    expect(descriptionFor(ListActivityTool::class))->toContain('project activity')
+        ->and(toolNameFor(ListActivityTool::class))->toBe('list-activity');
+
+    $serverTools = (new ReflectionClass(SpecifyServer::class))->getDefaultProperties()['tools'];
+
+    expect($serverTools)->toContain(ListActivityTool::class)
+        ->and(collect($serverTools)->map(fn (string $tool) => class_basename($tool))->all())->not->toContain('List'.'EventsTool');
+});
+
+test('list-activity returns project activity entries', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $team->addMember($user);
+    $project = Project::factory()->for($team)->create();
+    $repo = Repo::factory()->for($workspace)->create();
+    $project->attachRepo($repo);
+
+    WebhookEvent::create([
+        'repo_id' => $repo->getKey(),
+        'provider' => 'github',
+        'event' => 'pull_request',
+        'action' => 'opened',
+        'delivery_id' => 'delivery-activity-1',
+        'signature_valid' => true,
+        'payload' => ['number' => 123],
+    ]);
+
+    $this->actingAs($user);
+
+    $response = app(ListActivityTool::class)->handle(new Request([
+        'project_id' => $project->getKey(),
+    ]));
+    $payload = json_decode((string) $response->content(), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($payload)->toHaveKeys(['count', 'activity'])
+        ->and($payload['count'])->toBe(1)
+        ->and($payload['activity'][0]['event'])->toBe('pull_request')
+        ->and($payload['activity'][0]['action'])->toBe('opened');
 });
 
 test('list-tasks exposes current plan ownership on every task row', function () {
@@ -160,6 +236,30 @@ function namedParameterType(ReflectionMethod $method, string $parameterName): st
 function descriptionFor(string $class): string
 {
     return serverAttribute($class, Description::class);
+}
+
+/**
+ * @param  class-string<Tool>  $class
+ * @return array<string, string>
+ */
+function schemaDescriptionsFor(string $class): array
+{
+    $tool = app($class);
+    $schemas = $tool->schema(new JsonSchemaTypeFactory);
+
+    return collect($schemas)
+        ->map(fn ($schema) => $schema->toArray()['description'] ?? '')
+        ->all();
+}
+
+/**
+ * @param  class-string<Tool>  $class
+ */
+function toolNameFor(string $class): string
+{
+    $property = (new ReflectionClass($class))->getProperty('name');
+
+    return $property->getDefaultValue();
 }
 
 /**

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Ai\Agents\ReviewResponder;
+use App\Ai\Agents\TasksGenerator;
 use App\Enums\PlanStatus;
 use App\Mcp\Servers\SpecifyServer;
 use App\Mcp\Tools\ApprovePlanTool;
@@ -21,6 +23,7 @@ use App\Models\Plan;
 use App\Models\PlanApproval;
 use App\Models\Project;
 use App\Models\Repo;
+use App\Models\Scenario;
 use App\Models\Story;
 use App\Models\StoryApproval;
 use App\Models\Subtask;
@@ -57,6 +60,7 @@ test('load-bearing docs describe the current planning model', function () {
         ->and($agents)->toContain('Resolve Story through `Task -> Plan -> Story`')
         ->and($adrIndex)->toContain('Story and current Plan are the approval gates')
         ->and($prompt)->toContain('Shape Tasks around coherent implementation work')
+        ->and(file_get_contents(base_path('prompts/README.md')))->toContain('review-responder.md')
         ->and($agent)->toContain('may span acceptance criteria, scenarios, or shared enabling work');
 });
 
@@ -84,6 +88,59 @@ test('agent prompts describe current plan ownership', function () {
         ->and($subtaskExecutor)->toContain('execute one Subtask from that Plan')
         ->and($reviewResponder)->toContain('parent Task and current Plan')
         ->and($subtaskExecutor)->not->toContain('task'.' list');
+});
+
+test('tasks generator prompt includes scenarios supplied to the planner', function () {
+    $story = makeStory();
+    $criterion = $story->acceptanceCriteria()->firstOrFail();
+    Scenario::factory()->forCriterion($criterion)->create([
+        'position' => 1,
+        'name' => 'Checkout happy path',
+        'given_text' => 'Given a cart with billable items',
+        'when_text' => 'When the customer checks out',
+        'then_text' => 'Then the payment is captured',
+        'notes' => 'Use the primary payment provider.',
+    ]);
+
+    $prompt = (new TasksGenerator($story))->buildPrompt();
+
+    expect($prompt)->toContain('Scenarios (position. Given / When / Then):')
+        ->and($prompt)->toContain('1. Checkout happy path (AC #1)')
+        ->and($prompt)->toContain('Given: Given a cart with billable items')
+        ->and($prompt)->toContain('Then: Then the payment is captured')
+        ->and($prompt)->toContain('acceptance criteria and scenarios above');
+});
+
+test('review responder prompt includes current plan context', function () {
+    $story = Story::factory()->create();
+    $plan = Plan::factory()->for($story)->create([
+        'version' => 2,
+        'name' => 'Reviewable implementation plan',
+        'summary' => 'Respond to review without changing the product contract.',
+    ]);
+    $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
+    $task = Task::factory()->for($plan)->create([
+        'position' => 1,
+        'name' => 'Address review feedback',
+    ]);
+    $subtask = Subtask::factory()->for($task)->create([
+        'position' => 1,
+        'name' => 'Patch reviewed code',
+        'description' => 'Apply focused review fixes.',
+    ]);
+
+    $prompt = (new ReviewResponder(
+        subtask: $subtask,
+        pullRequestNumber: 86,
+        reviewSummary: '',
+        comments: [],
+        workingBranch: 'cleanup/mcp-prompt-contract',
+    ))->buildPrompt();
+
+    expect($prompt)->toContain("Current Plan #{$plan->getKey()} (version 2")
+        ->and($prompt)->toContain('Plan name: Reviewable implementation plan')
+        ->and($prompt)->toContain('Respond to review without changing the product contract.')
+        ->and($prompt)->toContain('Parent Task #1: Address review feedback');
 });
 
 test('mcp instructions and planning tool descriptions speak in current-plan terms', function () {


### PR DESCRIPTION
## Summary
- rename the MCP webhook stream tool to `list-activity` and return `activity` entries
- tighten story tool schema descriptions so implementation belongs in Plans, Tasks, and Subtasks
- update planning/execution/review prompts to describe current Plan ownership explicitly
- extend planning architecture conformance tests over prompt wording, story schemas, MCP activity registration, and activity payloads

## Verification
- `php artisan test --compact tests/Feature/PlanningArchitectureConformanceTest.php tests/Architecture/PlanningModelArchitectureTest.php tests/Architecture/TaskFactoryArchitectureTest.php`
- `composer test`
