### PR TITLE
Document project information architecture

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,4 +5,5 @@ These pages explain Specify's current architecture. ADRs in `docs/adr/` remain t
 | Page | Purpose |
 |---|---|
 | [AgentRun lifecycle](agent-run-lifecycle.md) | Explains AgentRun kinds and statuses, execution scheduling, executor selection, workspace handling, PR/review follow-ups, progress events, retry/cancel semantics, and cascade rules. |
+| [Project information architecture](project-information-architecture.md) | Explains Workspace, Team, Project, Feature, Repo, route, active-project, access-control, and MCP context rules. |
 | [Story planning model](story-planning-model.md) | Explains the current Product contract -> Plan -> Task -> Subtask structure, approval gates, execution flow, Story page seams, and MCP terminology. |

--- a/docs/architecture/project-information-architecture.md
+++ b/docs/architecture/project-information-architecture.md
@@ -215,8 +215,9 @@ MCP tools use Project context in two ways:
 
 `CurrentContextTool` returns acting user, current Workspace, current Team, and
 current Project. Tools that resolve Project-owned records use
-`ResolvesProjectAccess` so Story, Feature, Plan, Scenario, Task, and Subtask
-lookups all enforce the same access rule.
+`ResolvesProjectAccess` for Project, Feature, Story, Scenario, and Plan lookups.
+Tools that start from Task or Subtask manually resolve the owning Project through
+Plan and Story, then enforce the same access rule.
 
 Common MCP patterns:
 
@@ -224,7 +225,8 @@ Common MCP patterns:
 |---|---|
 | `list-projects` | Lists all accessible Projects. |
 | `switch-project` | Sets `users.current_project_id`. |
-| `list-features`, `list-stories`, `list-runs`, `list-repos` | Use explicit `project_id` or current Project. |
+| `list-features`, `list-stories`, `list-repos` | Use explicit `project_id` or current Project. |
+| `list-runs` | Requires at least one of `story_id`, `task_id`, or `subtask_id`, then authorises through the resolved Project. |
 | `create-feature`, `create-story`, `create-project` | Create records under the selected Project or Team. |
 | `add-github-repo-to-project`, `set-primary-repo`, `remove-project-repo` | Manage Project -> Repo attachment with approval-role checks. |
 | Story / Plan / Task / Subtask tools | Resolve access through the owning Project. |
@@ -242,7 +244,8 @@ URLs from the Project, Story, Subtask, and Run IDs when needed.
 - Do not attach a Repo to a Project in a different Workspace.
 - Do not set more than one primary Repo for a Project.
 - Do not create direct Task -> Story or Task -> Project ownership shortcuts.
-- Do not bypass `ResolvesProjectAccess` in MCP tools that touch
-  Project-owned records.
+- Do not bypass Project access checks in MCP tools that touch Project-owned
+  records; use `ResolvesProjectAccess` where it has a resolver and manual owner
+  resolution where it does not.
 - Do not expose run events without resolving the run back to an accessible
   Project.

