### PR TITLE
Add BYOK execution credentials

### DIFF
--- a/app/Jobs/ExecuteSubtaskJob.php
+++ b/app/Jobs/ExecuteSubtaskJob.php
@@ -60,7 +60,7 @@ class ExecuteSubtaskJob implements ShouldQueue
         $driver = $run->executor_driver ?? $executors->defaultDriver();
 
         try {
-            $executor = $executors->make($driver);
+            $executor = $executors->make($driver, $run);
             $outcome = $pipeline->run($run, $executor);
         } catch (Throwable $e) {
             Log::error('specify.subtask.run.failed', [

--- a/app/Jobs/GenerateTasksJob.php
+++ b/app/Jobs/GenerateTasksJob.php
@@ -6,6 +6,7 @@ use App\Ai\Agents\TasksGenerator;
 use App\Enums\PlanSource;
 use App\Models\AgentRun;
 use App\Models\Story;
+use App\Services\Ai\ByokProviderResolver;
 use App\Services\ExecutionService;
 use App\Services\Plans\PlanInputNormalizer;
 use App\Services\PlanWriter;
@@ -28,7 +29,7 @@ class GenerateTasksJob implements ShouldQueue
     public function __construct(public int $agentRunId) {}
 
     /** Queue handler — see class docblock. */
-    public function handle(ExecutionService $execution, PlanInputNormalizer $planInputs, PlanWriter $planWriter): void
+    public function handle(ExecutionService $execution, PlanInputNormalizer $planInputs, PlanWriter $planWriter, ?ByokProviderResolver $byok = null): void
     {
         $run = AgentRun::findOrFail($this->agentRunId);
         $story = $run->runnable;
@@ -43,7 +44,8 @@ class GenerateTasksJob implements ShouldQueue
 
         try {
             $agent = new TasksGenerator($story);
-            $response = $agent->prompt($agent->buildPrompt());
+            $provider = ($byok ?? app(ByokProviderResolver::class))->forRun($run, TasksGenerator::class);
+            $response = $agent->prompt($agent->buildPrompt(), provider: $provider?->provider, model: $provider?->model);
             $output = $response->toArray();
 
             $tasks = $planInputs->fromGeneratedTasks($story, $output['tasks'] ?? []);

--- a/app/Jobs/GenerateTasksJob.php
+++ b/app/Jobs/GenerateTasksJob.php
@@ -44,8 +44,13 @@ class GenerateTasksJob implements ShouldQueue
 
         try {
             $agent = new TasksGenerator($story);
-            $provider = ($byok ?? app(ByokProviderResolver::class))->forRun($run, TasksGenerator::class);
-            $response = $agent->prompt($agent->buildPrompt(), provider: $provider?->provider, model: $provider?->model);
+            $resolver = $byok ?? app(ByokProviderResolver::class);
+            $provider = $resolver->forRun($run, TasksGenerator::class);
+            try {
+                $response = $agent->prompt($agent->buildPrompt(), provider: $provider?->provider, model: $provider?->model);
+            } finally {
+                $resolver->release($provider);
+            }
             $output = $response->toArray();
 
             $tasks = $planInputs->fromGeneratedTasks($story, $output['tasks'] ?? []);

--- a/app/Jobs/ResolveConflictsJob.php
+++ b/app/Jobs/ResolveConflictsJob.php
@@ -65,7 +65,7 @@ class ResolveConflictsJob implements ShouldQueue
         $driver = $run->executor_driver !== null && $run->executor_driver !== ''
             ? (string) $run->executor_driver
             : $executors->defaultDriver();
-        $executor = $executors->make($driver);
+        $executor = $executors->make($driver, $run);
 
         if (! $executor->needsWorkingDirectory()) {
             $execution->markFailed($run, 'Conflict resolution requires an executor with a working directory (configure a cli or laravel-ai driver in specify.executor).');

--- a/app/Jobs/RespondToPrReviewJob.php
+++ b/app/Jobs/RespondToPrReviewJob.php
@@ -106,8 +106,13 @@ class RespondToPrReviewJob implements ShouldQueue
                     workingDir: $workingDir,
                 );
 
-                $provider = ($byok ?? app(ByokProviderResolver::class))->forRun($run, ReviewResponder::class);
-                $response = $agent->prompt($agent->buildPrompt(), provider: $provider?->provider, model: $provider?->model);
+                $resolver = $byok ?? app(ByokProviderResolver::class);
+                $provider = $resolver->forRun($run, ReviewResponder::class);
+                try {
+                    $response = $agent->prompt($agent->buildPrompt(), provider: $provider?->provider, model: $provider?->model);
+                } finally {
+                    $resolver->release($provider);
+                }
                 $output = $response->toArray();
 
                 $clarifications = (array) ($output['clarifications'] ?? []);

--- a/app/Jobs/RespondToPrReviewJob.php
+++ b/app/Jobs/RespondToPrReviewJob.php
@@ -6,6 +6,7 @@ use App\Ai\Agents\ReviewResponder;
 use App\Enums\AgentRunKind;
 use App\Models\AgentRun;
 use App\Models\Subtask;
+use App\Services\Ai\ByokProviderResolver;
 use App\Services\ExecutionService;
 use App\Services\Reviews\ReviewCommentsFetcher;
 use App\Services\WorkspaceRunner;
@@ -43,6 +44,7 @@ class RespondToPrReviewJob implements ShouldQueue
         ExecutionService $execution,
         WorkspaceRunner $workspace,
         ReviewCommentsFetcher $fetcher,
+        ?ByokProviderResolver $byok = null,
     ): void {
         $run = AgentRun::findOrFail($this->agentRunId);
 
@@ -75,7 +77,7 @@ class RespondToPrReviewJob implements ShouldQueue
         $lockKey = sprintf('specify:review-response:%d:%s', $repo->getKey(), $branch);
 
         try {
-            Cache::lock($lockKey, 1800)->block(300, function () use ($run, $repo, $branch, $prNumber, $subtask, $execution, $workspace, $fetcher, $logCtx) {
+            Cache::lock($lockKey, 1800)->block(300, function () use ($run, $repo, $branch, $prNumber, $subtask, $execution, $workspace, $fetcher, $byok, $logCtx) {
                 $workingDir = $workspace->prepare($repo, $run);
                 $workspace->checkoutBranch($workingDir, $branch, baseBranch: $repo->default_branch);
                 Log::info('specify.review_response.workspace.ready', $logCtx + ['working_dir' => $workingDir]);
@@ -104,7 +106,8 @@ class RespondToPrReviewJob implements ShouldQueue
                     workingDir: $workingDir,
                 );
 
-                $response = $agent->prompt($agent->buildPrompt());
+                $provider = ($byok ?? app(ByokProviderResolver::class))->forRun($run, ReviewResponder::class);
+                $response = $agent->prompt($agent->buildPrompt(), provider: $provider?->provider, model: $provider?->model);
                 $output = $response->toArray();
 
                 $clarifications = (array) ($output['clarifications'] ?? []);

--- a/app/Jobs/ReviewPullRequestJob.php
+++ b/app/Jobs/ReviewPullRequestJob.php
@@ -57,8 +57,13 @@ class ReviewPullRequestJob implements ShouldQueue
 
             $files = array_values(array_filter(array_map('strval', $output['files_changed'] ?? [])));
             $reviewer = new AdrConformanceReviewer($adrs, $this->clamp($diff, 32_768), $files);
-            $aiProvider = ($byok ?? app(ByokProviderResolver::class))->forRun($run, AdrConformanceReviewer::class);
-            $response = $reviewer->prompt($reviewer->buildPrompt(), provider: $aiProvider?->provider, model: $aiProvider?->model)->toArray();
+            $resolver = $byok ?? app(ByokProviderResolver::class);
+            $aiProvider = $resolver->forRun($run, AdrConformanceReviewer::class);
+            try {
+                $response = $reviewer->prompt($reviewer->buildPrompt(), provider: $aiProvider?->provider, model: $aiProvider?->model)->toArray();
+            } finally {
+                $resolver->release($aiProvider);
+            }
 
             $violations = is_array($response['violations'] ?? null) ? $response['violations'] : [];
             $comments = $this->violationsToComments($violations);

--- a/app/Jobs/ReviewPullRequestJob.php
+++ b/app/Jobs/ReviewPullRequestJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Ai\Agents\AdrConformanceReviewer;
 use App\Models\AgentRun;
+use App\Services\Ai\ByokProviderResolver;
 use App\Services\Reviews\ReviewComment;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -27,7 +28,7 @@ class ReviewPullRequestJob implements ShouldQueue
 
     public function __construct(public int $agentRunId) {}
 
-    public function handle(): void
+    public function handle(?ByokProviderResolver $byok = null): void
     {
         $run = AgentRun::find($this->agentRunId);
         if ($run === null) {
@@ -56,7 +57,8 @@ class ReviewPullRequestJob implements ShouldQueue
 
             $files = array_values(array_filter(array_map('strval', $output['files_changed'] ?? [])));
             $reviewer = new AdrConformanceReviewer($adrs, $this->clamp($diff, 32_768), $files);
-            $response = $reviewer->prompt($reviewer->buildPrompt())->toArray();
+            $aiProvider = ($byok ?? app(ByokProviderResolver::class))->forRun($run, AdrConformanceReviewer::class);
+            $response = $reviewer->prompt($reviewer->buildPrompt(), provider: $aiProvider?->provider, model: $aiProvider?->model)->toArray();
 
             $violations = is_array($response['violations'] ?? null) ? $response['violations'] : [];
             $comments = $this->violationsToComments($violations);

--- a/app/Mcp/Tools/GenerateTasksTool.php
+++ b/app/Mcp/Tools/GenerateTasksTool.php
@@ -52,7 +52,7 @@ class GenerateTasksTool extends Tool
             return Response::error('Story already has Tasks in its current Plan. Use set-tasks / update-task to replace or edit the current Plan.');
         }
 
-        $run = $execution->dispatchTaskGeneration($story);
+        $run = $execution->dispatchTaskGeneration($story, userId: $user->getKey());
 
         return Response::json([
             'story_id' => $story->id,

--- a/app/Mcp/Tools/StartRunTool.php
+++ b/app/Mcp/Tools/StartRunTool.php
@@ -41,7 +41,7 @@ class StartRunTool extends Tool
         }
 
         try {
-            $execution->startStoryExecution($story);
+            $execution->startStoryExecution($story, userId: $user->getKey());
         } catch (\RuntimeException $e) {
             return Response::error($e->getMessage());
         }

--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -29,6 +29,7 @@ use RuntimeException;
  */
 #[Fillable([
     'runnable_type', 'runnable_id',
+    'user_id',
     'repo_id', 'working_branch', 'executor_driver', 'kind',
     'authorizing_approval_type', 'authorizing_approval_id',
     'status', 'agent_name', 'model_id',
@@ -75,6 +76,11 @@ class AgentRun extends Model
     public function repo(): BelongsTo
     {
         return $this->belongsTo(Repo::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 
     public function isTerminal(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
@@ -17,7 +18,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 
-#[Fillable(['name', 'email', 'password', 'current_team_id', 'current_project_id', 'github_id', 'avatar_url', 'github_token', 'github_refresh_token', 'github_token_expires_at', 'github_scopes'])]
+#[Fillable(['name', 'email', 'password', 'current_team_id', 'current_project_id', 'github_id', 'avatar_url', 'github_token', 'github_refresh_token', 'github_token_expires_at', 'github_scopes', 'ai_provider'])]
 /**
  * Authenticated user.
  *
@@ -58,6 +59,11 @@ class User extends Authenticatable
     public function currentProject(): BelongsTo
     {
         return $this->belongsTo(Project::class, 'current_project_id');
+    }
+
+    public function aiCredentials(): HasMany
+    {
+        return $this->hasMany(UserAiCredential::class);
     }
 
     public function currentWorkspace(): ?Workspace

--- a/app/Models/UserAiCredential.php
+++ b/app/Models/UserAiCredential.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\UserAiCredentialFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Encrypted per-user AI provider credential for BYOK execution.
+ */
+#[Fillable(['user_id', 'provider', 'api_key', 'model', 'enabled'])]
+#[Hidden(['api_key'])]
+class UserAiCredential extends Model
+{
+    /** @use HasFactory<UserAiCredentialFactory> */
+    use HasFactory;
+
+    public const PROVIDER_ANTHROPIC = 'anthropic';
+
+    public const PROVIDER_OPENAI = 'openai';
+
+    /** @return list<string> */
+    public static function supportedProviders(): array
+    {
+        return [self::PROVIDER_ANTHROPIC, self::PROVIDER_OPENAI];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'api_key' => 'encrypted',
+            'enabled' => 'boolean',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/Ai/ByokProvider.php
+++ b/app/Services/Ai/ByokProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\Ai;
+
+/**
+ * Runtime provider name and optional model resolved from a user's BYOK key.
+ */
+class ByokProvider
+{
+    public function __construct(
+        public string $provider,
+        public ?string $model = null,
+    ) {}
+}

--- a/app/Services/Ai/ByokProviderResolver.php
+++ b/app/Services/Ai/ByokProviderResolver.php
@@ -56,4 +56,17 @@ class ByokProviderResolver
 
         return new ByokProvider($providerName, $model !== '' ? $model : null);
     }
+
+    public function release(?ByokProvider $provider): void
+    {
+        if ($provider === null) {
+            return;
+        }
+
+        Ai::forgetInstance($provider->provider);
+
+        $providers = (array) config('ai.providers', []);
+        unset($providers[$provider->provider]);
+        config(['ai.providers' => $providers]);
+    }
 }

--- a/app/Services/Ai/ByokProviderResolver.php
+++ b/app/Services/Ai/ByokProviderResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services\Ai;
+
+use App\Models\AgentRun;
+use App\Models\UserAiCredential;
+use Laravel\Ai\Ai;
+use RuntimeException;
+
+/**
+ * Resolves and registers per-run Laravel AI provider config from user BYOK keys.
+ */
+class ByokProviderResolver
+{
+    public function forRun(AgentRun $run, string $agentClass): ?ByokProvider
+    {
+        if (is_callable([$agentClass, 'isFaked']) && $agentClass::isFaked()) {
+            return null;
+        }
+
+        $user = $run->user;
+        if ($user === null) {
+            throw new RuntimeException('AI run has no user owner; BYOK credential cannot be resolved.');
+        }
+
+        $providers = UserAiCredential::supportedProviders();
+        $preferred = $user->ai_provider;
+        if (is_string($preferred) && in_array($preferred, $providers, true)) {
+            $providers = array_values(array_unique([$preferred, ...$providers]));
+        }
+
+        $credential = $user->aiCredentials()
+            ->where('enabled', true)
+            ->whereIn('provider', $providers)
+            ->orderByRaw(
+                'case provider '.
+                implode(' ', array_map(fn ($provider, $i) => "when ? then {$i}", $providers, array_keys($providers))).
+                ' end',
+                $providers,
+            )
+            ->first();
+
+        if ($credential === null) {
+            throw new RuntimeException('No enabled Anthropic or OpenAI BYOK credential is configured for this user.');
+        }
+
+        $providerName = 'byok-run-'.$run->getKey().'-'.$credential->provider;
+        $base = (array) config('ai.providers.'.$credential->provider, ['driver' => $credential->provider]);
+        $base['driver'] = $credential->provider;
+        $base['key'] = $credential->api_key;
+
+        config(['ai.providers.'.$providerName => $base]);
+        Ai::forgetInstance($providerName);
+
+        $model = trim((string) $credential->model);
+
+        return new ByokProvider($providerName, $model !== '' ? $model : null);
+    }
+}

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -41,12 +41,12 @@ class ExecutionService
     /**
      * Queue a `GenerateTasksJob` for the given Story and return the AgentRun row.
      */
-    public function dispatchTaskGeneration(Story $story, ?StoryApproval $approval = null): AgentRun
+    public function dispatchTaskGeneration(Story $story, ?StoryApproval $approval = null, ?int $userId = null): AgentRun
     {
         $run = AgentRun::create([
             'runnable_type' => $story->getMorphClass(),
             'runnable_id' => $story->getKey(),
-            'user_id' => Auth::id(),
+            'user_id' => $userId ?? Auth::id(),
             'authorizing_approval_type' => $approval?->getMorphClass(),
             'authorizing_approval_id' => $approval?->getKey(),
             'status' => AgentRunStatus::Queued,
@@ -71,9 +71,9 @@ class ExecutionService
      * (`finalizeSubtaskFromRun`) is the authoritative observer of all
      * siblings, not this return value.
      */
-    public function dispatchSubtaskExecution(Subtask $subtask, ?PlanApproval $approval = null, ?Repo $repo = null): AgentRun
+    public function dispatchSubtaskExecution(Subtask $subtask, ?PlanApproval $approval = null, ?Repo $repo = null, ?int $userId = null): AgentRun
     {
-        return $this->subtasks->dispatch($subtask, $approval, $repo);
+        return $this->subtasks->dispatch($subtask, $approval, $repo, $userId);
     }
 
     /**
@@ -203,9 +203,9 @@ class ExecutionService
      *
      * @throws RuntimeException When the Story is not in Approved status.
      */
-    public function startStoryExecution(Story $story, ?PlanApproval $approval = null): void
+    public function startStoryExecution(Story $story, ?PlanApproval $approval = null, ?int $userId = null): void
     {
-        $this->subtasks->startStory($story, $approval);
+        $this->subtasks->startStory($story, $approval, $userId);
     }
 
     /**

--- a/app/Services/ExecutionService.php
+++ b/app/Services/ExecutionService.php
@@ -17,6 +17,7 @@ use App\Models\Story;
 use App\Models\StoryApproval;
 use App\Models\Subtask;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use RuntimeException;
 
@@ -45,6 +46,7 @@ class ExecutionService
         $run = AgentRun::create([
             'runnable_type' => $story->getMorphClass(),
             'runnable_id' => $story->getKey(),
+            'user_id' => Auth::id(),
             'authorizing_approval_type' => $approval?->getMorphClass(),
             'authorizing_approval_id' => $approval?->getKey(),
             'status' => AgentRunStatus::Queued,
@@ -111,6 +113,7 @@ class ExecutionService
             $run = AgentRun::create([
                 'runnable_type' => $originRun->runnable_type,
                 'runnable_id' => $originRun->runnable_id,
+                'user_id' => $originRun->user_id,
                 'repo_id' => $repo->getKey(),
                 'working_branch' => $originRun->working_branch,
                 'executor_driver' => $originRun->executor_driver,
@@ -174,6 +177,7 @@ class ExecutionService
             $run = AgentRun::create([
                 'runnable_type' => $executeRun->runnable_type,
                 'runnable_id' => $executeRun->runnable_id,
+                'user_id' => $executeRun->user_id,
                 'repo_id' => $repo->getKey(),
                 'working_branch' => $executeRun->working_branch,
                 'executor_driver' => $executeRun->executor_driver,
@@ -426,6 +430,7 @@ class ExecutionService
             $repo,
             $driver ?? $fromRun->executor_driver,
             $fromRun->getKey(),
+            $fromRun->user_id,
         );
     }
 

--- a/app/Services/Executors/ExecutorFactory.php
+++ b/app/Services/Executors/ExecutorFactory.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Executors;
 
+use App\Models\AgentRun;
+use App\Services\Ai\ByokProviderResolver;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 
@@ -23,9 +25,10 @@ class ExecutorFactory
 {
     public function __construct(public Container $container) {}
 
-    public function make(string $name): Executor
+    public function make(string $name, ?AgentRun $run = null): Executor
     {
         $driver = $this->driverConfig($name);
+        $this->assertRunnableInCurrentRuntime($name, $driver);
         $class = (string) ($driver['class'] ?? '');
 
         if ($class === '' || ! is_subclass_of($class, Executor::class)) {
@@ -36,6 +39,10 @@ class ExecutorFactory
             CliExecutor::class => new CliExecutor(
                 command: array_values((array) ($driver['command'] ?? [])),
                 timeout: (int) ($driver['timeout'] ?? 1800),
+            ),
+            LaravelAiExecutor::class => new LaravelAiExecutor(
+                byok: $this->container->make(ByokProviderResolver::class),
+                run: $run,
             ),
             default => $this->container->make($class),
         };
@@ -60,6 +67,7 @@ class ExecutorFactory
                     "Race driver [{$name}] is not registered in specify.executor.drivers."
                 );
             }
+            $this->assertRunnableInCurrentRuntime($name, (array) $drivers[$name]);
         }
 
         return $names;
@@ -81,5 +89,22 @@ class ExecutorFactory
         }
 
         return $drivers[$name];
+    }
+
+    /**
+     * @param  array<string, mixed>  $driver
+     */
+    private function assertRunnableInCurrentRuntime(string $name, array $driver): void
+    {
+        $runtime = (string) config('specify.runtime.environment', 'local');
+        $environment = (string) ($driver['environment'] ?? 'local');
+
+        if ($runtime === 'hosted' && $environment !== 'remote') {
+            throw new InvalidArgumentException("Executor driver [{$name}] is local-only and cannot run in hosted runtime.");
+        }
+
+        if (app()->isProduction() && (($driver['class'] ?? null) === FakeExecutor::class)) {
+            throw new InvalidArgumentException("Executor driver [{$name}] is not available in production.");
+        }
     }
 }

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -72,11 +72,16 @@ class LaravelAiExecutor implements Executor
                 throw new RuntimeException('Laravel AI execution requires an AgentRun owner for BYOK credential resolution.');
             }
 
+            $resolver = $this->byok ?? app(ByokProviderResolver::class);
             $byok = $this->run !== null
-                ? ($this->byok ?? app(ByokProviderResolver::class))->forRun($this->run, SubtaskExecutor::class)
+                ? $resolver->forRun($this->run, SubtaskExecutor::class)
                 : null;
 
-            $response = $agent->prompt($prompt, provider: $byok?->provider, model: $byok?->model);
+            try {
+                $response = $agent->prompt($prompt, provider: $byok?->provider, model: $byok?->model);
+            } finally {
+                $resolver->release($byok);
+            }
         } catch (RequestException $e) {
             $status = $e->response?->status();
             $body = $e->response?->body();

--- a/app/Services/Executors/LaravelAiExecutor.php
+++ b/app/Services/Executors/LaravelAiExecutor.php
@@ -3,8 +3,10 @@
 namespace App\Services\Executors;
 
 use App\Ai\Agents\SubtaskExecutor;
+use App\Models\AgentRun;
 use App\Models\Repo;
 use App\Models\Subtask;
+use App\Services\Ai\ByokProviderResolver;
 use App\Services\Progress\ProgressEmitter;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Log;
@@ -21,6 +23,11 @@ use Throwable;
  */
 class LaravelAiExecutor implements Executor
 {
+    public function __construct(
+        private ?ByokProviderResolver $byok = null,
+        private ?AgentRun $run = null,
+    ) {}
+
     public function needsWorkingDirectory(): bool
     {
         return true;
@@ -61,7 +68,15 @@ class LaravelAiExecutor implements Executor
         }
 
         try {
-            $response = $agent->prompt($prompt);
+            if ($this->run === null && ! SubtaskExecutor::isFaked()) {
+                throw new RuntimeException('Laravel AI execution requires an AgentRun owner for BYOK credential resolution.');
+            }
+
+            $byok = $this->run !== null
+                ? ($this->byok ?? app(ByokProviderResolver::class))->forRun($this->run, SubtaskExecutor::class)
+                : null;
+
+            $response = $agent->prompt($prompt, provider: $byok?->provider, model: $byok?->model);
         } catch (RequestException $e) {
             $status = $e->response?->status();
             $body = $e->response?->body();

--- a/app/Services/SubtaskExecutionScheduler.php
+++ b/app/Services/SubtaskExecutionScheduler.php
@@ -17,6 +17,7 @@ use App\Models\Subtask;
 use App\Models\Task;
 use App\Services\Executors\ExecutorFactory;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use RuntimeException;
 
@@ -36,16 +37,20 @@ class SubtaskExecutionScheduler
      */
     public function dispatch(Subtask $subtask, ?PlanApproval $approval = null, ?Repo $repo = null): AgentRun
     {
-        $repo ??= $subtask->task?->plan?->story?->feature?->project?->primaryRepo();
+        return $this->dispatchForUser($subtask, $approval, $repo, Auth::id());
+    }
 
+    private function dispatchForUser(Subtask $subtask, ?PlanApproval $approval, ?Repo $repo, ?int $userId): AgentRun
+    {
+        $repo ??= $subtask->task?->plan?->story?->feature?->project?->primaryRepo();
         $race = $this->executors->raceDrivers();
         if ($race === []) {
-            return $this->dispatchDriverRun($subtask, $approval, $repo, $this->executors->defaultDriver(), null);
+            return $this->dispatchDriverRun($subtask, $approval, $repo, $this->executors->defaultDriver(), null, userId: $userId);
         }
 
         $first = null;
         foreach ($race as $driver) {
-            $run = $this->dispatchDriverRun($subtask, $approval, $repo, $driver, $driver);
+            $run = $this->dispatchDriverRun($subtask, $approval, $repo, $driver, $driver, userId: $userId);
             $first ??= $run;
         }
 
@@ -61,11 +66,12 @@ class SubtaskExecutionScheduler
         ?Repo $repo,
         ?string $driver,
         int $retryOfId,
+        ?int $userId = null,
     ): AgentRun {
         $resolvedDriver = $driver ?? $this->executors->defaultDriver();
         $branchSuffix = in_array($resolvedDriver, $this->executors->raceDrivers(), true) ? $resolvedDriver : null;
 
-        return $this->dispatchDriverRun($subtask, $approval, $repo, $resolvedDriver, $branchSuffix, $retryOfId);
+        return $this->dispatchDriverRun($subtask, $approval, $repo, $resolvedDriver, $branchSuffix, $retryOfId, $userId);
     }
 
     /**
@@ -98,13 +104,15 @@ class SubtaskExecutionScheduler
             ->latest('created_at')
             ->first();
 
-        DB::transaction(function () use ($story, $approval) {
+        $userId = Auth::id();
+
+        DB::transaction(function () use ($story, $approval, $userId) {
             foreach ($this->nextActionableSubtasks($story) as $subtask) {
                 if ($subtask->agentRuns()->active()->exists()) {
                     continue;
                 }
 
-                $this->dispatch($subtask, $approval);
+                $this->dispatchForUser($subtask, $approval, null, $userId);
             }
         });
     }
@@ -161,7 +169,7 @@ class SubtaskExecutionScheduler
 
             if ($anySucceeded) {
                 $subtask->forceFill(['status' => TaskStatus::Done->value])->save();
-                $this->advanceFromSubtask($subtask->fresh(), $run->authorizingApproval);
+                $this->advanceFromSubtask($subtask->fresh(), $run->authorizingApproval, $run->user_id);
 
                 return;
             }
@@ -177,10 +185,12 @@ class SubtaskExecutionScheduler
         string $driver,
         ?string $branchSuffix,
         ?int $retryOfId = null,
+        ?int $userId = null,
     ): AgentRun {
         $run = AgentRun::create([
             'runnable_type' => $subtask->getMorphClass(),
             'runnable_id' => $subtask->getKey(),
+            'user_id' => $userId,
             'repo_id' => $repo?->getKey(),
             'working_branch' => $this->workingBranchFor($subtask, $branchSuffix),
             'executor_driver' => $driver,
@@ -211,7 +221,7 @@ class SubtaskExecutionScheduler
         return $branch;
     }
 
-    private function advanceFromSubtask(?Subtask $subtask, $authorizingApproval): void
+    private function advanceFromSubtask(?Subtask $subtask, $authorizingApproval, ?int $userId): void
     {
         if (! $subtask) {
             return;
@@ -249,7 +259,7 @@ class SubtaskExecutionScheduler
                 continue;
             }
 
-            $this->dispatch($next, $approval);
+            $this->dispatchForUser($next, $approval, null, $userId);
         }
     }
 }

--- a/app/Services/SubtaskExecutionScheduler.php
+++ b/app/Services/SubtaskExecutionScheduler.php
@@ -35,9 +35,9 @@ class SubtaskExecutionScheduler
      * creates one sibling AgentRun per configured driver and returns the
      * first sibling for the caller's convenience.
      */
-    public function dispatch(Subtask $subtask, ?PlanApproval $approval = null, ?Repo $repo = null): AgentRun
+    public function dispatch(Subtask $subtask, ?PlanApproval $approval = null, ?Repo $repo = null, ?int $userId = null): AgentRun
     {
-        return $this->dispatchForUser($subtask, $approval, $repo, Auth::id());
+        return $this->dispatchForUser($subtask, $approval, $repo, $userId ?? Auth::id());
     }
 
     private function dispatchForUser(Subtask $subtask, ?PlanApproval $approval, ?Repo $repo, ?int $userId): AgentRun
@@ -79,7 +79,7 @@ class SubtaskExecutionScheduler
      *
      * @throws RuntimeException When the Story or current Plan is not ready for execution.
      */
-    public function startStory(Story $story, ?PlanApproval $approval = null): void
+    public function startStory(Story $story, ?PlanApproval $approval = null, ?int $userId = null): void
     {
         if (in_array($story->status, [StoryStatus::Done, StoryStatus::Cancelled, StoryStatus::Rejected], true)) {
             return;
@@ -104,7 +104,7 @@ class SubtaskExecutionScheduler
             ->latest('created_at')
             ->first();
 
-        $userId = Auth::id();
+        $userId ??= Auth::id();
 
         DB::transaction(function () use ($story, $approval, $userId) {
             foreach ($this->nextActionableSubtasks($story) as $subtask) {

--- a/config/specify.php
+++ b/config/specify.php
@@ -40,6 +40,10 @@ return [
         'api_base' => env('SPECIFY_GITHUB_API_BASE', 'https://api.github.com'),
     ],
 
+    'runtime' => [
+        'environment' => env('SPECIFY_RUNTIME_ENV', 'local'),
+    ],
+
     'gitlab' => [
         'api_base' => env('SPECIFY_GITLAB_API_BASE', 'https://gitlab.com/api/v4'),
     ],
@@ -104,24 +108,29 @@ return [
         'drivers' => [
             'laravel-ai' => [
                 'class' => LaravelAiExecutor::class,
+                'environment' => 'remote',
             ],
             'cli' => [
                 'class' => CliExecutor::class,
+                'environment' => 'local',
                 'command' => array_values(array_filter(explode(' ', (string) env('SPECIFY_CLI_COMMAND', 'claude -p')))),
                 'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
             ],
             'cli-claude' => [
                 'class' => CliExecutor::class,
+                'environment' => 'local',
                 'command' => ['claude', '-p'],
                 'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
             ],
             'cli-codex' => [
                 'class' => CliExecutor::class,
+                'environment' => 'local',
                 'command' => ['codex', 'exec'],
                 'timeout' => (int) env('SPECIFY_CLI_TIMEOUT', 1800),
             ],
             'fake' => [
                 'class' => FakeExecutor::class,
+                'environment' => 'local',
             ],
         ],
     ],

--- a/database/factories/UserAiCredentialFactory.php
+++ b/database/factories/UserAiCredentialFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\UserAiCredential;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<UserAiCredential>
+ */
+class UserAiCredentialFactory extends Factory
+{
+    protected $model = UserAiCredential::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'provider' => UserAiCredential::PROVIDER_ANTHROPIC,
+            'api_key' => 'test-key-'.fake()->uuid(),
+            'model' => null,
+            'enabled' => true,
+        ];
+    }
+}

--- a/database/migrations/2026_05_05_030000_create_user_ai_credentials_table.php
+++ b/database/migrations/2026_05_05_030000_create_user_ai_credentials_table.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Models\Story;
+use App\Models\Subtask;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -28,6 +31,28 @@ return new class extends Migration
         Schema::table('agent_runs', function (Blueprint $table) {
             $table->foreignId('user_id')->nullable()->after('id')->constrained()->nullOnDelete();
         });
+
+        DB::table('agent_runs')
+            ->whereNull('user_id')
+            ->where('runnable_type', Story::class)
+            ->update([
+                'user_id' => DB::raw('(select stories.created_by_id from stories where stories.id = agent_runs.runnable_id)'),
+            ]);
+
+        DB::table('agent_runs')
+            ->whereNull('user_id')
+            ->where('runnable_type', Subtask::class)
+            ->update([
+                'user_id' => DB::raw('(
+                    select stories.created_by_id
+                    from subtasks
+                    inner join tasks on tasks.id = subtasks.task_id
+                    inner join plans on plans.id = tasks.plan_id
+                    inner join stories on stories.id = plans.story_id
+                    where subtasks.id = agent_runs.runnable_id
+                    limit 1
+                )'),
+            ]);
     }
 
     public function down(): void

--- a/database/migrations/2026_05_05_030000_create_user_ai_credentials_table.php
+++ b/database/migrations/2026_05_05_030000_create_user_ai_credentials_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('ai_provider')->nullable()->after('github_scopes');
+        });
+
+        Schema::create('user_ai_credentials', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('provider');
+            $table->text('api_key');
+            $table->string('model')->nullable();
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'provider']);
+            $table->index(['user_id', 'enabled']);
+        });
+
+        Schema::table('agent_runs', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->after('id')->constrained()->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_runs', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+
+        Schema::dropIfExists('user_ai_credentials');
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('ai_provider');
+        });
+    }
+};

--- a/docs/adr/0013-byok-and-executor-locality.md
+++ b/docs/adr/0013-byok-and-executor-locality.md
@@ -1,0 +1,46 @@
+# 0013. BYOK and executor locality for hosted deployments
+
+Date: 2026-05-05
+Status: Accepted
+
+## Context
+
+Specify can run AI work for many users. In a live deployment, app-global AI
+provider keys would make the operator pay for user-triggered work and would
+blur audit ownership. Some executors are also inherently local: CLI drivers
+such as Claude Code or Codex inherit credentials and installed binaries from
+the worker host, so running them on the hosted server is not equivalent to
+running them on a user's machine.
+
+## Decision
+
+AI provider credentials are BYOK and user-scoped.
+
+- Users store encrypted Anthropic or OpenAI keys in their own settings.
+- `AgentRun.user_id` records the user who owns and funds the run.
+- Follow-up runs inherit the originating run owner.
+- Laravel AI SDK calls resolve an explicit per-run provider config from the
+  run owner's key.
+- User-triggered AI work does not fall back to app-global AI provider env keys.
+
+Executor locality is configuration and runtime enforced.
+
+- Each executor driver declares `environment: local|remote`.
+- `SPECIFY_RUNTIME_ENV=hosted` allows only `remote` executors.
+- Local CLI drivers remain available in local runtime.
+- Fake executors are not available in production.
+
+## Consequences
+
+Easier:
+
+- Hosted usage is funded by the user who triggered the run.
+- Failed runs can clearly state missing BYOK setup instead of leaking provider
+  errors or silently using operator keys.
+- Executor availability is explicit and enforced in the backend, not only UI.
+
+Harder / accepted trade-offs:
+
+- Every AI-dispatching path must carry run ownership.
+- Team/workspace-shared AI billing is not part of v1.
+- Local CLI executors require a separate remote-worker design before hosted use.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,5 +19,6 @@ except to mark them Superseded.
 | [0010](0010-cancel-and-retry-for-agent-runs.md) | Cancel and retry semantics for AgentRuns | Accepted |
 | [0011](0011-streaming-progress-events-from-executors.md) | Streaming progress events from executors | Proposed |
 | [0012](0012-project-first-information-architecture.md) | Project-first information architecture | Accepted |
+| [0013](0013-byok-and-executor-locality.md) | BYOK and executor locality for hosted deployments | Accepted |
 
 Use [`0000-template.md`](0000-template.md) when adding a new ADR. Number sequentially and update this index.

--- a/docs/architecture/agent-run-lifecycle.md
+++ b/docs/architecture/agent-run-lifecycle.md
@@ -26,6 +26,7 @@ Primary fields:
 - `repo_id` points at the repository used by workspace-backed runs.
 - `working_branch` is the branch the executor writes to.
 - `executor_driver` records the concrete executor used for this run.
+- `user_id` records the user whose BYOK credential funds the run.
 - `kind` records why the run exists.
 - `authorizing_approval_type` and `authorizing_approval_id` optionally point
   at the approval row that allowed the run. They may be null when approval was
@@ -122,6 +123,8 @@ independent Tasks, not inside one ordered Task.
 
 `executor_driver` is stamped on every Execute run. `ExecuteSubtaskJob` resolves
 that driver through `ExecutorFactory` immediately before running the pipeline.
+The factory also enforces executor locality: hosted runtime only runs drivers
+declared as remote-safe in `config/specify.php`.
 
 Single-driver mode creates one Execute run per Subtask using the default
 driver. Race mode creates one sibling Execute run per configured race driver.
@@ -129,6 +132,7 @@ Each sibling:
 
 - has the same Subtask runnable
 - records its own `executor_driver`
+- records the triggering `user_id`
 - uses its own branch suffix
 - opens its own PR
 - terminates independently
@@ -204,6 +208,15 @@ about to touch.
 
 The brief is capped and failure-tolerant. If context generation fails, the run
 continues without a brief.
+
+## BYOK
+
+Laravel AI SDK-backed runs resolve credentials from the AgentRun owner. The
+user stores encrypted Anthropic or OpenAI keys in Settings, and each AI job
+registers an explicit per-run provider config before prompting the agent.
+Missing user ownership or missing enabled credentials fails the run before a
+provider call is made. Hosted user-triggered work does not fall back to
+app-global AI provider keys.
 
 ## Progress events
 

--- a/resources/views/pages/settings/layout.blade.php
+++ b/resources/views/pages/settings/layout.blade.php
@@ -2,6 +2,7 @@
     <div class="me-10 w-full pb-4 md:w-[220px]">
         <flux:navlist aria-label="{{ __('Settings') }}">
             <flux:navlist.item :href="route('profile.edit')" wire:navigate>{{ __('Profile') }}</flux:navlist.item>
+            <flux:navlist.item :href="route('ai.edit')" wire:navigate>{{ __('AI keys') }}</flux:navlist.item>
             <flux:navlist.item :href="route('security.edit')" wire:navigate>{{ __('Security') }}</flux:navlist.item>
             <flux:navlist.item :href="route('appearance.edit')" wire:navigate>{{ __('Appearance') }}</flux:navlist.item>
         </flux:navlist>

--- a/resources/views/pages/settings/⚡ai.blade.php
+++ b/resources/views/pages/settings/⚡ai.blade.php
@@ -1,0 +1,196 @@
+<?php
+
+use App\Models\UserAiCredential;
+use Flux\Flux;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+new #[Title('AI key settings')] class extends Component {
+    public string $default_provider = '';
+
+    public string $anthropic_api_key = '';
+    public string $anthropic_model = '';
+    public bool $anthropic_enabled = false;
+    public bool $anthropic_configured = false;
+
+    public string $openai_api_key = '';
+    public string $openai_model = '';
+    public bool $openai_enabled = false;
+    public bool $openai_configured = false;
+
+    public function mount(): void
+    {
+        $this->loadCredentials();
+    }
+
+    public function saveProvider(string $provider): void
+    {
+        $this->guardProvider($provider);
+
+        $keyField = "{$provider}_api_key";
+        $modelField = "{$provider}_model";
+        $enabledField = "{$provider}_enabled";
+
+        $validated = Validator::make([
+            'api_key' => $this->{$keyField},
+            'model' => $this->{$modelField},
+            'enabled' => $this->{$enabledField},
+        ], [
+            'api_key' => ['nullable', 'string', 'min:8', 'max:4000'],
+            'model' => ['nullable', 'string', 'max:120'],
+            'enabled' => ['boolean'],
+        ])->validate();
+
+        $user = Auth::user();
+        $credential = $user->aiCredentials()->where('provider', $provider)->first();
+        if ($credential === null && trim((string) $validated['api_key']) === '') {
+            $this->addError($keyField, __('Enter an API key to configure this provider.'));
+
+            return;
+        }
+
+        $attributes = [
+            'model' => trim((string) $validated['model']) ?: null,
+            'enabled' => (bool) $validated['enabled'],
+        ];
+        if (trim((string) $validated['api_key']) !== '') {
+            $attributes['api_key'] = trim((string) $validated['api_key']);
+        }
+
+        $user->aiCredentials()->updateOrCreate(['provider' => $provider], $attributes);
+
+        if (! in_array($user->ai_provider, UserAiCredential::supportedProviders(), true)) {
+            $user->forceFill(['ai_provider' => $provider])->save();
+        }
+
+        $this->{$keyField} = '';
+        $this->loadCredentials();
+
+        Flux::toast(variant: 'success', text: __('AI key saved.'));
+    }
+
+    public function removeProvider(string $provider): void
+    {
+        $this->guardProvider($provider);
+
+        $user = Auth::user();
+        $user->aiCredentials()->where('provider', $provider)->delete();
+
+        if ($user->ai_provider === $provider) {
+            $next = $user->aiCredentials()->where('enabled', true)->orderBy('provider')->value('provider');
+            $user->forceFill(['ai_provider' => $next])->save();
+        }
+
+        $this->loadCredentials();
+
+        Flux::toast(variant: 'success', text: __('AI key removed.'));
+    }
+
+    public function setDefaultProvider(): void
+    {
+        $validated = Validator::make([
+            'provider' => $this->default_provider,
+        ], [
+            'provider' => ['required', Rule::in(UserAiCredential::supportedProviders())],
+        ])->validate();
+
+        $user = Auth::user();
+        $exists = $user->aiCredentials()
+            ->where('provider', $validated['provider'])
+            ->where('enabled', true)
+            ->exists();
+
+        if (! $exists) {
+            $this->addError('default_provider', __('Choose an enabled provider.'));
+
+            return;
+        }
+
+        $user->forceFill(['ai_provider' => $validated['provider']])->save();
+        $this->loadCredentials();
+
+        Flux::toast(variant: 'success', text: __('Default AI provider updated.'));
+    }
+
+    private function loadCredentials(): void
+    {
+        $user = Auth::user()->fresh('aiCredentials');
+        $this->default_provider = (string) ($user->ai_provider ?? '');
+
+        foreach (UserAiCredential::supportedProviders() as $provider) {
+            $credential = $user->aiCredentials->firstWhere('provider', $provider);
+            $this->{$provider.'_api_key'} = '';
+            $this->{$provider.'_model'} = (string) ($credential?->model ?? '');
+            $this->{$provider.'_enabled'} = (bool) ($credential?->enabled ?? false);
+            $this->{$provider.'_configured'} = $credential !== null;
+        }
+    }
+
+    private function guardProvider(string $provider): void
+    {
+        abort_unless(in_array($provider, UserAiCredential::supportedProviders(), true), 404);
+    }
+}; ?>
+
+<section class="w-full">
+    @include('partials.settings-heading')
+
+    <flux:heading class="sr-only">{{ __('AI key settings') }}</flux:heading>
+
+    <x-pages::settings.layout :heading="__('AI keys')" :subheading="__('Manage your personal provider keys for agent runs')">
+        <div class="space-y-10">
+            <form wire:submit="setDefaultProvider" class="space-y-4">
+                <flux:select wire:model="default_provider" :label="__('Default provider')">
+                    <flux:select.option value="">{{ __('Choose provider') }}</flux:select.option>
+                    <flux:select.option value="anthropic" :disabled="! $anthropic_enabled">{{ __('Anthropic') }}</flux:select.option>
+                    <flux:select.option value="openai" :disabled="! $openai_enabled">{{ __('OpenAI') }}</flux:select.option>
+                </flux:select>
+
+                <flux:button type="submit" variant="primary">{{ __('Save default') }}</flux:button>
+            </form>
+
+            <flux:separator />
+
+            <form wire:submit="saveProvider('anthropic')" class="space-y-4">
+                <div>
+                    <flux:heading>{{ __('Anthropic') }}</flux:heading>
+                    <flux:text variant="subtle">{{ $anthropic_configured ? __('Key configured') : __('No key configured') }}</flux:text>
+                </div>
+
+                <flux:input wire:model="anthropic_api_key" :label="$anthropic_configured ? __('Replace API key') : __('API key')" type="password" autocomplete="off" viewable />
+                <flux:input wire:model="anthropic_model" :label="__('Model override')" placeholder="claude-sonnet-4-6" />
+                <flux:checkbox wire:model="anthropic_enabled" :label="__('Enabled')" />
+
+                <div class="flex items-center gap-3">
+                    <flux:button type="submit" variant="primary">{{ __('Save Anthropic') }}</flux:button>
+                    @if ($anthropic_configured)
+                        <flux:button type="button" variant="danger" wire:click="removeProvider('anthropic')">{{ __('Remove') }}</flux:button>
+                    @endif
+                </div>
+            </form>
+
+            <flux:separator />
+
+            <form wire:submit="saveProvider('openai')" class="space-y-4">
+                <div>
+                    <flux:heading>{{ __('OpenAI') }}</flux:heading>
+                    <flux:text variant="subtle">{{ $openai_configured ? __('Key configured') : __('No key configured') }}</flux:text>
+                </div>
+
+                <flux:input wire:model="openai_api_key" :label="$openai_configured ? __('Replace API key') : __('API key')" type="password" autocomplete="off" viewable />
+                <flux:input wire:model="openai_model" :label="__('Model override')" placeholder="gpt-5.4" />
+                <flux:checkbox wire:model="openai_enabled" :label="__('Enabled')" />
+
+                <div class="flex items-center gap-3">
+                    <flux:button type="submit" variant="primary">{{ __('Save OpenAI') }}</flux:button>
+                    @if ($openai_configured)
+                        <flux:button type="button" variant="danger" wire:click="removeProvider('openai')">{{ __('Remove') }}</flux:button>
+                    @endif
+                </div>
+            </form>
+        </div>
+    </x-pages::settings.layout>
+</section>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -10,6 +10,7 @@ Route::middleware(['auth'])->group(function () {
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {
+    Route::livewire('settings/ai', 'pages::settings.ai')->name('ai.edit');
     Route::livewire('settings/appearance', 'pages::settings.appearance')->name('appearance.edit');
 
     Route::livewire('settings/security', 'pages::settings.security')

--- a/tests/Architecture/InformationArchitectureTest.php
+++ b/tests/Architecture/InformationArchitectureTest.php
@@ -8,6 +8,7 @@ test('authenticated application page routes use the project-first IA', function 
         'projects',
         'runs/{run}/events',
         'settings',
+        'settings/ai',
         'settings/appearance',
         'settings/profile',
         'settings/security',

--- a/tests/Feature/ByokExecutionTest.php
+++ b/tests/Feature/ByokExecutionTest.php
@@ -2,14 +2,28 @@
 
 use App\Ai\Agents\TasksGenerator;
 use App\Enums\AgentRunStatus;
+use App\Enums\PlanStatus;
+use App\Enums\StoryStatus;
+use App\Enums\TeamRole;
+use App\Mcp\Tools\GenerateTasksTool;
+use App\Mcp\Tools\StartRunTool;
 use App\Models\AgentRun;
+use App\Models\Feature;
+use App\Models\Plan;
+use App\Models\Project;
 use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Models\Team;
 use App\Models\User;
 use App\Models\UserAiCredential;
+use App\Models\Workspace;
 use App\Services\Ai\ByokProviderResolver;
 use App\Services\ExecutionService;
 use App\Services\Executors\ExecutorFactory;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Mcp\Request;
 use Livewire\Livewire;
 
 test('user AI credentials are encrypted and hidden', function () {
@@ -75,6 +89,23 @@ test('BYOK resolver registers a per-run provider config from the run owner', fun
         ->and(config('ai.providers.'.$provider->provider.'.key'))->toBe('sk-openai-user-key');
 });
 
+test('BYOK resolver releases per-run provider config after use', function () {
+    $user = User::factory()->create(['ai_provider' => 'anthropic']);
+    UserAiCredential::factory()->for($user)->create([
+        'provider' => 'anthropic',
+        'api_key' => 'sk-ant-user-key',
+    ]);
+    $run = AgentRun::factory()->for($user)->create();
+    $resolver = app(ByokProviderResolver::class);
+
+    $provider = $resolver->forRun($run, TasksGenerator::class);
+    expect(config('ai.providers.'.$provider->provider))->not->toBeNull();
+
+    $resolver->release($provider);
+
+    expect(config('ai.providers.'.$provider->provider))->toBeNull();
+});
+
 test('task generation fails before provider calls when the run owner has no BYOK key', function () {
     config(['queue.default' => 'sync']);
 
@@ -117,6 +148,42 @@ test('task generation persists the triggering user on the run', function () {
     expect($run->fresh()->user_id)->toBe($user->getKey());
 });
 
+test('MCP task generation persists the resolved MCP user on the run', function () {
+    Queue::fake();
+    [$user, $story] = byokMcpStoryScene(StoryStatus::Approved);
+    config(['specify.mcp.user_email' => $user->email]);
+
+    $response = app(GenerateTasksTool::class)->handle(
+        new Request(['story_id' => $story->getKey()]),
+        app(ExecutionService::class),
+    );
+
+    $run = AgentRun::query()->where('runnable_type', Story::class)->sole();
+
+    expect($response->isError())->toBeFalse()
+        ->and($run->user_id)->toBe($user->getKey());
+});
+
+test('MCP start run persists the resolved MCP user on subtask runs', function () {
+    Queue::fake();
+    [$user, $story] = byokMcpStoryScene(StoryStatus::Approved);
+    $plan = Plan::factory()->for($story)->create(['status' => PlanStatus::Approved]);
+    $story->forceFill(['current_plan_id' => $plan->getKey()])->save();
+    $task = Task::factory()->for($plan)->create(['position' => 1]);
+    Subtask::factory()->for($task)->create(['position' => 1]);
+    config(['specify.mcp.user_email' => $user->email]);
+
+    $response = app(StartRunTool::class)->handle(
+        new Request(['story_id' => $story->getKey()]),
+        app(ExecutionService::class),
+    );
+
+    $run = AgentRun::query()->where('runnable_type', Subtask::class)->sole();
+
+    expect($response->isError())->toBeFalse()
+        ->and($run->user_id)->toBe($user->getKey());
+});
+
 test('hosted runtime blocks local-only executor drivers', function () {
     config(['specify.runtime.environment' => 'hosted']);
 
@@ -133,3 +200,19 @@ test('hosted runtime fails race config containing local-only drivers', function 
     expect(fn () => app(ExecutorFactory::class)->raceDrivers())
         ->toThrow(InvalidArgumentException::class, 'local-only');
 });
+
+function byokMcpStoryScene(StoryStatus $status): array
+{
+    $workspace = Workspace::factory()->create();
+    $team = Team::factory()->for($workspace)->create();
+    $user = User::factory()->create();
+    $team->addMember($user, TeamRole::Admin);
+    $project = Project::factory()->for($team)->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create([
+        'created_by_id' => $user->getKey(),
+        'status' => $status,
+    ]);
+
+    return [$user, $story];
+}

--- a/tests/Feature/ByokExecutionTest.php
+++ b/tests/Feature/ByokExecutionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Ai\Agents\TasksGenerator;
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Models\Story;
+use App\Models\User;
+use App\Models\UserAiCredential;
+use App\Services\Ai\ByokProviderResolver;
+use App\Services\ExecutionService;
+use App\Services\Executors\ExecutorFactory;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+test('user AI credentials are encrypted and hidden', function () {
+    $credential = UserAiCredential::factory()->create([
+        'api_key' => 'sk-ant-test-secret',
+    ]);
+
+    $raw = DB::table('user_ai_credentials')->whereKey($credential->getKey())->value('api_key');
+
+    expect($raw)->not->toBe('sk-ant-test-secret')
+        ->and($credential->fresh()->api_key)->toBe('sk-ant-test-secret')
+        ->and($credential->fresh()->toArray())->not->toHaveKey('api_key');
+});
+
+test('AI settings page saves default provider credentials', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.ai')
+        ->set('anthropic_api_key', 'sk-ant-user-key')
+        ->set('anthropic_model', 'claude-sonnet-4-6')
+        ->set('anthropic_enabled', true)
+        ->call('saveProvider', 'anthropic')
+        ->assertHasNoErrors();
+
+    $credential = $user->aiCredentials()->where('provider', 'anthropic')->sole();
+
+    expect($credential->api_key)->toBe('sk-ant-user-key')
+        ->and($credential->model)->toBe('claude-sonnet-4-6')
+        ->and($credential->enabled)->toBeTrue()
+        ->and($user->fresh()->ai_provider)->toBe('anthropic');
+});
+
+test('AI settings page removes a provider key', function () {
+    $user = User::factory()->create(['ai_provider' => 'anthropic']);
+    UserAiCredential::factory()->for($user)->create(['provider' => 'anthropic']);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::settings.ai')
+        ->call('removeProvider', 'anthropic')
+        ->assertHasNoErrors();
+
+    expect($user->aiCredentials()->count())->toBe(0)
+        ->and($user->fresh()->ai_provider)->toBeNull();
+});
+
+test('BYOK resolver registers a per-run provider config from the run owner', function () {
+    $user = User::factory()->create(['ai_provider' => 'openai']);
+    UserAiCredential::factory()->for($user)->create([
+        'provider' => 'openai',
+        'api_key' => 'sk-openai-user-key',
+        'model' => 'gpt-5.4',
+    ]);
+    $run = AgentRun::factory()->for($user)->create();
+
+    $provider = app(ByokProviderResolver::class)->forRun($run, TasksGenerator::class);
+
+    expect($provider->provider)->toBe('byok-run-'.$run->getKey().'-openai')
+        ->and($provider->model)->toBe('gpt-5.4')
+        ->and(config('ai.providers.'.$provider->provider.'.driver'))->toBe('openai')
+        ->and(config('ai.providers.'.$provider->provider.'.key'))->toBe('sk-openai-user-key');
+});
+
+test('task generation fails before provider calls when the run owner has no BYOK key', function () {
+    config(['queue.default' => 'sync']);
+
+    $user = User::factory()->create();
+    $story = Story::factory()->create();
+
+    $this->actingAs($user);
+
+    expect(fn () => app(ExecutionService::class)->dispatchTaskGeneration($story))
+        ->toThrow(RuntimeException::class, 'No enabled Anthropic or OpenAI BYOK credential');
+
+    $run = AgentRun::query()->where('runnable_id', $story->getKey())->sole();
+    expect($run->user_id)->toBe($user->getKey())
+        ->and($run->status)->toBe(AgentRunStatus::Failed);
+});
+
+test('task generation persists the triggering user on the run', function () {
+    config(['queue.default' => 'sync']);
+
+    $user = User::factory()->create();
+    $story = Story::factory()->create();
+    TasksGenerator::fake(fn () => [
+        'summary' => 'one task plan',
+        'tasks' => [[
+            'name' => 'Task',
+            'description' => 'Task description',
+            'position' => 1,
+            'subtasks' => [[
+                'name' => 'Subtask',
+                'description' => 'Subtask description',
+                'position' => 1,
+            ]],
+        ]],
+    ]);
+
+    $this->actingAs($user);
+
+    $run = app(ExecutionService::class)->dispatchTaskGeneration($story);
+
+    expect($run->fresh()->user_id)->toBe($user->getKey());
+});
+
+test('hosted runtime blocks local-only executor drivers', function () {
+    config(['specify.runtime.environment' => 'hosted']);
+
+    expect(fn () => app(ExecutorFactory::class)->make('cli'))
+        ->toThrow(InvalidArgumentException::class, 'local-only');
+});
+
+test('hosted runtime fails race config containing local-only drivers', function () {
+    config([
+        'specify.runtime.environment' => 'hosted',
+        'specify.executor.race' => ['laravel-ai', 'cli-codex'],
+    ]);
+
+    expect(fn () => app(ExecutorFactory::class)->raceDrivers())
+        ->toThrow(InvalidArgumentException::class, 'local-only');
+});


### PR DESCRIPTION
## Summary

Implements per-user BYOK for hosted AI execution and blocks local-only executors in hosted runtime.

Changes:
- add encrypted per-user Anthropic/OpenAI credentials and AI key settings UI
- persist `agent_runs.user_id` as the run owner/funding identity
- resolve Laravel AI SDK calls through explicit per-run BYOK provider config
- carry run ownership into retries, review responses, conflict resolution, advisory reviews, and cascaded subtask runs
- add executor `environment: local|remote` config and hosted-runtime enforcement
- document the deployment decision in ADR-0013 and the AgentRun lifecycle docs

## Verification

- `php artisan test --compact --filter=ByokExecution`
- `php artisan test --compact tests/Feature/MultiExecutorRaceTest.php tests/Feature/TaskGenerationTest.php tests/Feature/CliExecutorTest.php tests/Feature/AdrConformanceReviewTest.php tests/Feature/AgentRunRetryTest.php tests/Feature/ConflictResolutionTest.php`
- `composer test`

## Notes

Hosted runtime is controlled with `SPECIFY_RUNTIME_ENV=hosted`. In hosted mode, CLI drivers remain registered but cannot be instantiated or used in race mode unless explicitly configured as `environment: remote`.
