### PR TITLE
Allow explicitly remote executor drivers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,9 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
 
-# Specify runtime. Hosted deployments only run remote executors; local CLI
-# executors stay on developer machines where their binaries and credentials live.
+# Specify runtime. Hosted deployments run remote executors by default. Local
+# CLI executors stay on developer machines unless explicitly allowlisted for a
+# remote-safe worker deployment with SPECIFY_REMOTE_EXECUTORS.
 SPECIFY_RUNTIME_ENV=local
 SPECIFY_REMOTE_EXECUTORS=
 SPECIFY_EXECUTOR_DRIVER=laravel-ai

--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,7 @@ VITE_APP_NAME="${APP_NAME}"
 # Specify runtime. Hosted deployments only run remote executors; local CLI
 # executors stay on developer machines where their binaries and credentials live.
 SPECIFY_RUNTIME_ENV=local
+SPECIFY_REMOTE_EXECUTORS=
 SPECIFY_EXECUTOR_DRIVER=laravel-ai
 SPECIFY_EXECUTOR_RACE=
 # SPECIFY_CLI_COMMAND="claude -p"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Product edits reopen Story approval and current Plan approval. Plan/Task/Subtask
 - `CliExecutor` — local-only; runs any one-shot agent CLI (claude, codex, gemini, aider) in cwd, observes via `git status`.
 - `FakeExecutor` — test double.
 
-Bound by `specify.executor.default`. In hosted runtime (`SPECIFY_RUNTIME_ENV=hosted`), only remote executors are allowed. User-triggered Laravel AI calls are BYOK: users configure their own Anthropic/OpenAI key at `/settings/ai`; the app does not need an operator-paid provider key for execution.
+Bound by `specify.executor.default`. In hosted runtime (`SPECIFY_RUNTIME_ENV=hosted`), only remote executors are allowed unless a local driver is explicitly named in `SPECIFY_REMOTE_EXECUTORS` for a deployment with a remote-safe worker. User-triggered Laravel AI calls are BYOK: users configure their own Anthropic/OpenAI key at `/settings/ai`; the app does not need an operator-paid provider key for execution.
 
 See `config/specify.php` for all knobs (`runs_path`, `git.{name,email}`, `workspace.{push_after_commit, open_pr_after_push}`, `github.api_base`, `runtime.environment`, `executor.{default,race,drivers}`).
 
@@ -56,11 +56,12 @@ For a live server, start from `.env.example`, set `APP_ENV=production`, use a du
 
 ```dotenv
 SPECIFY_RUNTIME_ENV=hosted
+SPECIFY_REMOTE_EXECUTORS=
 SPECIFY_EXECUTOR_DRIVER=laravel-ai
 SPECIFY_EXECUTOR_RACE=
 ```
 
-Do not configure local CLI executors on the hosted app unless that deployment is explicitly a remote worker with its own isolated credentials and binaries. See `docs/operations/hosted-deployment.md` for the operational checklist.
+Do not configure local CLI executors on the hosted app unless that deployment is explicitly a remote worker with its own isolated credentials and binaries, and the driver is named in `SPECIFY_REMOTE_EXECUTORS`. See `docs/operations/hosted-deployment.md` for the operational checklist.
 
 ## Repos
 

--- a/app/Services/Executors/ExecutorFactory.php
+++ b/app/Services/Executors/ExecutorFactory.php
@@ -99,12 +99,19 @@ class ExecutorFactory
         $runtime = (string) config('specify.runtime.environment', 'local');
         $environment = (string) ($driver['environment'] ?? 'local');
 
-        if ($runtime === 'hosted' && $environment !== 'remote') {
+        if ($runtime === 'hosted' && $environment !== 'remote' && ! $this->isExplicitlyRemoteEnabled($name)) {
             throw new InvalidArgumentException("Executor driver [{$name}] is local-only and cannot run in hosted runtime.");
         }
 
         if (app()->isProduction() && (($driver['class'] ?? null) === FakeExecutor::class)) {
             throw new InvalidArgumentException("Executor driver [{$name}] is not available in production.");
         }
+    }
+
+    private function isExplicitlyRemoteEnabled(string $name): bool
+    {
+        $names = (array) config('specify.runtime.remote_executors', []);
+
+        return in_array($name, array_map('strval', $names), true);
     }
 }

