### PR TITLE
Extract story page workflow actions

### DIFF
--- a/app/Services/Stories/StoryPageWorkflow.php
+++ b/app/Services/Stories/StoryPageWorkflow.php
@@ -4,6 +4,7 @@ namespace App\Services\Stories;
 
 use App\Enums\AgentRunStatus;
 use App\Enums\ApprovalDecision;
+use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
 use App\Enums\TaskStatus;
 use App\Models\AgentRun;
@@ -35,7 +36,9 @@ class StoryPageWorkflow
 
     public function recordStoryDecision(Story $story, User $user, ApprovalDecision $decision, ?string $note = null): void
     {
+        abort_unless(in_array($story->status, [StoryStatus::PendingApproval, StoryStatus::ChangesRequested], true), 422, 'Story is not awaiting a decision.');
         abort_unless($user->canApproveInProject($story->feature->project), 403);
+        $this->guardDecisionNote($decision, $note);
 
         $this->approvals->recordDecision($story, $user, $decision, $note);
     }
@@ -51,7 +54,9 @@ class StoryPageWorkflow
     public function recordPlanDecision(Story $story, User $user, ApprovalDecision $decision, ?string $note = null): void
     {
         abort_unless($story->currentPlan, 404);
+        abort_unless($story->currentPlan->status === PlanStatus::PendingApproval, 422, 'Plan is not awaiting a decision.');
         abort_unless($user->canApproveInProject($story->feature->project), 403);
+        $this->guardDecisionNote($decision, $note);
 
         $this->approvals->recordPlanDecision($story->currentPlan, $user, $decision, $note);
     }
@@ -108,5 +113,14 @@ class StoryPageWorkflow
         abort_unless($user->canApproveInProject($story->feature->project), 403);
 
         $this->approvals->recompute($story);
+    }
+
+    private function guardDecisionNote(ApprovalDecision $decision, ?string $note): void
+    {
+        if (! in_array($decision, [ApprovalDecision::ChangesRequested, ApprovalDecision::Reject], true)) {
+            return;
+        }
+
+        abort_if(trim((string) $note) === '', 422, 'Notes are required for this decision.');
     }
 }

