### PR TITLE
Land merged architecture docs stack

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,5 +5,8 @@ These pages explain Specify's current architecture. ADRs in `docs/adr/` remain t
 | Page | Purpose |
 |---|---|
 | [AgentRun lifecycle](agent-run-lifecycle.md) | Explains AgentRun kinds and statuses, execution scheduling, executor selection, workspace handling, PR/review follow-ups, progress events, retry/cancel semantics, and cascade rules. |
+| [Approval architecture](approval-architecture.md) | Explains Story and current-Plan approval gates, policies, decision replay, auto-approval, reopening, and AgentRun authorisation. |
+| [MCP surface](mcp-surface.md) | Explains the Laravel MCP server, authentication, Project access checks, tool groups, product-contract writes, Plan writes, approvals, execution, repos, and activity tools. |
 | [Project information architecture](project-information-architecture.md) | Explains Workspace, Team, Project, Feature, Repo, route, active-project, access-control, and MCP context rules. |
+| [Repository integration](repository-integration.md) | Explains Repo attachment, provider adapters, GitHub OAuth/webhooks, PR creation and retry, webhook intake, review responses, and advisory review probes. |
 | [Story planning model](story-planning-model.md) | Explains the current Product contract -> Plan -> Task -> Subtask structure, approval gates, execution flow, Story page seams, and MCP terminology. |