--- a/app/Services/Executors/ExecutorFactory.php
+++ b/app/Services/Executors/ExecutorFactory.php
@@ -100,7 +100,7 @@ class ExecutorFactory
         $environment = (string) ($driver['environment'] ?? 'local');
 
         if ($runtime === 'hosted' && $environment !== 'remote' && ! $this->isExplicitlyRemoteEnabled($name)) {
-            throw new InvalidArgumentException("Executor driver [{$name}] is local-only and cannot run in hosted runtime.");
+            throw new InvalidArgumentException("Executor driver [{$name}] is local-only and cannot run in hosted runtime unless it is explicitly listed in SPECIFY_REMOTE_EXECUTORS for a remote-safe worker deployment.");
         }
 
         if (app()->isProduction() && (($driver['class'] ?? null) === FakeExecutor::class)) {

--- a/config/specify.php
+++ b/config/specify.php
@@ -42,6 +42,10 @@ return [
 
     'runtime' => [
         'environment' => env('SPECIFY_RUNTIME_ENV', 'local'),
+        'remote_executors' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('SPECIFY_REMOTE_EXECUTORS', ''))
+        ))),
     ],
 
     'gitlab' => [
@@ -92,8 +96,12 @@ return [
     | driver in the list, each on its own branch, each opening its own PR.
     | The reviewer picks one to merge; the choice is the data.
     |
-    | Race driver names must exist in `drivers`. Single-driver mode
-    | (race=[]) is the default and matches pre-race behaviour.
+    | Race driver names must exist in `drivers`. In hosted runtime, local
+    | drivers are rejected unless their driver name appears in
+    | `runtime.remote_executors`, which is the operator's explicit statement
+    | that this deployment has a remote-safe worker for that driver.
+    | Single-driver mode (race=[]) is the default and matches pre-race
+    | behaviour.
     |
     */
 

--- a/docs/architecture/agent-run-lifecycle.md
+++ b/docs/architecture/agent-run-lifecycle.md
@@ -123,8 +123,10 @@ independent Tasks, not inside one ordered Task.
 
 `executor_driver` is stamped on every Execute run. `ExecuteSubtaskJob` resolves
 that driver through `ExecutorFactory` immediately before running the pipeline.
-The factory also enforces executor locality: hosted runtime only runs drivers
-declared as remote-safe in `config/specify.php`.
+The factory also enforces executor locality: hosted runtime runs drivers
+declared as remote-safe in `config/specify.php`, plus any local driver names
+explicitly listed in `specify.runtime.remote_executors` for deployments where
+the operator has provided a remote-safe worker.
 
 Single-driver mode creates one Execute run per Subtask using the default
 driver. Race mode creates one sibling Execute run per configured race driver.

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -15,14 +15,26 @@ APP_ENV=production
 APP_DEBUG=false
 QUEUE_CONNECTION=database
 SPECIFY_RUNTIME_ENV=hosted
+SPECIFY_REMOTE_EXECUTORS=
 SPECIFY_EXECUTOR_DRIVER=laravel-ai
 SPECIFY_EXECUTOR_RACE=
 ```
 
 `SPECIFY_RUNTIME_ENV=hosted` makes `ExecutorFactory` reject local-only drivers
 such as `cli`, `cli-claude`, `cli-codex`, and `fake`. Hosted execution should
-use `laravel-ai` unless a separate remote-worker driver has been designed and
-registered as `environment: remote`.
+use `laravel-ai` unless a separate remote-worker deployment has been designed.
+
+If a hosted deployment intentionally runs a CLI driver on an isolated remote
+worker with its own credentials and binaries, name that driver explicitly:
+
+```dotenv
+SPECIFY_REMOTE_EXECUTORS=cli-codex
+SPECIFY_EXECUTOR_DRIVER=cli-codex
+```
+
+Multiple explicitly remote drivers can be comma-separated. This is an
+operator assertion that the named driver is safe in this deployment; it does
+not install binaries, provision credentials, or sandbox the worker.
 
 ## BYOK
 

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -20,9 +20,11 @@ SPECIFY_EXECUTOR_DRIVER=laravel-ai
 SPECIFY_EXECUTOR_RACE=
 ```
 
-`SPECIFY_RUNTIME_ENV=hosted` makes `ExecutorFactory` reject local-only drivers
-such as `cli`, `cli-claude`, `cli-codex`, and `fake`. Hosted execution should
-use `laravel-ai` unless a separate remote-worker deployment has been designed.
+By default, `SPECIFY_RUNTIME_ENV=hosted` makes `ExecutorFactory` reject
+local-only drivers such as `cli`, `cli-claude`, `cli-codex`, and `fake`.
+Hosted execution should use `laravel-ai` unless a separate remote-worker
+deployment has been designed and the driver is explicitly listed in
+`SPECIFY_REMOTE_EXECUTORS`.
 
 If a hosted deployment intentionally runs a CLI driver on an isolated remote
 worker with its own credentials and binaries, name that driver explicitly:

--- a/tests/Architecture/HostedDeploymentDocumentationTest.php
+++ b/tests/Architecture/HostedDeploymentDocumentationTest.php
@@ -4,6 +4,7 @@ test('hosted deployment environment example teaches BYOK and locality knobs', fu
     $env = readProjectFile('.env.example');
 
     expect($env)->toContain('SPECIFY_RUNTIME_ENV=local')
+        ->and($env)->toContain('SPECIFY_REMOTE_EXECUTORS=')
         ->and($env)->toContain('SPECIFY_EXECUTOR_DRIVER=laravel-ai')
         ->and($env)->toContain('SPECIFY_EXECUTOR_RACE=')
         ->and($env)->toContain('MCP_USER_EMAIL=')
@@ -16,7 +17,10 @@ test('hosted deployment docs do not describe app-paid AI execution', function ()
     $aiConfig = readProjectFile('config/ai.php');
 
     expect($readme)->toContain('users configure their own Anthropic/OpenAI key')
+        ->and($readme)->toContain('SPECIFY_REMOTE_EXECUTORS')
         ->and($deployment)->toContain('Do not set an app-wide AI provider key')
+        ->and($deployment)->toContain('operator assertion that the named driver is safe')
+        ->and(readProjectFile('docs/architecture/agent-run-lifecycle.md'))->toContain('specify.runtime.remote_executors')
         ->and($aiConfig)->toContain('user-triggered agent calls through per-run BYOK provider')
         ->and($readme)->not->toContain('describe-only');
 });

--- a/tests/Feature/ByokExecutionTest.php
+++ b/tests/Feature/ByokExecutionTest.php
@@ -20,6 +20,7 @@ use App\Models\UserAiCredential;
 use App\Models\Workspace;
 use App\Services\Ai\ByokProviderResolver;
 use App\Services\ExecutionService;
+use App\Services\Executors\CliExecutor;
 use App\Services\Executors\ExecutorFactory;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
@@ -199,6 +200,18 @@ test('hosted runtime fails race config containing local-only drivers', function 
 
     expect(fn () => app(ExecutorFactory::class)->raceDrivers())
         ->toThrow(InvalidArgumentException::class, 'local-only');
+});
+
+test('hosted runtime allows local drivers only when explicitly configured as remote', function () {
+    config([
+        'specify.runtime.environment' => 'hosted',
+        'specify.runtime.remote_executors' => ['cli-codex'],
+        'specify.executor.race' => ['laravel-ai', 'cli-codex'],
+    ]);
+
+    expect(app(ExecutorFactory::class)->make('cli-codex'))
+        ->toBeInstanceOf(CliExecutor::class)
+        ->and(app(ExecutorFactory::class)->raceDrivers())->toBe(['laravel-ai', 'cli-codex']);
 });
 
 function byokMcpStoryScene(StoryStatus $status): array

--- a/tests/Feature/ByokExecutionTest.php
+++ b/tests/Feature/ByokExecutionTest.php
@@ -189,7 +189,7 @@ test('hosted runtime blocks local-only executor drivers', function () {
     config(['specify.runtime.environment' => 'hosted']);
 
     expect(fn () => app(ExecutorFactory::class)->make('cli'))
-        ->toThrow(InvalidArgumentException::class, 'local-only');
+        ->toThrow(InvalidArgumentException::class, 'SPECIFY_REMOTE_EXECUTORS');
 });
 
 test('hosted runtime fails race config containing local-only drivers', function () {
@@ -199,7 +199,7 @@ test('hosted runtime fails race config containing local-only drivers', function 
     ]);
 
     expect(fn () => app(ExecutorFactory::class)->raceDrivers())
-        ->toThrow(InvalidArgumentException::class, 'local-only');
+        ->toThrow(InvalidArgumentException::class, 'SPECIFY_REMOTE_EXECUTORS');
 });
 
 test('hosted runtime allows local drivers only when explicitly configured as remote', function () {


### PR DESCRIPTION
## Summary
- add `SPECIFY_REMOTE_EXECUTORS` / `specify.runtime.remote_executors` as an explicit hosted allowlist for local drivers that have a remote-safe worker deployment
- keep hosted runtime blocking local drivers by default, including race-mode validation
- document the operator contract in README, hosted deployment docs, and AgentRun lifecycle docs

## Tests
- vendor/bin/pint --dirty --format=compact
- php artisan test --compact tests/Feature/ByokExecutionTest.php tests/Architecture/HostedDeploymentDocumentationTest.php
- composer test