### PR TITLE
Extract story contract editing lifecycle

### DIFF
--- a/app/Services/Stories/StoryContractEditor.php
+++ b/app/Services/Stories/StoryContractEditor.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Services\Stories;
+
+use App\Enums\StoryStatus;
+use App\Models\AcceptanceCriterion;
+use App\Models\Story;
+use Illuminate\Support\Facades\DB;
+
+class StoryContractEditor
+{
+    public function __construct(private StoryRevisionLifecycle $revisions) {}
+
+    /**
+     * @param  list<array{id: int|null, statement: string}>  $criteria
+     */
+    public function update(Story $story, string $name, string $description, array $criteria): bool
+    {
+        abort_if(in_array($story->status, [StoryStatus::Done, StoryStatus::Cancelled, StoryStatus::Rejected], true), 422, 'Story is read-only.');
+
+        $changed = DB::transaction(function () use ($story, $name, $description, $criteria): bool {
+            $changed = false;
+
+            $trimmedName = trim($name);
+            if ($story->name !== $trimmedName || $story->description !== $description) {
+                Story::withoutRevisionBump(function () use ($story, $trimmedName, $description): void {
+                    $story->fill([
+                        'name' => $trimmedName,
+                        'description' => $description,
+                    ])->save();
+                });
+                $changed = true;
+            }
+
+            return $this->syncCriteria($story, $criteria) || $changed;
+        });
+
+        if ($changed) {
+            $this->revisions->recordContentArtifactChanged($story->fresh());
+        }
+
+        return $changed;
+    }
+
+    /**
+     * @param  list<array{id: int|null, statement: string}>  $criteria
+     */
+    private function syncCriteria(Story $story, array $criteria): bool
+    {
+        $existing = $story->acceptanceCriteria()->get()->keyBy('id');
+        $kept = [];
+        $changed = false;
+
+        AcceptanceCriterion::withoutEvents(function () use ($story, $criteria, $existing, &$kept, &$changed): void {
+            foreach ($criteria as $i => $row) {
+                $position = $i + 1;
+                $text = trim((string) ($row['statement'] ?? ''));
+                $id = $row['id'] ?? null;
+
+                if ($id !== null && $existing->has($id)) {
+                    $criterion = $existing[$id];
+                    if ($criterion->statement !== $text || $criterion->position !== $position) {
+                        $criterion->update(['statement' => $text, 'position' => $position]);
+                        $changed = true;
+                    }
+                    $kept[] = $id;
+
+                    continue;
+                }
+
+                $story->acceptanceCriteria()->create([
+                    'position' => $position,
+                    'statement' => $text,
+                ]);
+                $changed = true;
+            }
+
+            $toDelete = $existing->keys()->diff($kept);
+            if ($toDelete->isNotEmpty()) {
+                AcceptanceCriterion::whereIn('id', $toDelete)->delete();
+                $changed = true;
+            }
+        });
+
+        return $changed;
+    }
+}