--- a/docs/architecture/approval-architecture.md
+++ b/docs/architecture/approval-architecture.md
@@ -1,0 +1,285 @@
+# Approval architecture
+
+Specify has two human gates:
+
+- Story approval gates the product contract.
+- Current Plan approval gates the implementation plan.
+
+Tasks and Subtasks are not approval gates. PR review is not an approval gate.
+
+This page describes the current implementation shape. The load-bearing decision
+is [ADR-0001](../adr/0001-story-and-plan-approval-gates.md). The hierarchy
+being approved is covered by [Story planning model](story-planning-model.md).
+
+## Gate targets
+
+Story approval answers: "Is this product contract worth implementing?"
+
+Story-owned contract data includes:
+
+- Story body fields such as name, kind, actor, intent, outcome, description,
+  and notes
+- acceptance criteria
+- scenarios
+
+Plan approval answers: "Is this implementation interpretation acceptable?"
+
+Plan-owned delivery data includes:
+
+- current Plan fields
+- Tasks
+- Subtasks
+- Task links to acceptance criteria, scenarios, and dependencies
+
+Execution requires both the Story and the current Plan to be approved. A Story
+can be approved while its current Plan is still draft, pending, or changes
+requested.
+
+## Core records
+
+| Record | Purpose |
+|---|---|
+| `ApprovalPolicy` | Threshold and self-approval rules for a scope. |
+| `StoryApproval` | Immutable decision row for one Story revision. |
+| `PlanApproval` | Immutable decision row for one Plan revision. |
+
+`StoryApproval` and `PlanApproval` are append-only audit rows. Updates and
+deletes are blocked by model hooks. Corrections happen by recording another
+decision, such as `revoke` or `changes_requested`.
+
+Approval rows are filtered by the target's current revision during recompute.
+Older revision rows stay in the database but do not count toward the current
+gate.
+
+The approval-row tables allow multiple decisions from the same approver on the
+same revision. `ApprovalGate` replays all rows in creation order and maintains
+the effective approver set in memory.
+
+## Policy resolution
+
+`ApprovalPolicy` stores:
+
+- `scope_type`
+- `scope_id`
+- `required_approvals`
+- `allow_self_approval`
+- `auto_approve`
+- `notes`
+
+Story policy resolution is:
+
+```text
+Story policy
+  -> Project policy
+    -> Workspace policy
+      -> default policy
+```
+
+Plan policy resolution delegates to the Story's effective policy. Plan-scoped
+policy constants exist on the model, but the current resolver does not read
+Plan-scoped policies.
+
+Default policy:
+
+```text
+required_approvals = 0
+allow_self_approval = false
+auto_approve = false
+```
+
+With `required_approvals = 0`, submitting a non-draft gate moves it to
+approved during recompute without creating an approval row. This is why
+AgentRun `authorizing_approval` can legitimately be null even though the gate
+was approval-satisfied.
+
+`auto_approve = true` also makes the gate approval-satisfied regardless of the
+effective approval count. Draft targets are not auto-promoted until they are
+submitted.
+
+## Decisions
+
+Approval decisions are:
+
+| Decision | Replay effect |
+|---|---|
+| `approve` | Adds the approver to the effective approval set. |
+| `revoke` | Removes the approver from the effective approval set. |
+| `changes_requested` | Clears the effective approval set and moves the gate back to review state. |
+| `reject` | Terminally rejects the gate. |
+
+`reject` short-circuits replay. Once a Story or Plan is rejected,
+`ApprovalService` rejects further decisions for that target.
+
+`changes_requested` behaves differently by target:
+
+- Story moves to `changes_requested`.
+- Plan moves to `pending_approval`.
+
+That is intentional: Plan has no separate `changes_requested` enum value.
+
+## State machine
+
+`ApprovalService` records decisions and asks `ApprovalGate` to recompute the
+target state.
+
+Story path:
+
+```text
+Story::submitForApproval()
+  -> StoryApprovalSubmission::submit()
+  -> status = pending_approval
+  -> ApprovalService::recompute()
+  -> ApprovalGate::nextStatus()
+```
+
+Plan path:
+
+```text
+Plan::submitForApproval()
+  -> PlanApprovalLifecycle::submit()
+  -> status = pending_approval
+  -> ApprovalService::recomputePlan()
+  -> ApprovalGate::nextStatus()
+```
+
+Decision recording:
+
+```text
+ApprovalService::recordDecision()
+  -> create StoryApproval
+  -> recompute Story
+
+ApprovalService::recordPlanDecision()
+  -> create PlanApproval
+  -> recompute Plan
+```
+
+Recompute rules:
+
+- Any `reject` decision returns rejected.
+- Latest effective `changes_requested` state returns the target's review-state
+  status.
+- `approve` decisions count once per approver.
+- `revoke` removes that approver from the count.
+- The gate is approved when `auto_approve` is true or the effective approver
+  count meets `required_approvals`.
+- Draft targets stay draft until submitted.
+
+## Submission guards
+
+Story submission guards:
+
+- rejected Stories cannot be submitted
+- Story must have at least one acceptance criterion
+
+Plan submission guards:
+
+- only the Story's current Plan can be submitted
+- rejected Plans cannot be submitted
+- Plan must have at least one Task
+
+Plan decisions have extra guards:
+
+- only the current Plan can receive decisions
+- draft Plans cannot receive decisions before submission
+- rejected and superseded Plans cannot receive decisions
+
+Self-approval is rejected for `approve` decisions when the effective policy has
+`allow_self_approval = false` and the approver is the Story creator. This guard
+also applies to Plan approval because a Plan inherits the Story policy and
+creator.
+
+## Reopening
+
+Product-contract edits reopen Story approval and current Plan approval.
+
+Product-contract edits include:
+
+- watched Story body fields
+- acceptance criteria changes
+- scenario changes
+
+Story body edits bump `stories.revision` through `StoryRevisionLifecycle`.
+Acceptance-criterion and scenario changes call
+`StoryRevisionLifecycle::recordContentArtifactChanged()`.
+
+When Story revision changes:
+
+- non-draft, non-terminal Stories move back to the policy-derived review state
+- current Plan approval is reopened because the implementation interpretation
+  may be stale
+- prior Story approval rows remain stored but no longer count because their
+  `story_revision` is old
+
+Plan edits reopen only Plan approval. They do not reopen Story approval unless
+the product contract also changed.
+
+Plan approval reopening increments `plans.revision` and sets status according
+to the current Plan state:
+
+| Current Plan status | Reopen result |
+|---|---|
+| `draft` | stays `draft` |
+| `superseded` | stays `superseded` |
+| `done` | stays `done` |
+| any other status, including `rejected` | moves to `pending_approval`, then recomputes |
+
+Executor-proposed Subtasks appended mid-run are the ADR-0005 exception: they
+grow the Plan append-only and do not reopen approval.
+
+## Authorisation and AgentRuns
+
+Plan generation interprets an approved Story into a Plan. When a concrete
+`StoryApproval` row is available, the generated `AgentRun` may point to it
+through `authorizing_approval`.
+
+Subtask execution requires an approved Story and approved current Plan. When a
+concrete `PlanApproval` row is available, Execute AgentRuns may point to it
+through `authorizing_approval`.
+
+Auto-approval paths can approve without creating a `StoryApproval` or
+`PlanApproval` row, so `authorizing_approval` is nullable by design.
+
+Retries re-check the current Story and Plan approval state. A retry is rejected
+if the Story or current Plan is no longer approved.
+
+## Web and MCP surfaces
+
+Primary web surfaces:
+
+- Story page product-contract approval actions
+- Story page current-Plan approval actions
+- Project approval views
+
+Primary MCP surfaces:
+
+- `submit-story`
+- `approve-story`
+- `request-story-changes`
+- `reject-story`
+- `submit-plan`
+- `approve-plan`
+- `request-plan-changes`
+- `reject-plan`
+
+MCP submit tools use `ResolvesProjectAccess`: the user must be able to access the
+owning Project, but submit does not require approver rights.
+
+MCP decision tools use `RecordsApprovalDecisions` and `ResolvesProjectAccess`.
+The user must be able to access the owning Project and must have approver rights
+in that Project.
+
+## Invariants to preserve
+
+- Do not add Task or Subtask approval gates.
+- Do not mutate or delete StoryApproval or PlanApproval rows.
+- Do not count approval rows from older revisions.
+- Do not treat `authorizing_approval = null` as unauthorised by itself;
+  auto-approval can satisfy the gate without a concrete row.
+- Do not approve a draft Story or Plan without submission.
+- Do not allow decisions on non-current Plans.
+- Do not reopen Story approval for delivery-plan-only edits.
+- Do not reopen Plan approval for ADR-0005 append-only executor growth.
+- Do not bypass `ApprovalService` for approval decisions.
+- Do not bypass `StoryRevisionLifecycle` or `PlanApprovalLifecycle` when edits
+  should reopen approval.

