### PR TITLE
Document hosted BYOK deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,10 +64,31 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
 
-# Laravel AI (Specify) — Anthropic for in-app agents. Uses SPECIFY_* so ANTHROPIC_API_KEY can stay for CLI tools.
-SPECIFY_ANTHROPIC_API_KEY=
-# SPECIFY_ANTHROPIC_URL=https://api.anthropic.com/v1
-# SPECIFY_CONFLICT_RESOLUTION_MAX_CYCLES=3
+# Specify runtime. Hosted deployments only run remote executors; local CLI
+# executors stay on developer machines where their binaries and credentials live.
+SPECIFY_RUNTIME_ENV=local
+SPECIFY_EXECUTOR_DRIVER=laravel-ai
+SPECIFY_EXECUTOR_RACE=
+# SPECIFY_CLI_COMMAND="claude -p"
+# SPECIFY_CLI_TIMEOUT=1800
+
+# Specify git / PR behavior.
+SPECIFY_GIT_NAME="Specify Bot"
+SPECIFY_GIT_EMAIL=bot@specify.local
+SPECIFY_PUSH_AFTER_COMMIT=true
+SPECIFY_OPEN_PR_AFTER_PUSH=true
+# SPECIFY_RUNS_PATH=
+
+# Optional execution helpers.
+SPECIFY_CONTEXT_BUILDER=recency
+SPECIFY_CONTEXT_WINDOW=30.days
+SPECIFY_CONTEXT_MAX_FILES=10
+SPECIFY_REVIEW_ENABLED=false
+SPECIFY_REVIEW_PERSONAS=adr-conformance
+SPECIFY_CONFLICT_RESOLUTION_MAX_CYCLES=3
+
+# Local MCP stdio servers need an acting user because there is no web session.
+MCP_USER_EMAIL=
 
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Requires PHP `^8.4`, Node, and SQLite by default. `composer setup` creates `data
 
 ## Domain at a glance
 
-`Workspace -> Project -> Feature -> Story -> AcceptanceCriterion / Scenario -> Plan -> Task -> Subtask`.
+`Workspace -> Team -> Project -> Feature -> Story -> AcceptanceCriterion / Scenario -> Plan -> Task -> Subtask`.
 
-- **Workspace** — tenant boundary, owned by a User. `Team` is workspace-scoped (M:N via `team_user`).
+- **Workspace** — tenant boundary, owned by a User. `Team` is workspace-scoped (M:N via `team_user`); Projects belong to Teams.
 - **Story** — product-owner unit of value; carries kind, actor, intent, outcome, `revision` (auto-bumps on product edits), `description`, `notes`, acceptance criteria, and scenarios.
 - **Plan** — implementation interpretation of a Story. `stories.current_plan_id` points at the active Plan; previous Plans remain history.
 - **Task** — delivery work item under a Plan. A Task may reference an acceptance criterion or scenario, but it is not defined as one acceptance criterion. Subtasks are the executor's step list.
@@ -42,11 +42,25 @@ Product edits reopen Story approval and current Plan approval. Plan/Task/Subtask
 
 `Executor` interface — `needsWorkingDirectory()`, `execute(Subtask, ?workingDir, ?Repo, ?workingBranch): ExecutionResult`.
 
-- `LaravelAiExecutor` — describe-only, wraps the `TaskExecutor` agent (no fs mutation).
-- `CliExecutor` — generic; runs any one-shot agent CLI (claude, codex, gemini, aider) in cwd, observes via `git status`.
+- `LaravelAiExecutor` — remote-capable; wraps the `SubtaskExecutor` agent, uses repo-editing tools, and resolves the run owner's BYOK credential.
+- `CliExecutor` — local-only; runs any one-shot agent CLI (claude, codex, gemini, aider) in cwd, observes via `git status`.
 - `FakeExecutor` — test double.
 
-Bound by `specify.executor.driver`. See `config/specify.php` for all knobs (`runs_path`, `git.{name,email}`, `workspace.{push_after_commit, open_pr_after_push}`, `github.api_base`, `executor.{driver, cli.{command, timeout}}`).
+Bound by `specify.executor.default`. In hosted runtime (`SPECIFY_RUNTIME_ENV=hosted`), only remote executors are allowed. User-triggered Laravel AI calls are BYOK: users configure their own Anthropic/OpenAI key at `/settings/ai`; the app does not need an operator-paid provider key for execution.
+
+See `config/specify.php` for all knobs (`runs_path`, `git.{name,email}`, `workspace.{push_after_commit, open_pr_after_push}`, `github.api_base`, `runtime.environment`, `executor.{default,race,drivers}`).
+
+## Hosted deployment
+
+For a live server, start from `.env.example`, set `APP_ENV=production`, use a durable queue connection, and set:
+
+```dotenv
+SPECIFY_RUNTIME_ENV=hosted
+SPECIFY_EXECUTOR_DRIVER=laravel-ai
+SPECIFY_EXECUTOR_RACE=
+```
+
+Do not configure local CLI executors on the hosted app unless that deployment is explicitly a remote worker with its own isolated credentials and binaries. See `docs/operations/hosted-deployment.md` for the operational checklist.
 
 ## Repos
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Product edits reopen Story approval and current Plan approval. Plan/Task/Subtask
 
 ## Pluggable executors
 
-`Executor` interface — `needsWorkingDirectory()`, `execute(Subtask, ?workingDir, ?Repo, ?workingBranch): ExecutionResult`.
+`Executor` interface — `needsWorkingDirectory()`, `execute(Subtask, ?workingDir, ?Repo, ?workingBranch, ?contextBrief = null, ?emitter = null, ?promptOverride = null): ExecutionResult`.
 
 - `LaravelAiExecutor` — remote-capable; wraps the `SubtaskExecutor` agent, uses repo-editing tools, and resolves the run owner's BYOK credential.
 - `CliExecutor` — local-only; runs any one-shot agent CLI (claude, codex, gemini, aider) in cwd, observes via `git status`.

--- a/config/ai.php
+++ b/config/ai.php
@@ -48,8 +48,9 @@ return [
     | to perform tasks like text, image, and audio creation via agents.
     |
     | Specify resolves user-triggered agent calls through per-run BYOK provider
-    | config. These base provider entries supply defaults such as endpoint URLs;
-    | run ownership supplies the API key.
+    | config. BYOK overrides `key` on a temporary per-run provider. These base
+    | provider entries may still read env keys for non-BYOK usage, and supply
+    | shared defaults such as endpoint URLs.
     |
     */
 

--- a/config/ai.php
+++ b/config/ai.php
@@ -47,8 +47,9 @@ return [
     | represents an AI provider and API key combination which can be used
     | to perform tasks like text, image, and audio creation via agents.
     |
-    | Specify uses SPECIFY_* env names for Anthropic so CLI tools (e.g. Claude
-    | Code) can keep using ANTHROPIC_API_KEY without colliding with this app.
+    | Specify resolves user-triggered agent calls through per-run BYOK provider
+    | config. These base provider entries supply defaults such as endpoint URLs;
+    | run ownership supplies the API key.
     |
     */
 

--- a/config/specify.php
+++ b/config/specify.php
@@ -58,10 +58,10 @@ return [
     |--------------------------------------------------------------------------
     |
     | Drives subtask execution. "laravel-ai" uses the laravel/ai SubtaskExecutor
-    | agent and is describe-only (no filesystem mutation). "cli" spawns an
+    | agent with repo-editing tools and user BYOK credentials. "cli" spawns an
     | external agent CLI in the working directory and observes filesystem
     | changes via git afterward. Any CLI that supports one-shot prompting
-    | works (claude, codex, gemini, aider, …) — supply binary + args.
+    | works (claude, codex, gemini, aider, ...) — supply binary + args.
     |
     */
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,7 @@
+# Operations
+
+Operational notes for running Specify outside local development.
+
+| Page | Purpose |
+|---|---|
+| [Hosted deployment](hosted-deployment.md) | BYOK, executor locality, queues, git/PR settings, and MCP user setup for a live server. |

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -1,0 +1,77 @@
+# Hosted deployment
+
+Specify can be deployed as a normal Laravel app, but AI execution has two
+operator-facing constraints:
+
+- users fund AI calls with their own BYOK credentials
+- local CLI executors must not run on the hosted server by accident
+
+## Runtime mode
+
+Set hosted runtime explicitly:
+
+```dotenv
+APP_ENV=production
+APP_DEBUG=false
+QUEUE_CONNECTION=database
+SPECIFY_RUNTIME_ENV=hosted
+SPECIFY_EXECUTOR_DRIVER=laravel-ai
+SPECIFY_EXECUTOR_RACE=
+```
+
+`SPECIFY_RUNTIME_ENV=hosted` makes `ExecutorFactory` reject local-only drivers
+such as `cli`, `cli-claude`, `cli-codex`, and `fake`. Hosted execution should
+use `laravel-ai` unless a separate remote-worker driver has been designed and
+registered as `environment: remote`.
+
+## BYOK
+
+Users configure Anthropic or OpenAI credentials in `/settings/ai`. The key is
+encrypted in `user_ai_credentials`, and each `AgentRun` stores the `user_id`
+that owns and funds the run.
+
+Do not set an app-wide AI provider key for user-triggered execution. BYOK
+resolution builds a per-run Laravel AI provider config from the run owner's
+enabled credential and removes that temporary provider after the call.
+
+## Queue workers
+
+Run a real queue worker in production. The default `.env.example` uses the
+database queue because it is portable:
+
+```bash
+php artisan queue:work --tries=1 --timeout=3600
+```
+
+Long-running workers should be restarted during deploys so config, prompts,
+and code changes are picked up:
+
+```bash
+php artisan queue:restart
+```
+
+## Git and pull requests
+
+Configure the bot identity and PR behavior:
+
+```dotenv
+SPECIFY_GIT_NAME="Specify Bot"
+SPECIFY_GIT_EMAIL=bot@example.com
+SPECIFY_PUSH_AFTER_COMMIT=true
+SPECIFY_OPEN_PR_AFTER_PUSH=true
+```
+
+Attach repos through the app so repository access tokens and webhook secrets
+are encrypted per `Repo`. PR creation is intentionally non-fatal; failures are
+recorded on the `AgentRun` as `pull_request_error`.
+
+## MCP stdio servers
+
+Local MCP stdio servers do not have a browser session. Set `MCP_USER_EMAIL` to
+an existing user when running `mcp:start` locally:
+
+```dotenv
+MCP_USER_EMAIL=operator@example.com
+```
+
+Web-authenticated app routes continue to use the Laravel session user.

--- a/tests/Architecture/HostedDeploymentDocumentationTest.php
+++ b/tests/Architecture/HostedDeploymentDocumentationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 test('hosted deployment environment example teaches BYOK and locality knobs', function () {
-    $env = file_get_contents(base_path('.env.example'));
+    $env = readProjectFile('.env.example');
 
     expect($env)->toContain('SPECIFY_RUNTIME_ENV=local')
         ->and($env)->toContain('SPECIFY_EXECUTOR_DRIVER=laravel-ai')
@@ -11,12 +11,25 @@ test('hosted deployment environment example teaches BYOK and locality knobs', fu
 });
 
 test('hosted deployment docs do not describe app-paid AI execution', function () {
-    $readme = file_get_contents(base_path('README.md'));
-    $deployment = file_get_contents(base_path('docs/operations/hosted-deployment.md'));
-    $aiConfig = file_get_contents(base_path('config/ai.php'));
+    $readme = readProjectFile('README.md');
+    $deployment = readProjectFile('docs/operations/hosted-deployment.md');
+    $aiConfig = readProjectFile('config/ai.php');
 
     expect($readme)->toContain('users configure their own Anthropic/OpenAI key')
         ->and($deployment)->toContain('Do not set an app-wide AI provider key')
         ->and($aiConfig)->toContain('user-triggered agent calls through per-run BYOK provider')
         ->and($readme)->not->toContain('describe-only');
 });
+
+function readProjectFile(string $path): string
+{
+    $absolutePath = base_path($path);
+
+    expect(is_readable($absolutePath), "{$path} should be readable")->toBeTrue();
+
+    $contents = file_get_contents($absolutePath);
+
+    expect($contents, "{$path} should be readable")->not->toBeFalse();
+
+    return $contents;
+}

--- a/tests/Architecture/HostedDeploymentDocumentationTest.php
+++ b/tests/Architecture/HostedDeploymentDocumentationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+test('hosted deployment environment example teaches BYOK and locality knobs', function () {
+    $env = file_get_contents(base_path('.env.example'));
+
+    expect($env)->toContain('SPECIFY_RUNTIME_ENV=local')
+        ->and($env)->toContain('SPECIFY_EXECUTOR_DRIVER=laravel-ai')
+        ->and($env)->toContain('SPECIFY_EXECUTOR_RACE=')
+        ->and($env)->toContain('MCP_USER_EMAIL=')
+        ->and($env)->not->toContain('SPECIFY_ANTHROPIC_API_KEY=');
+});
+
+test('hosted deployment docs do not describe app-paid AI execution', function () {
+    $readme = file_get_contents(base_path('README.md'));
+    $deployment = file_get_contents(base_path('docs/operations/hosted-deployment.md'));
+    $aiConfig = file_get_contents(base_path('config/ai.php'));
+
+    expect($readme)->toContain('users configure their own Anthropic/OpenAI key')
+        ->and($deployment)->toContain('Do not set an app-wide AI provider key')
+        ->and($aiConfig)->toContain('user-triggered agent calls through per-run BYOK provider')
+        ->and($readme)->not->toContain('describe-only');
+});


### PR DESCRIPTION
## Summary
- replace app-paid AI key guidance in .env.example with hosted runtime, executor, queue-adjacent, review, and MCP settings
- update README/config comments so Laravel AI execution is described as BYOK and remote-capable, not describe-only
- add hosted deployment operations docs and architecture tests that lock in the BYOK/locality guidance

## Tests
- vendor/bin/pint --dirty --test --format=compact
- php artisan test --compact tests/Architecture/HostedDeploymentDocumentationTest.php
- composer test