--- a/app/Services/Stories/StoryPageWorkflow.php
+++ b/app/Services/Stories/StoryPageWorkflow.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Enums\AgentRunStatus;
+use App\Enums\ApprovalDecision;
+use App\Enums\StoryStatus;
+use App\Enums\TaskStatus;
+use App\Models\AgentRun;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\User;
+use App\Services\ApprovalService;
+use App\Services\ExecutionService;
+
+class StoryPageWorkflow
+{
+    public function __construct(
+        private ApprovalService $approvals,
+        private ExecutionService $execution,
+    ) {}
+
+    public function submitStory(Story $story, User $user): void
+    {
+        abort_unless($story->status === StoryStatus::Draft, 422, 'Story is not a draft.');
+        abort_unless($story->created_by_id === $user->getKey() || $user->canApproveInProject($story->feature->project), 403);
+
+        $story->submitForApproval();
+
+        $fresh = $story->fresh();
+        if ($fresh->status === StoryStatus::Approved && ! $fresh->currentPlanTasks()->exists()) {
+            $this->execution->dispatchTaskGeneration($fresh);
+        }
+    }
+
+    public function recordStoryDecision(Story $story, User $user, ApprovalDecision $decision, ?string $note = null): void
+    {
+        abort_unless($user->canApproveInProject($story->feature->project), 403);
+
+        $this->approvals->recordDecision($story, $user, $decision, $note);
+    }
+
+    public function submitCurrentPlan(Story $story, User $user): void
+    {
+        abort_unless($story->currentPlan, 404);
+        abort_unless($user->canApproveInProject($story->feature->project), 403);
+
+        $story->currentPlan->submitForApproval();
+    }
+
+    public function recordPlanDecision(Story $story, User $user, ApprovalDecision $decision, ?string $note = null): void
+    {
+        abort_unless($story->currentPlan, 404);
+        abort_unless($user->canApproveInProject($story->feature->project), 403);
+
+        $this->approvals->recordPlanDecision($story->currentPlan, $user, $decision, $note);
+    }
+
+    public function generateCurrentPlan(Story $story, User $user): void
+    {
+        abort_unless($story->status === StoryStatus::Approved, 422, 'Story must be Approved.');
+        abort_if($story->currentPlanTasks()->exists(), 422, 'Plan already exists.');
+        abort_unless($user->canApproveInProject($story->feature->project), 403);
+
+        $this->execution->dispatchTaskGeneration($story);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function resolveConflicts(Story $story, User $user): array
+    {
+        abort_unless($user->canApproveInProject($story->feature->project), 403);
+
+        return $this->execution->dispatchConflictResolution($story);
+    }
+
+    public function resumeExecution(Story $story, User $user): void
+    {
+        abort_unless($story->status === StoryStatus::Approved, 422, 'Story must be Approved.');
+        abort_unless($user->canApproveInProject($story->feature->project), 403);
+
+        $subtaskIds = Subtask::whereIn('task_id', $story->currentPlanTasks()->pluck('id'))->pluck('id');
+
+        AgentRun::where('runnable_type', Subtask::class)
+            ->whereIn('runnable_id', $subtaskIds)
+            ->active()
+            ->update([
+                'status' => AgentRunStatus::Aborted->value,
+                'error_message' => 'Aborted on resume.',
+                'finished_at' => now(),
+            ]);
+
+        Subtask::whereIn('id', $subtaskIds)
+            ->where('status', TaskStatus::Blocked)
+            ->update(['status' => TaskStatus::Pending->value]);
+
+        $this->execution->startStoryExecution($story->fresh());
+    }
+
+    public function autoApproveStoryContract(Story $story, User $user): void
+    {
+        abort_unless($story->status === StoryStatus::PendingApproval, 422, 'Story is not awaiting approval.');
+        abort_unless($story->currentPlanTasks()->exists(), 422, 'No plan to execute.');
+
+        $policy = $story->effectivePolicy();
+        abort_unless($policy->auto_approve || $policy->required_approvals === 0, 403, 'Policy requires explicit approvals.');
+        abort_unless($user->canApproveInProject($story->feature->project), 403);
+
+        $this->approvals->recompute($story);
+    }
+}

--- a/app/Services/Stories/StoryPageWorkflow.php
+++ b/app/Services/Stories/StoryPageWorkflow.php
@@ -2,7 +2,6 @@
 
 namespace App\Services\Stories;
 
-use App\Enums\AgentRunStatus;
 use App\Enums\ApprovalDecision;
 use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
@@ -84,17 +83,15 @@ class StoryPageWorkflow
     {
         abort_unless($story->status === StoryStatus::Approved, 422, 'Story must be Approved.');
         abort_unless($user->canApproveInProject($story->feature->project), 403);
+        abort_unless($story->currentPlan?->isApproved(), 422, 'Current plan must be Approved before execution resumes.');
 
         $subtaskIds = Subtask::whereIn('task_id', $story->currentPlanTasks()->pluck('id'))->pluck('id');
 
         AgentRun::where('runnable_type', Subtask::class)
             ->whereIn('runnable_id', $subtaskIds)
             ->active()
-            ->update([
-                'status' => AgentRunStatus::Aborted->value,
-                'error_message' => 'Aborted on resume.',
-                'finished_at' => now(),
-            ]);
+            ->get()
+            ->each(fn (AgentRun $run) => $this->execution->markAborted($run, 'Aborted on resume.'));
 
         Subtask::whereIn('id', $subtaskIds)
             ->where('status', TaskStatus::Blocked)

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Enums\AgentRunStatus;
 use App\Enums\ApprovalDecision;
 use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
@@ -8,10 +7,8 @@ use App\Enums\TaskStatus;
 use App\Models\AcceptanceCriterion;
 use App\Models\AgentRun;
 use App\Models\Story;
-use App\Models\Subtask;
-use App\Models\Task;
 use App\Services\ApprovalService;
-use App\Services\ExecutionService;
+use App\Services\Stories\StoryPageWorkflow;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
@@ -223,15 +220,8 @@ new #[Title('Story')] class extends Component {
     {
         $story = $this->story;
         abort_unless($story, 404);
-        abort_unless($story->status === StoryStatus::Draft, 422, 'Story is not a draft.');
-        abort_unless($story->created_by_id === Auth::id() || Auth::user()->canApproveInProject($story->feature->project), 403);
 
-        $story->submitForApproval();
-
-        $fresh = $story->fresh();
-        if ($fresh->status === StoryStatus::Approved && ! $fresh->currentPlanTasks()->exists()) {
-            app(ExecutionService::class)->dispatchTaskGeneration($fresh);
-        }
+        app(StoryPageWorkflow::class)->submitStory($story, Auth::user());
 
         unset($this->story);
     }
@@ -241,9 +231,8 @@ new #[Title('Story')] class extends Component {
         $story = $this->story;
         abort_unless($story, 404);
         $user = Auth::user();
-        abort_unless($user->canApproveInProject($story->feature->project), 403);
 
-        app(ApprovalService::class)->recordDecision(
+        app(StoryPageWorkflow::class)->recordStoryDecision(
             $story,
             $user,
             ApprovalDecision::from($decision),
@@ -257,22 +246,20 @@ new #[Title('Story')] class extends Component {
     public function submitPlan(): void
     {
         $story = $this->story;
-        abort_unless($story && $story->currentPlan, 404);
-        abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
+        abort_unless($story, 404);
 
-        $story->currentPlan->submitForApproval();
+        app(StoryPageWorkflow::class)->submitCurrentPlan($story, Auth::user());
         unset($this->story);
     }
 
     public function decidePlan(string $decision): void
     {
         $story = $this->story;
-        abort_unless($story && $story->currentPlan, 404);
+        abort_unless($story, 404);
         $user = Auth::user();
-        abort_unless($user->canApproveInProject($story->feature->project), 403);
 
-        app(ApprovalService::class)->recordPlanDecision(
-            $story->currentPlan,
+        app(StoryPageWorkflow::class)->recordPlanDecision(
+            $story,
             $user,
             ApprovalDecision::from($decision),
             $this->planApprovalNote ?: null,
@@ -286,11 +273,8 @@ new #[Title('Story')] class extends Component {
     {
         $story = $this->story;
         abort_unless($story, 404);
-        abort_unless($story->status === StoryStatus::Approved, 422, 'Story must be Approved.');
-        abort_if($story->currentPlanTasks()->exists(), 422, 'Plan already exists.');
-        abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
 
-        app(ExecutionService::class)->dispatchTaskGeneration($story);
+        app(StoryPageWorkflow::class)->generateCurrentPlan($story, Auth::user());
 
         unset($this->story);
     }
@@ -299,9 +283,8 @@ new #[Title('Story')] class extends Component {
     {
         $story = $this->story;
         abort_unless($story, 404);
-        abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
 
-        $result = app(ExecutionService::class)->dispatchConflictResolution($story);
+        $result = app(StoryPageWorkflow::class)->resolveConflicts($story, Auth::user());
 
         match ($result['status']) {
             'dispatched' => session()->flash('conflict_resolution', __('AI conflict-resolution run queued.')),
@@ -316,25 +299,8 @@ new #[Title('Story')] class extends Component {
     {
         $story = $this->story;
         abort_unless($story, 404);
-        abort_unless($story->status === StoryStatus::Approved, 422, 'Story must be Approved.');
-        abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
 
-        $subtaskIds = Subtask::whereIn('task_id', $story->currentPlanTasks()->pluck('id'))->pluck('id');
-
-        AgentRun::where('runnable_type', Subtask::class)
-            ->whereIn('runnable_id', $subtaskIds)
-            ->active()
-            ->update([
-                'status' => AgentRunStatus::Aborted->value,
-                'error_message' => 'Aborted on resume.',
-                'finished_at' => now(),
-            ]);
-
-        Subtask::whereIn('id', $subtaskIds)
-            ->where('status', TaskStatus::Blocked)
-            ->update(['status' => TaskStatus::Pending->value]);
-
-        app(ExecutionService::class)->startStoryExecution($story->fresh());
+        app(StoryPageWorkflow::class)->resumeExecution($story, Auth::user());
         unset($this->story);
     }
 
@@ -342,14 +308,8 @@ new #[Title('Story')] class extends Component {
     {
         $story = $this->story;
         abort_unless($story, 404);
-        abort_unless($story->status === StoryStatus::PendingApproval, 422, 'Story is not awaiting approval.');
-        abort_unless($story->currentPlanTasks()->exists(), 422, 'No plan to execute.');
 
-        $policy = $story->effectivePolicy();
-        abort_unless($policy->auto_approve || $policy->required_approvals === 0, 403, 'Policy requires explicit approvals.');
-        abort_unless(Auth::user()->canApproveInProject($story->feature->project), 403);
-
-        app(ApprovalService::class)->recompute($story);
+        app(StoryPageWorkflow::class)->autoApproveStoryContract($story, Auth::user());
         unset($this->story);
     }
 

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -9,6 +9,7 @@ use App\Models\AcceptanceCriterion;
 use App\Models\AgentRun;
 use App\Models\ApprovalPolicy;
 use App\Models\Feature;
+use App\Models\PlanApproval;
 use App\Models\Project;
 use App\Models\Story;
 use App\Models\StoryApproval;
@@ -160,6 +161,24 @@ test('author can approve own pending story when allow_self_approval=true', funct
         ->assertSee('Approve');
 });
 
+test('story decision action records approval with note through the story page workflow', function () {
+    $s = showPageScene(['status' => StoryStatus::PendingApproval]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->set('approvalNote', 'ship the contract')
+        ->call('decide', ApprovalDecision::Approve->value)
+        ->assertSet('approvalNote', null);
+
+    $approval = StoryApproval::query()->where('story_id', $s['story']->id)->sole();
+
+    expect($approval->decision)->toBe(ApprovalDecision::Approve)
+        ->and($approval->notes)->toBe('ship the contract')
+        ->and($s['story']->fresh()->status)->toBe(StoryStatus::Approved);
+});
+
 test('eligible-approvers section renders only when threshold > 1', function () {
     $other = User::factory()->create(['name' => 'second-eligible']);
     $s = showPageScene(['status' => StoryStatus::PendingApproval]);
@@ -209,6 +228,36 @@ test('approval tracks render separately for story contract and current plan', fu
         ->assertSee('Current plan')
         ->assertSee('Execution is blocked until the current plan is approved.')
         ->assertSee('Approve current plan');
+});
+
+test('plan decision action records approval with note through the story page workflow', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $ac = AcceptanceCriterion::create([
+        'story_id' => $s['story']->id,
+        'position' => 1,
+        'statement' => 'AC-text-must-lead',
+    ]);
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create([
+        'name' => 'task-name-secondary',
+        'position' => 1,
+        'acceptance_criterion_id' => $ac->id,
+    ]);
+    $task->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->set('planApprovalNote', 'plan is executable')
+        ->call('decidePlan', ApprovalDecision::Approve->value)
+        ->assertSet('planApprovalNote', null);
+
+    $approval = PlanApproval::query()->where('plan_id', $task->plan_id)->sole();
+
+    expect($approval->decision)->toBe(ApprovalDecision::Approve)
+        ->and($approval->notes)->toBe('plan is executable')
+        ->and($task->plan->fresh()->status)->toBe(PlanStatus::Approved);
 });
 
 test('plan section is AC-led: AC text leads, Task name follows', function () {

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -179,6 +179,34 @@ test('story decision action records approval with note through the story page wo
         ->and($s['story']->fresh()->status)->toBe(StoryStatus::Approved);
 });
 
+test('story decision action rejects crafted calls outside review states', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('decide', ApprovalDecision::Approve->value)
+        ->assertStatus(422);
+
+    expect(StoryApproval::query()->where('story_id', $s['story']->id)->count())->toBe(0)
+        ->and($s['story']->fresh()->status)->toBe(StoryStatus::Draft);
+});
+
+test('story change-request and reject decisions require notes', function () {
+    $s = showPageScene(['status' => StoryStatus::PendingApproval]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('decide', ApprovalDecision::ChangesRequested->value)
+        ->assertStatus(422);
+
+    expect(StoryApproval::query()->where('story_id', $s['story']->id)->count())->toBe(0)
+        ->and($s['story']->fresh()->status)->toBe(StoryStatus::PendingApproval);
+});
+
 test('eligible-approvers section renders only when threshold > 1', function () {
     $other = User::factory()->create(['name' => 'second-eligible']);
     $s = showPageScene(['status' => StoryStatus::PendingApproval]);
@@ -258,6 +286,40 @@ test('plan decision action records approval with note through the story page wor
     expect($approval->decision)->toBe(ApprovalDecision::Approve)
         ->and($approval->notes)->toBe('plan is executable')
         ->and($task->plan->fresh()->status)->toBe(PlanStatus::Approved);
+});
+
+test('plan decision action rejects crafted calls when current plan is not pending approval', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create();
+    $task->plan->forceFill(['status' => PlanStatus::Done->value])->save();
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('decidePlan', ApprovalDecision::Approve->value)
+        ->assertStatus(422);
+
+    expect(PlanApproval::query()->where('plan_id', $task->plan_id)->count())->toBe(0)
+        ->and($task->plan->fresh()->status)->toBe(PlanStatus::Done);
+});
+
+test('plan change-request and reject decisions require notes', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create();
+    $task->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('decidePlan', ApprovalDecision::Reject->value)
+        ->assertStatus(422);
+
+    expect(PlanApproval::query()->where('plan_id', $task->plan_id)->count())->toBe(0)
+        ->and($task->plan->fresh()->status)->toBe(PlanStatus::PendingApproval);
 });
 
 test('plan section is AC-led: AC text leads, Task name follows', function () {

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -4,6 +4,7 @@ use App\Enums\AgentRunStatus;
 use App\Enums\ApprovalDecision;
 use App\Enums\PlanStatus;
 use App\Enums\StoryStatus;
+use App\Enums\TaskStatus;
 use App\Enums\TeamRole;
 use App\Models\AcceptanceCriterion;
 use App\Models\AgentRun;
@@ -320,6 +321,57 @@ test('plan change-request and reject decisions require notes', function () {
 
     expect(PlanApproval::query()->where('plan_id', $task->plan_id)->count())->toBe(0)
         ->and($task->plan->fresh()->status)->toBe(PlanStatus::PendingApproval);
+});
+
+test('resume execution rejects unapproved current plan before mutating run state', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create();
+    $task->plan->forceFill(['status' => PlanStatus::PendingApproval->value])->save();
+    $subtask = Subtask::factory()->for($task)->create(['status' => TaskStatus::Blocked]);
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('resumeExecution')
+        ->assertStatus(422);
+
+    expect($run->fresh()->status)->toBe(AgentRunStatus::Running)
+        ->and($subtask->fresh()->status)->toBe(TaskStatus::Blocked);
+});
+
+test('resume execution finalizes active race siblings through execution service', function () {
+    $s = showPageScene(['status' => StoryStatus::Approved]);
+    attachPolicy($s['ws'], required: 1, allowSelf: true);
+
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create();
+    $task->plan->forceFill(['status' => PlanStatus::Approved->value])->save();
+    $subtask = Subtask::factory()->for($task)->create(['status' => TaskStatus::Pending]);
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+    $active = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+    ]);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('resumeExecution')
+        ->assertOk();
+
+    expect($active->fresh()->status)->toBe(AgentRunStatus::Aborted)
+        ->and($subtask->fresh()->status)->toBe(TaskStatus::Done);
 });
 
 test('plan section is AC-led: AC text leads, Task name follows', function () {


### PR DESCRIPTION
## Summary
- Add `StoryPageWorkflow` to own Story show workflow actions: story submission/decisions, current-plan submission/decisions, plan generation, conflict resolution, and execution resume/auto-approval
- Keep the Livewire Story page responsible for UI state, notes, flash messages, redirects, and render context
- Add page-level regression tests for Story and current-Plan decision actions with notes

## Verification
- `php artisan test --compact tests/Feature/StoryShowPageTest.php tests/Feature/StoryShowTest.php tests/Feature/TaskShowTest.php tests/Feature/ConflictResolutionTest.php tests/Feature/PlanApprovalTest.php tests/Feature/SubtaskExecutionTest.php`
- `composer test`