--- a/app/Services/Stories/StoryContractEditor.php
+++ b/app/Services/Stories/StoryContractEditor.php
@@ -18,7 +18,7 @@ class StoryContractEditor
     {
         abort_if(in_array($story->status, [StoryStatus::Done, StoryStatus::Cancelled, StoryStatus::Rejected], true), 422, 'Story is read-only.');
 
-        $changed = DB::transaction(function () use ($story, $name, $description, $criteria): bool {
+        return DB::transaction(function () use ($story, $name, $description, $criteria): bool {
             $changed = false;
 
             $trimmedName = trim($name);
@@ -32,14 +32,14 @@ class StoryContractEditor
                 $changed = true;
             }
 
-            return $this->syncCriteria($story, $criteria) || $changed;
+            $changed = $this->syncCriteria($story, $criteria) || $changed;
+
+            if ($changed) {
+                $this->revisions->recordContentArtifactChanged($story->fresh());
+            }
+
+            return $changed;
         });
-
-        if ($changed) {
-            $this->revisions->recordContentArtifactChanged($story->fresh());
-        }
-
-        return $changed;
     }
 
     /**
@@ -57,7 +57,9 @@ class StoryContractEditor
                 $text = trim((string) ($row['statement'] ?? ''));
                 $id = $row['id'] ?? null;
 
-                if ($id !== null && $existing->has($id)) {
+                abort_unless($id === null || $existing->has($id), 422, 'Acceptance criterion does not belong to this story.');
+
+                if ($id !== null) {
                     $criterion = $existing[$id];
                     if ($criterion->statement !== $text || $criterion->position !== $position) {
                         $criterion->update(['statement' => $text, 'position' => $position]);

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -7,10 +7,9 @@ use App\Enums\TaskStatus;
 use App\Models\AcceptanceCriterion;
 use App\Models\AgentRun;
 use App\Models\Story;
-use App\Services\ApprovalService;
+use App\Services\Stories\StoryContractEditor;
 use App\Services\Stories\StoryPageWorkflow;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Attributes\Validate;
@@ -105,62 +104,15 @@ new #[Title('Story')] class extends Component {
             'editCriteria.*.statement' => 'required|string|max:1000',
         ]);
 
-        $criteriaChanged = $this->syncCriteria($story);
-
-        $story->update([
-            'name' => trim($this->editName),
-            'description' => $this->editDescription,
-        ]);
-
-        if ($criteriaChanged && in_array($story->status, [StoryStatus::Approved, StoryStatus::ChangesRequested], true)) {
-            $story->silentlyForceFill([
-                'status' => StoryStatus::PendingApproval->value,
-                'revision' => ($story->revision ?? 1) + 1,
-            ]);
-            app(ApprovalService::class)->recompute($story->fresh());
-        }
+        app(StoryContractEditor::class)->update(
+            $story,
+            $this->editName,
+            $this->editDescription,
+            $this->editCriteria,
+        );
 
         $this->editing = false;
         unset($this->story);
-    }
-
-    private function syncCriteria(Story $story): bool
-    {
-        $existing = $story->acceptanceCriteria()->get()->keyBy('id');
-        $kept = [];
-        $changed = false;
-
-        return DB::transaction(function () use ($story, $existing, &$kept, &$changed) {
-            foreach ($this->editCriteria as $i => $row) {
-                $position = $i + 1;
-                $text = trim((string) ($row['statement'] ?? ''));
-                $id = $row['id'] ?? null;
-
-                if ($id !== null && $existing->has($id)) {
-                    $ac = $existing[$id];
-                    if ($ac->statement !== $text || $ac->position !== $position) {
-                        $ac->update(['statement' => $text, 'position' => $position]);
-                        $changed = true;
-                    }
-                    $kept[] = $id;
-                } else {
-                    AcceptanceCriterion::create([
-                        'story_id' => $story->id,
-                        'position' => $position,
-                        'statement' => $text,
-                    ]);
-                    $changed = true;
-                }
-            }
-
-            $toDelete = $existing->keys()->diff($kept);
-            if ($toDelete->isNotEmpty()) {
-                AcceptanceCriterion::whereIn('id', $toDelete)->delete();
-                $changed = true;
-            }
-
-            return $changed;
-        });
     }
 
     private function canEdit(Story $story): bool

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -527,6 +527,70 @@ test('reset-approval banner does not render when nothing changes during edit', f
         ->assertDontSee('Save & request re-approval');
 });
 
+test('saving unchanged story contract does not bump revision', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft, 'revision' => 7]);
+    attachPolicy($s['ws'], required: 1);
+
+    AcceptanceCriterion::withoutEvents(function () use ($s): void {
+        AcceptanceCriterion::create([
+            'story_id' => $s['story']->id,
+            'position' => 1,
+            'statement' => 'unchanged-ac',
+        ]);
+    });
+    forceStoryStatus($s['story'], StoryStatus::Approved, revision: 7);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('startEdit')
+        ->call('saveEdit')
+        ->assertOk();
+
+    $fresh = $s['story']->fresh();
+
+    expect($fresh->revision)->toBe(7)
+        ->and($fresh->status)->toBe(StoryStatus::Approved);
+});
+
+test('saving edited story contract preserves acceptance criterion ids and reopens approvals once', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft, 'revision' => 3]);
+    attachPolicy($s['ws'], required: 1);
+
+    $criterion = AcceptanceCriterion::withoutEvents(fn () => AcceptanceCriterion::create([
+        'story_id' => $s['story']->id,
+        'position' => 1,
+        'statement' => 'original-ac',
+    ]));
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create([
+        'acceptance_criterion_id' => $criterion->id,
+    ]);
+    $task->plan->forceFill(['status' => PlanStatus::Approved->value])->save();
+    forceStoryStatus($s['story'], StoryStatus::Approved, revision: 3);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('startEdit')
+        ->set('editName', 'edited story name')
+        ->set('editCriteria', [
+            ['id' => $criterion->id, 'statement' => 'edited-ac'],
+        ])
+        ->call('saveEdit')
+        ->assertOk();
+
+    $fresh = $s['story']->fresh();
+    $freshCriterion = $criterion->fresh();
+
+    expect($fresh->name)->toBe('edited story name')
+        ->and($fresh->revision)->toBe(4)
+        ->and($fresh->status)->toBe(StoryStatus::PendingApproval)
+        ->and($freshCriterion->statement)->toBe('edited-ac')
+        ->and($freshCriterion->getKey())->toBe($criterion->getKey())
+        ->and($task->fresh()->acceptance_criterion_id)->toBe($criterion->getKey())
+        ->and($task->plan->fresh()->status)->toBe(PlanStatus::PendingApproval);
+});
+
 test('plan section renders with compact/expanded toggle controls', function () {
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -19,6 +19,9 @@ use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Services\ApprovalService;
+use App\Services\Stories\StoryContractEditor;
+use App\Services\Stories\StoryRevisionLifecycle;
 use Livewire\Livewire;
 
 function showPageScene(array $opts = []): array
@@ -589,6 +592,74 @@ test('saving edited story contract preserves acceptance criterion ids and reopen
         ->and($freshCriterion->getKey())->toBe($criterion->getKey())
         ->and($task->fresh()->acceptance_criterion_id)->toBe($criterion->getKey())
         ->and($task->plan->fresh()->status)->toBe(PlanStatus::PendingApproval);
+});
+
+test('saving story contract rejects forged acceptance criterion ids without deleting existing links', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft, 'revision' => 3]);
+    $other = showPageScene(['status' => StoryStatus::Draft]);
+    attachPolicy($s['ws'], required: 1);
+
+    $criterion = AcceptanceCriterion::withoutEvents(fn () => AcceptanceCriterion::create([
+        'story_id' => $s['story']->id,
+        'position' => 1,
+        'statement' => 'owned-ac',
+    ]));
+    $foreign = AcceptanceCriterion::withoutEvents(fn () => AcceptanceCriterion::create([
+        'story_id' => $other['story']->id,
+        'position' => 1,
+        'statement' => 'foreign-ac',
+    ]));
+    $task = Task::factory()->forCurrentPlanOf($s['story'])->create([
+        'acceptance_criterion_id' => $criterion->id,
+    ]);
+    forceStoryStatus($s['story'], StoryStatus::Approved, revision: 3);
+
+    $this->actingAs($s['user']);
+
+    Livewire::test('pages::stories.show', ['story' => $s['story']->id])
+        ->call('startEdit')
+        ->set('editCriteria', [
+            ['id' => $foreign->id, 'statement' => 'forged-ac'],
+        ])
+        ->call('saveEdit')
+        ->assertStatus(422);
+
+    expect($criterion->fresh()->statement)->toBe('owned-ac')
+        ->and($foreign->fresh()->statement)->toBe('foreign-ac')
+        ->and($task->fresh()->acceptance_criterion_id)->toBe($criterion->id)
+        ->and($s['story']->fresh()->revision)->toBe(3);
+});
+
+test('story contract edit rolls back when lifecycle reopening fails', function () {
+    $s = showPageScene(['status' => StoryStatus::Draft, 'revision' => 5]);
+    attachPolicy($s['ws'], required: 1);
+
+    $criterion = AcceptanceCriterion::withoutEvents(fn () => AcceptanceCriterion::create([
+        'story_id' => $s['story']->id,
+        'position' => 1,
+        'statement' => 'original-ac',
+    ]));
+    forceStoryStatus($s['story'], StoryStatus::Approved, revision: 5);
+
+    app()->bind(StoryRevisionLifecycle::class, fn () => new class(app(ApprovalService::class)) extends StoryRevisionLifecycle
+    {
+        public function recordContentArtifactChanged(Story $story): void
+        {
+            throw new RuntimeException('Lifecycle failed.');
+        }
+    });
+
+    expect(fn () => app(StoryContractEditor::class)->update(
+        $s['story']->fresh(),
+        'new name',
+        'new description',
+        [['id' => $criterion->id, 'statement' => 'edited-ac']],
+    ))->toThrow(RuntimeException::class, 'Lifecycle failed.');
+
+    expect($s['story']->fresh()->name)->toBe('show-page-story')
+        ->and($s['story']->fresh()->description)->not->toBe('new description')
+        ->and($s['story']->fresh()->revision)->toBe(5)
+        ->and($criterion->fresh()->statement)->toBe('original-ac');
 });
 
 test('plan section renders with compact/expanded toggle controls', function () {


### PR DESCRIPTION
## Summary
- Add `StoryContractEditor` to own Story show contract edits and ID-preserving acceptance-criteria synchronization
- Route the Story show edit form through the editor instead of inline criteria/database/reapproval logic
- Reuse `StoryRevisionLifecycle::recordContentArtifactChanged()` so Story and current-Plan approval reopen semantics live in one place
- Add regression coverage for no-op saves, one-revision contract edits, and preserving acceptance criterion IDs linked from Tasks

## Verification
- `php artisan test --compact tests/Feature/StoryShowPageTest.php tests/Feature/StoryAcceptanceCriteriaWriterTest.php tests/Feature/StoryShowTest.php tests/Feature/PlanApprovalTest.php`
- `composer test`