--- a/docs/architecture/mcp-surface.md
+++ b/docs/architecture/mcp-surface.md
@@ -1,0 +1,262 @@
+# MCP surface
+
+Specify exposes its planning and execution workflow through a Laravel MCP
+server. The MCP surface uses the same product and delivery language as the web
+app: Project, Feature, Story, AcceptanceCriterion, Scenario, Plan, Task,
+Subtask, Repo, and AgentRun.
+
+This page describes the current implementation shape. Related pages:
+[Project information architecture](project-information-architecture.md),
+[Story planning model](story-planning-model.md),
+[Approval architecture](approval-architecture.md),
+[AgentRun lifecycle](agent-run-lifecycle.md), and
+[Repository integration](repository-integration.md).
+
+## Server shape
+
+`App\Mcp\Servers\SpecifyServer` registers tools only. It currently exposes no
+MCP resources and no MCP prompts.
+
+The server instructions are part of the contract. They tell agents:
+
+- Project -> Feature -> Story -> AcceptanceCriterion / Scenario -> Plan ->
+  Task -> Subtask is the hierarchy.
+- Feature and Story are product language, not implementation detail.
+- Acceptance criteria are atomic observable rules.
+- Scenarios hold Given / When / Then examples.
+- Plan, Task, and Subtask are delivery language.
+- Story approval gates product contract; current Plan approval gates execution.
+- Implementation details belong in Plans, Tasks, and Subtasks, not Features or
+  Stories.
+
+Tool classes follow the same local shape:
+
+- `#[Description(...)]` explains what the tool does.
+- `protected string $name` defines the MCP tool name.
+- `handle()` resolves the acting user, validates input, performs the operation,
+  and returns `Response::json()` or `Response::error()`.
+- `schema()` describes accepted arguments.
+
+## Authentication
+
+`App\Mcp\Auth::resolve()` resolves the acting user from the MCP request. When
+the request has no authenticated user, it falls back to
+`specify.mcp.user_email`.
+
+Tools should not reach around this helper. Tools that need a user should call
+`resolveUser()` from `ResolvesProjectAccess`, which returns either a `User` or
+a `Response::error('Authentication required.')`.
+
+GitHub repo tools use the acting user's stored GitHub OAuth token. Repo catalog
+lookups go through `GithubRepoCatalog`, which caches the user's accessible
+GitHub repos for five minutes.
+
+## Access control
+
+Most tools are project-scoped. `ResolvesProjectAccess` centralises access
+checks for:
+
+- Project
+- Feature
+- Story
+- Scenario
+- Plan
+
+Tools that start from Task, Subtask, AgentRun, Repo, or WebhookEvent resolve
+the owning Project or attached Projects manually, then verify access through
+`canAccessProject()` or the same `accessibleProjectIds()` set.
+
+Approval and repo-management tools add Owner/Admin role checks:
+
+- approval decisions require `User::canApproveInProject()` for the owning Project
+- repo management currently uses the same `User::canApproveInProject()` check
+- project creation requires Owner or Admin in the selected Team
+
+Current role authority comes from `User::canApproveInProject()`, which allows
+Team `Owner` and `Admin`.
+
+## Project context
+
+Many tools accept an optional `project_id`. When omitted, they default to the
+acting user's `current_project_id`.
+
+Tools that default this way must return a clear error when neither an explicit
+Project nor a current Project is available.
+
+Project context tools:
+
+| Tool | Purpose |
+|---|---|
+| `current-context` | Returns acting user, current Workspace, current Team, and current Project. |
+| `list-projects` | Lists accessible Projects and marks the current Project. |
+| `switch-project` | Validates access and writes `users.current_project_id`. |
+| `create-project` | Creates a Project under a Team, optionally attaches GitHub Repos, and switches current Project to the new Project. |
+
+## Tool groups
+
+Project and Feature tools:
+
+- `get-project`
+- `list-projects`
+- `create-project`
+- `switch-project`
+- `list-features`
+- `get-feature`
+- `create-feature`
+- `update-feature`
+
+Story product-contract tools:
+
+- `list-stories`
+- `get-story`
+- `create-story`
+- `update-story`
+- `add-acceptance-criterion`
+- `list-scenarios`
+- `create-scenario`
+- `update-scenario`
+- `add-story-dependency`
+
+Plan and delivery tools:
+
+- `create-plan`
+- `get-plan`
+- `list-plans`
+- `update-plan`
+- `set-current-plan`
+- `set-tasks`
+- `list-tasks`
+- `get-task`
+- `update-task`
+- `update-subtask`
+
+Approval tools:
+
+- `submit-story`
+- `approve-story`
+- `request-story-changes`
+- `reject-story`
+- `submit-plan`
+- `approve-plan`
+- `request-plan-changes`
+- `reject-plan`
+
+Execution and observation tools:
+
+- `generate-tasks`
+- `start-run`
+- `list-runs`
+- `get-run`
+- `list-activity`
+
+Repo tools:
+
+- `add-github-repo-to-project`
+- `list-repos`
+- `get-repo`
+- `set-primary-repo`
+- `remove-project-repo`
+
+## Product contract writes
+
+Story tools write product contract data only. They should not smuggle
+implementation details into Feature or Story descriptions.
+
+Product contract changes go through Story writer services:
+
+- `StoryWriter`
+- `AcceptanceCriteriaWriter`
+- `ScenarioWriter`
+- `StoryRevisionLifecycle`
+
+Those services own revision bumps and approval reopening. MCP tools should not
+hand-edit Story contract rows in a way that bypasses the lifecycle.
+
+Acceptance criteria and scenarios are separate surfaces:
+
+- acceptance criteria are short rule statements
+- scenarios are Given / When / Then examples
+
+Do not collapse scenarios into acceptance-criterion strings.
+
+## Plan writes
+
+`set-tasks` replaces the Story's current implementation Plan in one
+transaction. It routes through `PlanWriter::replacePlan()`, which writes the
+fresh Plan, Tasks, and Subtasks and owns current-Plan semantics.
+
+Plan replacement behavior:
+
+- Tasks belong to the new Plan.
+- Subtasks belong to Tasks.
+- Tasks may link to acceptance criteria and scenarios from the same Story.
+- Tasks may declare dependencies by Task position.
+- Approved Stories receive a new current Plan that starts pending approval.
+- Non-approved Stories receive a draft Plan.
+
+Task and Subtask update tools reopen Plan approval when structural fields
+change. They do not reopen Story approval unless the product contract changes.
+
+## Approvals
+
+Approval tools use `RecordsApprovalDecisions` plus
+`ResolvesProjectAccess`.
+
+Story approval tools act on the Story product contract. Plan approval tools act
+only on the Story's current Plan.
+
+Plan approval tools must not accept decisions for superseded or non-current
+Plans. The approval service and lifecycle enforce this; MCP tools should keep
+the same constraint in their resolver path.
+
+Approval tool responses return the approval row ID and refreshed target status.
+That is enough for clients to continue the workflow without re-fetching the
+entire Story or Plan.
+
+## Execution tools
+
+`generate-tasks` creates a new current implementation Plan for an approved
+Story when the Story does not already have Tasks in its current Plan. Generated
+Plans reopen Plan approval so humans can review the breakdown before execution.
+
+`start-run` starts or resumes execution for a Story whose product contract and
+current Plan are both approved. It calls `ExecutionService::startStoryExecution()`.
+
+Run lookup tools:
+
+- `list-runs` requires at least one of `story_id`, `task_id`, or `subtask_id`
+- `get-run` resolves Project access from the AgentRun runnable
+- `get-run` omits the full diff unless `include_diff=true`
+
+MCP does not expose direct cancellation or retry tools currently. Those
+surfaces exist in the web run console and `ExecutionService`.
+
+## Repo and activity tools
+
+Repo tools mirror the Project Repos page behavior.
+
+`add-github-repo-to-project`:
+
+- defaults to current Project when `project_id` is omitted
+- requires a connected GitHub OAuth session
+- validates the repo against the user's GitHub catalog
+- creates or reuses a workspace Repo
+- attempts webhook installation
+- attaches the Repo to the Project
+
+`list-activity` reads webhook delivery rows. It requires `repo_id` or
+`project_id`; there is no unscoped activity dump.
+
+## Invariants to preserve
+
+- Do not add MCP-only domain language that differs from the web app and ADRs.
+- Do not let MCP tools bypass Project access checks.
+- Do not let MCP approval tools bypass approver-role checks.
+- Do not write Story product-contract data outside the Story writer and
+  revision lifecycle seams.
+- Do not replace Plans outside `PlanWriter::replacePlan()`.
+- Do not create Tasks directly under Stories.
+- Do not start execution without both an approved Story and approved current
+  Plan.
+- Do not return full run diffs by default from `get-run`.
+- Do not expose workspace-wide activity without a Repo or Project filter.

