### PR TITLE
Supersede stale executor ADR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Specify is a Laravel 13 system where humans approve AI actions on code repos. **
 |---|---|
 | Touch the approval state machine | [ADR-0001](docs/adr/0001-story-and-plan-approval-gates.md), `app/Services/ApprovalService.php` |
 | Edit Story / criteria / scenarios / Plan / Task / Subtask | [ADR-0002](docs/adr/0002-story-scenario-plan-task-subtask-hierarchy.md), `app/Services/PlanWriter.php` |
-| Add or change an Executor | [ADR-0003](docs/adr/0003-pluggable-executor-interface.md), `app/Services/Executors/` |
+| Add or change an Executor | [ADR-0014](docs/adr/0014-executor-contract-and-runtime-locality.md), `app/Services/Executors/`, `config/specify.php` |
 | Race executors against each other | [ADR-0006](docs/adr/0006-multi-executor-race-mode.md), `config/specify.php` (`executor.race`), `App\Services\Executors\ExecutorFactory` |
 | Touch PR creation | [ADR-0004](docs/adr/0004-pr-after-push-is-non-fatal.md), `app/Services/PullRequests/` |
 | Touch advisory PR review | `app/Services/Reviews/` (`ReviewProvider`, `GithubReviewProvider`), `app/Jobs/ReviewPullRequestJob.php` — gated on `SPECIFY_REVIEW_ENABLED`, never blocks merge |

--- a/app/Services/Executors/Executor.php
+++ b/app/Services/Executors/Executor.php
@@ -10,7 +10,7 @@ use App\Services\Progress\ProgressEmitter;
  * Strategy that performs the engineering work for one Subtask.
  *
  * Implementations are registered in `specify.executor.drivers` and resolved
- * by name via `ExecutorFactory` (see ADR-0003).
+ * by name via `ExecutorFactory` (see ADR-0014).
  * `LaravelAiExecutor`, `CliExecutor`, and `FakeExecutor` cover the in-tree
  * cases; new drivers register a name and implement this contract.
  */

--- a/docs/adr/0003-pluggable-executor-interface.md
+++ b/docs/adr/0003-pluggable-executor-interface.md
@@ -1,7 +1,7 @@
 # 0003. Pluggable Executor interface
 
 Date: 2026-05-01
-Status: Accepted
+Status: Superseded by [0014](0014-executor-contract-and-runtime-locality.md)
 
 ## Context
 

--- a/docs/adr/0014-executor-contract-and-runtime-locality.md
+++ b/docs/adr/0014-executor-contract-and-runtime-locality.md
@@ -1,0 +1,91 @@
+# 0014. Executor contract and runtime locality
+
+Date: 2026-05-05
+Status: Accepted
+
+Supersedes: [0003](0003-pluggable-executor-interface.md)
+
+## Context
+
+ADR-0003 introduced the pluggable `Executor` interface. The interface remains
+the right boundary, but the implementation details changed: the in-process
+Laravel AI executor now performs repo-editing work through tools, user-funded
+AI calls are BYOK, and hosted deployments must enforce executor locality.
+
+The current executor decision also incorporates later changes from:
+
+- [ADR-0006](0006-multi-executor-race-mode.md), which runs multiple executor
+  drivers against the same Subtask.
+- [ADR-0011](0011-streaming-progress-events-from-executors.md), which added
+  progress events to the executor call.
+- [ADR-0013](0013-byok-and-executor-locality.md), which made user-owned AI
+  credentials and runtime locality mandatory for hosted deployments.
+
+## Decision
+
+Keep one executor interface under `App\Services\Executors\Executor`:
+
+```php
+interface Executor
+{
+    public function needsWorkingDirectory(): bool;
+
+    public function execute(
+        Subtask $subtask,
+        ?string $workingDir,
+        ?Repo $repo,
+        ?string $workingBranch,
+        ?string $contextBrief = null,
+        ?ProgressEmitter $emitter = null,
+        ?string $promptOverride = null,
+    ): ExecutionResult;
+}
+```
+
+`needsWorkingDirectory()` tells `SubtaskRunPipeline` whether to prepare,
+checkout, commit, push, and open a PR. Executors that return `false` are
+describe-only; executors that return `true` are expected to inspect and mutate
+the checked-out repo.
+
+The in-tree drivers are:
+
+- `LaravelAiExecutor` — remote-capable. It wraps `SubtaskExecutor`, gives the
+  agent repo-editing tools, and resolves the run owner's BYOK provider through
+  `ByokProviderResolver`.
+- `CliExecutor` — local by default. It runs a configured one-shot CLI agent in
+  the working directory and observes changes via git.
+- `FakeExecutor` — test-only deterministic executor.
+
+`ExecutorFactory` is the only place that resolves driver names. It reads:
+
+- `specify.executor.default` for single-driver execution
+- `specify.executor.race` for race-mode fan-out
+- `specify.executor.drivers` for driver class, locality, command, and timeout
+- `specify.runtime.environment` to distinguish local and hosted runtime
+- `specify.runtime.remote_executors` for local drivers that an operator has
+  explicitly made safe on a remote worker
+
+Hosted runtime rejects local drivers unless the driver is listed in
+`specify.runtime.remote_executors`. That list is an operator assertion; it
+does not install binaries, provision credentials, or sandbox the worker.
+
+## Consequences
+
+Easier:
+
+- Every execution path resolves drivers through one factory.
+- Hosted deployments fail fast when a local-only driver is accidentally
+  configured.
+- Race mode and single-driver mode share the same validation rules.
+- Laravel AI execution can run on a hosted server without an app-paid provider
+  key because the AgentRun owner supplies BYOK credentials.
+
+Harder / accepted trade-offs:
+
+- Local CLI drivers need a separately designed remote worker before they can
+  be safely used in hosted runtime.
+- The executor interface is broad enough for context injection, progress
+  events, and prompt overrides; new drivers must consciously handle or ignore
+  those optional arguments.
+- `specify.runtime.remote_executors` is configuration trust, not a security
+  boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,7 +9,7 @@ except to mark them Superseded.
 |---|-------|--------|
 | [0001](0001-story-and-plan-approval-gates.md) | Story and current Plan are the approval gates | Accepted |
 | [0002](0002-story-scenario-plan-task-subtask-hierarchy.md) | Story, Scenario, Plan, Task, Subtask hierarchy | Accepted |
