### PR TITLE
Consolidate story activity projection

### DIFF
--- a/app/Mcp/Servers/SpecifyServer.php
+++ b/app/Mcp/Servers/SpecifyServer.php
@@ -65,7 +65,7 @@ Voice and scope, very important:
 - An ACCEPTANCE CRITERION is a short, atomic, observable rule. Do not put whole Given/When/Then scenarios here.
 - A SCENARIO holds Given/When/Then behaviour examples.
 - A PLAN is the implementation interpretation of a story.
-- Plans have their own approval lifecycle. Story approval gates the product contract; current-plan approval gates execution.
+- Plans have their own approval lifecycle. Story approval gates the product contract; current plan approval gates execution.
 - A TASK is an actionable work item under a plan. A SUBTASK is the executor-sized engineering step.
 
 Never put schemas, class names, file paths, or migration steps in a feature or story description — that belongs in plans, tasks, or subtasks.

--- a/app/Services/Stories/StoryRunProjection.php
+++ b/app/Services/Stories/StoryRunProjection.php
@@ -7,6 +7,7 @@ use App\Models\AgentRun;
 use App\Models\Story;
 use App\Models\Subtask;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 class StoryRunProjection
 {
@@ -29,6 +30,50 @@ class StoryRunProjection
             ->with('runnable')
             ->latest('id')
             ->first();
+    }
+
+    /**
+     * Story-runnable AgentRuns: plan-generation runs, latest first.
+     *
+     * @return Collection<int, AgentRun>
+     */
+    public function planGenerationRuns(Story $story): Collection
+    {
+        return AgentRun::query()
+            ->where('runnable_type', Story::class)
+            ->where('runnable_id', $story->getKey())
+            ->latest('id')
+            ->get();
+    }
+
+    public function latestCurrentPlanRun(Story $story): ?AgentRun
+    {
+        return $story->currentPlanTasks
+            ->flatMap->subtasks
+            ->flatMap->agentRuns
+            ->sortByDesc('id')
+            ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function currentPlanViewData(Story $story): array
+    {
+        $tasksByAc = $story->currentPlanTasks->groupBy('acceptance_criterion_id');
+        $latestRun = $this->latestCurrentPlanRun($story);
+
+        return [
+            'story' => $story,
+            'tasksByAc' => $tasksByAc,
+            'unmappedTasks' => $tasksByAc->get(null, collect())->sortBy('position')->values(),
+            'acs' => $story->acceptanceCriteria->sortBy('position')->values(),
+            'subtaskCount' => $story->currentPlanTasks->reduce(fn ($acc, $task) => $acc + $task->subtasks->count(), 0),
+            'shouldRunMode' => $this->hasActiveSubtaskRun($story),
+            'branch' => $latestRun?->working_branch,
+            'repo' => $latestRun?->repo,
+            'planGenRuns' => $this->planGenerationRuns($story),
+        ];
     }
 
     private function subtaskIdQueryFor(Story $story): Builder

--- a/app/Services/Stories/StoryRunProjection.php
+++ b/app/Services/Stories/StoryRunProjection.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Collection;
 
 class StoryRunProjection
 {
+    private const PLAN_GENERATION_RUN_LIMIT = 25;
+
     public function hasActiveSubtaskRun(Story $story): bool
     {
         return AgentRun::query()
@@ -43,16 +45,18 @@ class StoryRunProjection
             ->where('runnable_type', Story::class)
             ->where('runnable_id', $story->getKey())
             ->latest('id')
-            ->get();
+            ->limit(self::PLAN_GENERATION_RUN_LIMIT)
+            ->get(['id', 'runnable_type', 'runnable_id', 'status', 'finished_at', 'error_message']);
     }
 
     public function latestCurrentPlanRun(Story $story): ?AgentRun
     {
-        return $story->currentPlanTasks
-            ->flatMap->subtasks
-            ->flatMap->agentRuns
-            ->sortByDesc('id')
-            ->first();
+        return AgentRun::query()
+            ->where('runnable_type', Subtask::class)
+            ->whereIn('runnable_id', $this->subtaskIdQueryFor($story))
+            ->with('repo')
+            ->latest('id')
+            ->first(['id', 'runnable_type', 'runnable_id', 'repo_id', 'working_branch']);
     }
 
     /**
@@ -60,6 +64,14 @@ class StoryRunProjection
      */
     public function currentPlanViewData(Story $story): array
     {
+        $story->loadMissing([
+            'acceptanceCriteria',
+            'currentPlanTasks.acceptanceCriterion',
+            'currentPlanTasks.scenario',
+            'currentPlanTasks.dependencies',
+            'currentPlanTasks.subtasks.agentRuns.repo',
+        ]);
+
         $tasksByAc = $story->currentPlanTasks->groupBy('acceptance_criterion_id');
         $latestRun = $this->latestCurrentPlanRun($story);
 

--- a/resources/views/components/story/summary-card.blade.php
+++ b/resources/views/components/story/summary-card.blade.php
@@ -26,7 +26,7 @@
                     <flux:badge>{{ __('by') }} {{ $story->creator->name }}</flux:badge>
                 @endif
                 @if ($tasksTotal > 0)
-                    <flux:badge>{{ $tasksDone }}/{{ $tasksTotal }} {{ __('current-plan tasks') }}</flux:badge>
+                    <flux:badge>{{ $tasksDone }}/{{ $tasksTotal }} {{ __('current Plan Tasks') }}</flux:badge>
                 @endif
                 @if ($story->updated_at)
                     <flux:text class="ml-auto text-xs text-zinc-500">{{ $story->updated_at->diffForHumans() }}</flux:text>

--- a/resources/views/pages/stories/⚡show.blade.php
+++ b/resources/views/pages/stories/⚡show.blade.php
@@ -9,6 +9,7 @@ use App\Models\AgentRun;
 use App\Models\Story;
 use App\Services\Stories\StoryContractEditor;
 use App\Services\Stories\StoryPageWorkflow;
+use App\Services\Stories\StoryRunProjection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
@@ -579,23 +580,6 @@ new #[Title('Story')] class extends Component {
     }
 
     /**
-     * Story-runnable AgentRuns: plan-generation runs, latest first.
-     */
-    #[Computed]
-    public function planGenerationRuns()
-    {
-        if (! $this->story) {
-            return collect();
-        }
-
-        return AgentRun::query()
-            ->where('runnable_type', Story::class)
-            ->where('runnable_id', $this->story_id)
-            ->latest('id')
-            ->get();
-    }
-
-    /**
      * @return array<string, mixed>
      */
     #[Computed]
@@ -606,20 +590,7 @@ new #[Title('Story')] class extends Component {
             return [];
         }
 
-        $tasksByAc = $story->currentPlanTasks->groupBy('acceptance_criterion_id');
-        $latestRun = $story->currentPlanTasks->flatMap->subtasks->flatMap->agentRuns->sortByDesc('id')->first();
-
-        return [
-            'story' => $story,
-            'tasksByAc' => $tasksByAc,
-            'unmappedTasks' => $tasksByAc->get(null, collect())->sortBy('position')->values(),
-            'acs' => $story->acceptanceCriteria->sortBy('position')->values(),
-            'subtaskCount' => $story->currentPlanTasks->reduce(fn ($acc, $task) => $acc + $task->subtasks->count(), 0),
-            'shouldRunMode' => $this->hasActiveSubtaskRun,
-            'branch' => $latestRun?->working_branch,
-            'repo' => $latestRun?->repo,
-            'planGenRuns' => $this->planGenerationRuns,
-        ];
+        return app(StoryRunProjection::class)->currentPlanViewData($story);
     }
 
     /**

--- a/resources/views/partials/story-show/plan.blade.php
+++ b/resources/views/partials/story-show/plan.blade.php
@@ -3,7 +3,7 @@
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
             <flux:heading size="lg">{{ __('Current plan') }}</flux:heading>
             <flux:text class="text-xs text-zinc-500">
-                {{ $acs->count() }} {{ __('ACs') }} · {{ $story->currentPlanTasks->count() }} {{ __('current-plan tasks') }} · {{ $subtaskCount }} {{ __('subtasks') }}
+                {{ $acs->count() }} {{ __('ACs') }} · {{ $story->currentPlanTasks->count() }} {{ __('current Plan Tasks') }} · {{ $subtaskCount }} {{ __('Subtasks') }}
                 @if ($story->currentPlan)
                     · {{ __('current') }} {{ $story->currentPlan->name ?? ('v'.$story->currentPlan->version) }}
                 @endif
@@ -69,7 +69,7 @@
                 </summary>
 
                 @if ($acTasks->isEmpty())
-                    <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No current-plan task is mapped to this AC yet.') }}</flux:text>
+                    <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No current Plan Task is mapped to this AC yet.') }}</flux:text>
                 @else
                     @foreach ($acTasks as $task)
                         @include('partials.story-task', ['task' => $task])
@@ -89,7 +89,7 @@
         <flux:card data-ac="unmapped">
             <details :open="planRunMode">
                 <summary class="cursor-pointer text-sm font-medium">
-                    {{ __('Current-plan tasks not mapped to an AC') }} ({{ $unmappedTasks->count() }})
+                    {{ __('Current Plan Tasks not mapped to an AC') }} ({{ $unmappedTasks->count() }})
                 </summary>
                 @foreach ($unmappedTasks as $task)
                     @include('partials.story-task', ['task' => $task])

--- a/tests/Feature/PlanningArchitectureConformanceTest.php
+++ b/tests/Feature/PlanningArchitectureConformanceTest.php
@@ -143,12 +143,12 @@ test('review responder prompt includes current plan context', function () {
         ->and($prompt)->toContain('Parent Task #1: Address review feedback');
 });
 
-test('mcp instructions and planning tool descriptions speak in current-plan terms', function () {
+test('mcp instructions and planning tool descriptions speak in current plan terms', function () {
     $instructions = serverAttribute(SpecifyServer::class, Instructions::class);
 
     expect($instructions)->toContain('Project → Feature → Story → AcceptanceCriterion / Scenario → Plan → Task → Subtask')
         ->and($instructions)->toContain('the current plan owns tasks')
-        ->and($instructions)->toContain('current-plan approval gates execution');
+        ->and($instructions)->toContain('current plan approval gates execution');
 
     $descriptions = [
         GenerateTasksTool::class => descriptionFor(GenerateTasksTool::class),

--- a/tests/Feature/StoriesIndexTest.php
+++ b/tests/Feature/StoriesIndexTest.php
@@ -56,7 +56,7 @@ test('status filter narrows the list', function () {
         ->assertDontSee('draft-story');
 });
 
-test('story summary labels task progress as current-plan tasks', function () {
+test('story summary labels task progress as current Plan Tasks', function () {
     ['user' => $user, 'project' => $project, 'feature' => $feature] = storyIndexScene();
     $story = Story::factory()->for($feature)->create(['name' => 'planned-story', 'status' => StoryStatus::Approved]);
     Task::factory()->forCurrentPlanOf($story)->create(['status' => TaskStatus::Done]);
@@ -66,7 +66,7 @@ test('story summary labels task progress as current-plan tasks', function () {
 
     Livewire::test('pages::stories.index', ['project' => $project->id])
         ->assertSee('planned-story')
-        ->assertSee('1/2 current-plan tasks')
+        ->assertSee('1/2 current Plan Tasks')
         ->assertDontSee('1/2 tasks');
 });
 

--- a/tests/Feature/StoryRunProjectionTest.php
+++ b/tests/Feature/StoryRunProjectionTest.php
@@ -60,3 +60,42 @@ test('story run projection returns latest active conflict resolution run', funct
     expect($result)->not->toBeNull()
         ->and($result->id)->toBe($running->id);
 });
+
+test('story run projection prepares current plan activity view data', function () {
+    $story = Story::factory()->create();
+    $ac = $story->acceptanceCriteria()->create([
+        'position' => 1,
+        'statement' => 'The current plan maps work to this AC.',
+    ]);
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
+        'acceptance_criterion_id' => $ac->getKey(),
+    ]);
+    $subtask = Subtask::factory()->for($task)->create();
+    $older = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Succeeded,
+        'working_branch' => 'specify/older',
+    ]);
+    $latest = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subtask->id,
+        'status' => AgentRunStatus::Running,
+        'working_branch' => 'specify/latest',
+    ]);
+    $planRun = AgentRun::factory()->create([
+        'runnable_type' => Story::class,
+        'runnable_id' => $story->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    $data = app(StoryRunProjection::class)->currentPlanViewData($story->fresh()->load([
+        'acceptanceCriteria',
+        'currentPlanTasks.subtasks.agentRuns.repo',
+    ]));
+
+    expect($data['tasksByAc']->get($ac->getKey())->first()->id)->toBe($task->id)
+        ->and($data['branch'])->toBe('specify/latest')
+        ->and($data['planGenRuns']->pluck('id')->all())->toBe([$planRun->id])
+        ->and($older->id)->toBeLessThan($latest->id);
+});

--- a/tests/Feature/StoryRunProjectionTest.php
+++ b/tests/Feature/StoryRunProjectionTest.php
@@ -99,3 +99,23 @@ test('story run projection prepares current plan activity view data', function (
         ->and($data['planGenRuns']->pluck('id')->all())->toBe([$planRun->id])
         ->and($older->id)->toBeLessThan($latest->id);
 });
+
+test('story run projection limits plan generation run payload', function () {
+    $story = Story::factory()->create();
+
+    foreach (range(1, 30) as $i) {
+        AgentRun::factory()->create([
+            'runnable_type' => Story::class,
+            'runnable_id' => $story->id,
+            'status' => AgentRunStatus::Succeeded,
+            'output' => ['large' => str_repeat('x', 100)],
+            'diff' => str_repeat('y', 100),
+        ]);
+    }
+
+    $runs = app(StoryRunProjection::class)->planGenerationRuns($story);
+
+    expect($runs)->toHaveCount(25)
+        ->and($runs->first()->getAttributes())->toHaveKeys(['id', 'status', 'finished_at', 'error_message'])
+        ->and($runs->first()->getAttributes())->not->toHaveKeys(['output', 'diff']);
+});

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -403,7 +403,7 @@ test('plan section is AC-led: AC text leads, Task name follows', function () {
         ->and($acIdx)->toBeLessThan($taskIdx);
 });
 
-test('plan section labels current-plan task counts and empty AC mappings', function () {
+test('plan section labels current Plan Task counts and empty AC mappings', function () {
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);
 
@@ -417,11 +417,11 @@ test('plan section labels current-plan task counts and empty AC mappings', funct
 
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertSee('Current plan')
-        ->assertSee('0 current-plan tasks')
-        ->assertSee('No current-plan task is mapped to this AC yet.');
+        ->assertSee('0 current Plan Tasks')
+        ->assertSee('No current Plan Task is mapped to this AC yet.');
 });
 
-test('task missing acceptance_criterion_id renders under current-plan unmapped tasks', function () {
+test('task missing acceptance_criterion_id renders under current plan unmapped tasks', function () {
     $s = showPageScene(['status' => StoryStatus::Approved]);
     attachPolicy($s['ws'], required: 1);
 
@@ -435,7 +435,7 @@ test('task missing acceptance_criterion_id renders under current-plan unmapped t
 
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertSeeHtml('data-ac="unmapped"')
-        ->assertSee('Current-plan tasks not mapped to an AC')
+        ->assertSee('Current Plan Tasks not mapped to an AC')
         ->assertSee('orphan-task');
 });
 


### PR DESCRIPTION
## Summary
- Move Story show current-Plan activity view data into `StoryRunProjection`
- Centralize latest current-Plan run, branch/repo, and plan-generation run lookup behind the Story run projection
- Keep the Story show page focused on delegating render data instead of assembling run activity inline
- Align visible copy and MCP instructions around current Plan / Task terminology

## Verification
- `php artisan test --compact tests/Feature/StoryRunProjectionTest.php tests/Feature/StoryShowPageTest.php tests/Feature/StoryShowTest.php tests/Feature/StoriesIndexTest.php tests/Feature/StoryPullRequestsTest.php tests/Feature/PlanningArchitectureConformanceTest.php`
- `composer test`