--- a/docs/architecture/repository-integration.md
+++ b/docs/architecture/repository-integration.md
@@ -1,0 +1,245 @@
+# Repository integration
+
+Specify connects Projects to git repositories, runs AI work in repo-backed
+workspaces, opens pull requests, and uses host webhooks to keep PR state and
+review-response loops inside the app.
+
+This page describes the current implementation shape. Related decisions are
+[ADR-0004](../adr/0004-pr-after-push-is-non-fatal.md),
+[ADR-0008](../adr/0008-pr-review-feedback-via-webhooks.md), and
+[ADR-0010](../adr/0010-cancel-and-retry-for-agent-runs.md). Run execution is
+covered by [AgentRun lifecycle](agent-run-lifecycle.md); Project ownership is
+covered by [Project information architecture](project-information-architecture.md).
+
+## Repo model
+
+`Repo` is workspace-scoped. A Repo can attach to one or more Projects in the
+same Workspace through `project_repo`.
+
+Stored Repo fields include:
+
+- `workspace_id`
+- `name`
+- `provider`
+- `url`
+- `default_branch`
+- encrypted `access_token`
+- encrypted `webhook_secret`
+- `review_response_enabled`
+- `max_review_response_cycles`
+- `metadata`
+
+Provider selection lives on the Repo:
+
+| Surface | Method | Current drivers |
+|---|---|---|
+| Pull request creation | `Repo::pullRequestProvider()` | GitHub, GitLab, Bitbucket |
+| Advisory review posting | `Repo::reviewProvider()` | GitHub |
+| GitHub owner/repo parsing | `Repo::ownerRepo()` | GitHub only |
+
+Unsupported providers return null for provider-specific surfaces. Callers must
+treat that as "skip this integration," not as run failure.
+
+## Project attachment
+
+Projects attach Repos through `Project::attachRepo()`.
+
+Attachment rules:
+
+- Repo must belong to the same Workspace as the Project.
+- First attached Repo becomes primary automatically.
+- Passing `primary=true` makes the new Repo primary and clears the previous
+  primary.
+- `Project::setPrimaryRepo()` only accepts already-attached Repos.
+
+The primary Repo is the default execution Repo for Subtask runs:
+
+```text
+Subtask -> Task -> Plan -> Story -> Feature -> Project -> primaryRepo()
+```
+
+Repo management surfaces:
+
+| Surface | Responsibility |
+|---|---|
+| Project Repos page | Human repo attachment, primary selection, removal. |
+| `add-github-repo-to-project` | Creates or reuses a workspace GitHub Repo, installs webhook when missing and possible, and attaches it to a Project. |
+| `set-primary-repo` | Marks an attached Repo primary. |
+| `remove-project-repo` | Deletes GitHub webhook when applicable, detaches the Repo from Projects, then deletes the Repo row. |
+
+Repo management requires project approver/manage rights.
+
+## GitHub OAuth and webhooks
+
+GitHub Repos are normally created from the acting user's GitHub OAuth token.
+`AddGithubRepoToProjectTool` looks up the repo in `GithubRepoCatalog`, then
+creates or reuses a matching workspace Repo by URL.
+
+When it creates a Repo, it stores the repo URL, default branch, provider, and
+token. When it reuses an existing Repo, it leaves the stored token and default
+branch as-is. The tool attempts webhook installation only when the reused or
+created Repo has no `webhook_secret`.
+
+Webhook installation:
+
+- requires a GitHub provider Repo
+- requires an access token
+- requires a parseable GitHub `owner/repo`
+- requires `admin:repo_hook`
+- generates `webhook_secret` if missing
+- creates or updates a hook pointing at `route('webhooks.github', $repo)`
+- currently asks GitHub to deliver `pull_request` events
+- stores `github_hook_id` and `github_hook_url` in `metadata`
+
+Missing `admin:repo_hook` is not treated as a hard attach failure in the MCP
+flow. The Repo can still be attached and used for execution; webhook-driven
+features simply will not work until the hook is configured.
+
+The controller can handle review events when GitHub sends them, but automatic
+hook installation currently subscribes only to `pull_request`. Review-response
+automation therefore depends on the hook being configured to deliver
+`pull_request_review` and `pull_request_review_comment` events.
+
+Webhook deletion is best-effort. A 404 from GitHub is accepted as already gone;
+other failures are logged but do not block local cleanup.
+
+## Pull request creation
+
+`SubtaskRunPipeline` opens a PR after a successful commit and push when:
+
+- `specify.workspace.push_after_commit` is true
+- `specify.workspace.open_pr_after_push` is true
+- the run has a Repo
+- the Repo has a pull request provider
+
+`PullRequestProvider` implementations expose:
+
+- `createPullRequest()`
+- `findOpenPullRequest()`
+
+PR title and body come from `PrPayloadBuilder`. The body includes Story,
+acceptance criterion, executor summary, changed files, clarifications, appended
+Subtasks, and the human-review footer.
+
+PR creation is non-fatal. If the provider throws, the run still succeeds and
+the error is recorded in `AgentRun.output.pull_request_error`. Successful PR
+creation records `pull_request_url` and `pull_request_number`.
+
+Retrying PR open uses `OpenPullRequestJob`:
+
+- only applies to succeeded runs without `pull_request_url`
+- serialises per run with a cache lock
+- re-checks the run output inside the lock
+- tries to adopt an existing open PR for the branch before creating another
+- preserves the terminal run status and only updates output
+
+GitHub PR lookup intentionally lists open PRs and matches `head.ref`
+client-side because same-repo branch names with slashes are unreliable through
+GitHub's filtered `head=user:branch` query.
+
+## Webhook intake
+
+GitHub webhooks arrive at:
+
+```text
+POST /webhooks/github/{repo}
+```
+
+`GithubWebhookController` validates `X-Hub-Signature-256` before treating a
+delivery as legitimate. Invalid-signature attempts are stored with
+`signature_valid=false` and `delivery_id=null`; this prevents an attacker from
+occupying the unique delivery slot for a valid future delivery.
+
+Signature-valid deliveries are stored in `webhook_events` with:
+
+- Repo
+- provider
+- event
+- action
+- delivery ID
+- payload
+- signature validity
+- matched AgentRun when one is found
+
+`webhook_events.delivery_id` is unique when present. Duplicate valid deliveries
+return a duplicate response instead of re-processing the event.
+
+Current event handling:
+
+| GitHub event | Action handling |
+|---|---|
+| `pull_request` | Matches the originating Execute run by PR number and stamps PR action / merge data into run output. |
+| `pull_request_review` | On submitted reviews with body or non-approval state, dispatches review response when enabled. |
+| `pull_request_review_comment` | On created comments, dispatches review response when enabled. |
+
+Events that do not match an originating Execute run are acknowledged with
+`matched=false`.
+
+## Review responses
+
+Review-response runs are opt-in per Repo:
+
+- `review_response_enabled`
+- `max_review_response_cycles`
+
+When a review event is delivered and actionable, the controller asks
+`ExecutionService::dispatchReviewResponse()` to create a `respond_to_review`
+AgentRun. The controller does not create AgentRuns directly.
+
+Dispatch rules:
+
+- lock the Repo row inside a transaction
+- count existing response cycles for the PR
+- stop when `max_review_response_cycles` is reached
+- create a queued `respond_to_review` run using the originating Execute run's
+  Subtask, Repo, branch, and executor driver
+
+`RespondToPrReviewJob`:
+
+- prepares the same workspace and branch
+- fetches review summary and inline comments
+- runs `ReviewResponder`
+- commits using the agent-provided `commit_message`, falling back to
+  `fix(review): address PR #N review`
+- pushes the commit when a diff exists
+- marks the response run succeeded on no-diff responses after the agent runs,
+  including clarification-only responses
+- does not open a new PR
+
+Review-response runs do not affect Subtask completion. The original Execute
+run already decided delivery state.
+
+## Advisory reviews and probes
+
+Advisory ADR-conformance review uses `ReviewProvider`.
+
+Current shape:
+
+- GitHub is the only advisory review driver.
+- `ReviewPullRequestJob` posts comment-style reviews only.
+- Failures are recorded as `review_error` on the AgentRun output.
+- Advisory review never changes run status, approval state, or mergeability.
+
+Read-only GitHub probes live in `GithubPullRequestProbe`.
+
+Current probe behavior:
+
+- mergeability probing is best-effort and request-memoized
+- mergeability failures return null and log
+- conflict-resolution comments are best-effort issue comments
+- unsupported providers return null/false
+
+## Invariants to preserve
+
+- Do not attach a Repo to a Project in another Workspace.
+- Do not allow more than one primary Repo per Project.
+- Do not fail an AgentRun because PR creation failed.
+- Do not create AgentRuns directly from webhook controllers.
+- Do not process invalid-signature webhook deliveries as idempotent successes.
+- Do not let duplicate GitHub deliveries dispatch duplicate review-response
+  runs.
+- Do not assume the auto-installed webhook receives review events unless its
+  GitHub event list includes them.
+- Do not let review-response runs affect Subtask completion.
+- Do not make advisory reviews blocking.
+- Do not assume every Repo provider supports every integration surface.


### PR DESCRIPTION
## Summary

This carries forward the already-reviewed architecture documentation from the stacked docs PRs that were marked merged into their intermediate stack branches rather than into `main`.

Included docs:
- approval architecture from #96
- repository integration architecture from #97
- MCP surface architecture from #98
- architecture index links for those pages

## Verification

- `git diff --cached --check` before commit

## Notes

#95 did land on `main`; this PR only contains the remaining docs that were still present on the top stack branch but absent from `main`.