-| [0003](0003-pluggable-executor-interface.md) | Pluggable Executor interface | Accepted |
+| [0003](0003-pluggable-executor-interface.md) | Pluggable Executor interface | Superseded by [0014](0014-executor-contract-and-runtime-locality.md) |
 | [0004](0004-pr-after-push-is-non-fatal.md) | Opening the pull request after push is a non-fatal step | Accepted |
 | [0005](0005-plans-grow-append-only-mid-run.md) | Plans grow append-only mid-run | Accepted |
 | [0006](0006-multi-executor-race-mode.md) | Multi-executor race mode | Accepted |
@@ -20,5 +20,6 @@ except to mark them Superseded.
 | [0011](0011-streaming-progress-events-from-executors.md) | Streaming progress events from executors | Proposed |
 | [0012](0012-project-first-information-architecture.md) | Project-first information architecture | Accepted |
 | [0013](0013-byok-and-executor-locality.md) | BYOK and executor locality for hosted deployments | Accepted |
+| [0014](0014-executor-contract-and-runtime-locality.md) | Executor contract and runtime locality | Accepted |
 
 Use [`0000-template.md`](0000-template.md) when adding a new ADR. Number sequentially and update this index.

--- a/docs/architecture/agent-run-lifecycle.md
+++ b/docs/architecture/agent-run-lifecycle.md
@@ -6,7 +6,7 @@ which approval context applied, which executor ran, which branch was used,
 what changed, and how the run terminated.
 
 This page describes the current implementation shape. The load-bearing
-decisions are [ADR-0003](../adr/0003-pluggable-executor-interface.md),
+decisions are [ADR-0014](../adr/0014-executor-contract-and-runtime-locality.md),
 [ADR-0004](../adr/0004-pr-after-push-is-non-fatal.md),
 [ADR-0006](../adr/0006-multi-executor-race-mode.md),
 [ADR-0007](../adr/0007-already-complete-subtasks.md),

--- a/tests/Architecture/ExecutorArchitectureDocumentationTest.php
+++ b/tests/Architecture/ExecutorArchitectureDocumentationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+test('current executor guidance points at the current ADR', function () {
+    $agents = readExecutorDoc('AGENTS.md');
+    $lifecycle = readExecutorDoc('docs/architecture/agent-run-lifecycle.md');
+    $executor = readExecutorDoc('app/Services/Executors/Executor.php');
+    $adrIndex = readExecutorDoc('docs/adr/README.md');
+
+    expect($agents)->toContain('ADR-0014')
+        ->and($lifecycle)->toContain('ADR-0014')
+        ->and($executor)->toContain('ADR-0014')
+        ->and($adrIndex)->toContain('Superseded by [0014]');
+});
+
+test('current executor ADR describes the implemented drivers', function () {
+    $oldAdr = readExecutorDoc('docs/adr/0003-pluggable-executor-interface.md');
+    $currentAdr = readExecutorDoc('docs/adr/0014-executor-contract-and-runtime-locality.md');
+
+    expect($oldAdr)->toContain('Status: Superseded by [0014]')
+        ->and($currentAdr)->toContain('LaravelAiExecutor')
+        ->and($currentAdr)->toContain('SubtaskExecutor')
+        ->and($currentAdr)->toContain('BYOK')
+        ->and($currentAdr)->toContain('specify.runtime.remote_executors')
+        ->and($currentAdr)->not->toContain('TaskExecutor');
+});
+
+function readExecutorDoc(string $path): string
+{
+    $absolutePath = base_path($path);
+
+    expect(is_readable($absolutePath), "{$path} should be readable")->toBeTrue();
+
+    $contents = file_get_contents($absolutePath);
+
+    expect($contents, "{$path} should be readable")->not->toBeFalse();
+
+    return $contents;
+}


### PR DESCRIPTION
## Summary
- mark ADR-0003 as superseded and add ADR-0014 with the current executor contract, BYOK behavior, and locality enforcement
- update current contributor/code/architecture references to ADR-0014
- add architecture tests that keep executor guidance pointed at the current ADR and prevent stale `TaskExecutor` wording from reappearing in the current decision

## Tests
- vendor/bin/pint --dirty --test --format=compact
- php artisan test --compact tests/Architecture/ExecutorArchitectureDocumentationTest.php tests/Architecture/HostedDeploymentDocumentationTest.php
- composer test