--- a/docs/architecture/project-information-architecture.md
+++ b/docs/architecture/project-information-architecture.md
@@ -1,0 +1,248 @@
+# Project information architecture
+
+Specify is organised around Projects. Workspace and Team provide tenancy and
+membership; Project is the persistent product context; Feature, Story, Plan,
+Task, Subtask, Repo, and AgentRun hang from that context.
+
+This page describes the current implementation shape. The load-bearing
+decision is [ADR-0012](../adr/0012-project-first-information-architecture.md).
+The Story and execution details are covered by
+[Story planning model](story-planning-model.md) and
+[AgentRun lifecycle](agent-run-lifecycle.md).
+
+## Domain shape
+
+```text
+Workspace
+  -> Team
+    -> Project
+      -> Feature
+        -> Story
+          -> Plan
+            -> Task
+              -> Subtask
+
+Workspace
+  -> Repo
+
+Project
+  -> Repo via project_repo
+```
+
+The main ownership rules:
+
+- `Workspace` is the tenant boundary. It owns Teams and Repos directly.
+- `Team` is the membership and role boundary inside a Workspace.
+- `Project` is owned by a Team and contains Features.
+- `Feature` contains Stories.
+- `Story` owns product-contract children and Plan history.
+- `Plan` owns Tasks; Tasks own Subtasks.
+- `Repo` is workspace-scoped and can attach to one or more Projects through
+  `project_repo`.
+
+Project context is resolved by following the domain chain:
+
+| Starting point | Project resolution |
+|---|---|
+| `Feature` | `Feature -> Project` |
+| `Story` | `Story -> Feature -> Project` |
+| `Plan` | `Plan -> Story -> Feature -> Project` |
+| `Task` | `Task -> Plan -> Story -> Feature -> Project` |
+| `Subtask` | `Subtask -> Task -> Plan -> Story -> Feature -> Project` |
+| `AgentRun` for a Story | `AgentRun -> Story -> Feature -> Project` |
+| `AgentRun` for a Subtask | `AgentRun -> Subtask -> Task -> Plan -> Story -> Feature -> Project` |
+
+Do not add shortcut foreign keys to avoid these joins unless the model is
+deliberately denormalised and documented. In particular, Tasks do not point
+directly at Stories or Projects.
+
+## Workspace and Team
+
+`Workspace` is ambient context rather than a product navigation target. New
+users are bootstrapped with a personal Workspace and Team during auth setup.
+
+`Team` carries membership through the `team_user` pivot. The pivot stores
+`TeamRole`, and those roles drive project management and approval authority.
+
+Current role checks:
+
+- `User::accessibleProjectIds()` returns Projects owned by Teams the user
+  belongs to.
+- `User::canApproveInProject()` allows `Owner` and `Admin` roles.
+- Project, Feature, Story, Plan, Task, Subtask, Run, and Repo pages reject
+  inaccessible Project IDs with a 404.
+- Active-project state is only a UI convenience; it does not grant access.
+
+## Project context
+
+`users.current_project_id` stores the active Project. The URL remains the
+source of truth for project-scoped pages.
+
+Current write paths:
+
+- Project-scoped Livewire pages accept `{project}` in `mount()` and verify
+  access.
+- Several high-traffic Project pages mirror the route Project into
+  `users.current_project_id` so the sidebar and MCP defaults stay aligned with
+  navigation.
+- The app switcher calls `User::switchProject()` and navigates to the selected
+  Project overview.
+- `User::switchWorkspace()` changes `current_team_id` and clears
+  `current_project_id`.
+- MCP tools default to `current_project_id` when a `project_id` argument is
+  optional.
+
+Current read paths:
+
+- The sidebar reads `currentWorkspace()` and `currentProject`.
+- Project lists use `accessibleProjectsInCurrentWorkspace()`.
+- Project-scoped pages use the URL Project parameter and access checks.
+- Workspace-scoped pages use `scopedProjectIds()` when they need the active
+  Project filter, or `accessibleProjectIds()` when they intentionally span all
+  accessible Projects.
+
+The app switcher currently allows an "All projects" state by setting
+`current_project_id` to null. Project-scoped pages still require an explicit
+Project in the URL.
+
+## Web routes
+
+Workspace-scoped routes:
+
+| Route | Purpose |
+|---|---|
+| `/triage` | Cross-project approval queue. |
+| `/activity` | Cross-project activity stream. |
+| `/projects` | Project picker/list. |
+
+Project-scoped routes:
+
+| Route | Purpose |
+|---|---|
+| `/projects/{project}` | Project overview and Feature management. |
+| `/projects/{project}/features/{feature}` | Feature document. |
+| `/projects/{project}/stories` | Project Story list. |
+| `/projects/{project}/stories/create` | Create a Story under the Project. |
+| `/projects/{project}/stories/{story}` | Story document. |
+| `/projects/{project}/plans` | Project Plan list. |
+| `/projects/{project}/plans/{plan}` | Plan document. |
+| `/projects/{project}/approvals` | Project approval view. |
+| `/projects/{project}/runs` | Project run list. |
+| `/projects/{project}/repos` | Project repository management. |
+| `/projects/{project}/stories/{story}/tasks/{task}` | Task document. |
+| `/projects/{project}/stories/{story}/subtasks/{subtask}` | Subtask document. |
+| `/projects/{project}/stories/{story}/subtasks/{subtask}/runs/{run}` | Run console. |
+
+Current exception:
+
+- `/runs/{run}/events` is a polling endpoint for run progress events. It is
+  not a navigation route. `RunEventsController` authorises it by resolving the
+  `AgentRun` back to its Story or Subtask Project and checking
+  `accessibleProjectIds()`.
+
+Flat record-page routes such as `/stories/{id}` and `/runs/{id}` are not part
+of the current web product surface.
+
+## Livewire page contract
+
+Project-owned pages follow the same route contract:
+
+1. accept the Project route parameter
+2. check that the authenticated user can access it
+3. store the Project ID locally for queries and route generation
+4. ensure child route parameters belong to that Project
+
+Pages that represent a user's current working context should also mirror the
+route Project into `users.current_project_id`. The mirror is not required for
+authorisation; it keeps ambient UI and MCP defaults aligned with the page the
+user is viewing.
+
+Examples:
+
+| Page | Route binding check |
+|---|---|
+| `pages::projects.show` | Project ID must be accessible. |
+| `pages::features.show` | Feature must belong to the route Project. |
+| `pages::stories.index` | Project ID must be accessible. |
+| `pages::stories.show` | Story must be accessible and, when supplied, belong to the route Project. |
+| `pages::runs.show` | Run must resolve through the route Project, Story, and Subtask. |
+| `pages::repos.index` | Project ID must be accessible before Repo management. |
+
+Queries should prefer the route Project over ambient user state on
+project-scoped pages. Ambient state is useful for defaults and sidebar chrome,
+not for authorisation.
+
+## Repositories
+
+Repos are workspace-scoped because a single git repository can be shared across
+Projects in the same Workspace. Projects attach Repos through `project_repo`.
+
+`project_repo` stores:
+
+- `project_id`
+- `repo_id`
+- `role`
+- `is_primary`
+
+`Project::attachRepo()` preserves the same-workspace invariant and chooses a
+primary Repo automatically when the Project has no existing primary. Passing
+`primary=true` or calling `setPrimaryRepo()` clears the previous primary for
+that Project.
+
+The primary Repo is the default execution Repo:
+
+```text
+Subtask -> Task -> Plan -> Story -> Feature -> Project -> primaryRepo()
+```
+
+Repo provider selection:
+
+| Provider surface | Selection point |
+|---|---|
+| Pull requests | `Repo::pullRequestProvider()` |
+| Advisory reviews | `Repo::reviewProvider()` |
+| Webhooks | GitHub webhook route keyed by Repo ID |
+
+Removing a Repo from a Project currently detaches the Repo from Projects and
+deletes the Repo row after deleting the GitHub webhook when applicable.
+
+## MCP surface
+
+MCP tools use Project context in two ways:
+
+- explicit `project_id` arguments for project-scoped list/create/manage tools
+- defaulting to the user's current Project when `project_id` is optional
+
+`CurrentContextTool` returns acting user, current Workspace, current Team, and
+current Project. Tools that resolve Project-owned records use
+`ResolvesProjectAccess` so Story, Feature, Plan, Scenario, Task, and Subtask
+lookups all enforce the same access rule.
+
+Common MCP patterns:
+
+| Tool shape | Project behaviour |
+|---|---|
+| `list-projects` | Lists all accessible Projects. |
+| `switch-project` | Sets `users.current_project_id`. |
+| `list-features`, `list-stories`, `list-runs`, `list-repos` | Use explicit `project_id` or current Project. |
+| `create-feature`, `create-story`, `create-project` | Create records under the selected Project or Team. |
+| `add-github-repo-to-project`, `set-primary-repo`, `remove-project-repo` | Manage Project -> Repo attachment with approval-role checks. |
+| Story / Plan / Task / Subtask tools | Resolve access through the owning Project. |
+
+The MCP surface returns IDs and data, not canonical web URLs. Clients can build
+URLs from the Project, Story, Subtask, and Run IDs when needed.
+
+## Invariants to preserve
+
+- Do not make Workspace a primary product navigation target.
+- Do not add flat record-page routes for Project-owned records.
+- Do not trust `current_project_id` for authorisation.
+- Do not query Project-owned data from ambient state when the URL supplies a
+  Project.
+- Do not attach a Repo to a Project in a different Workspace.
+- Do not set more than one primary Repo for a Project.
+- Do not create direct Task -> Story or Task -> Project ownership shortcuts.
+- Do not bypass `ResolvesProjectAccess` in MCP tools that touch
+  Project-owned records.
+- Do not expose run events without resolving the run back to an accessible
+  Project.


### PR DESCRIPTION
## Summary
- add a Project information architecture page covering Workspace/Team/Project ownership, active-project state, project-scoped routes, Livewire page contracts, Repo attachment, and MCP project context
- document the current run-events polling endpoint exception to the nested route surface
- link the new page from the architecture index

## Verification
- `git diff --check`
- link/path sanity check for referenced ADR and architecture pages
- route/model sanity check against `routes/web.php`, `User`, `Project`, `Repo`, `CurrentContextTool`, and `ResolvesProjectAccess`

Docs-only change; `composer test` not run.