### PR TITLE
Polish current-plan task copy + extract PlanRunProjection

### DIFF
--- a/app/Services/Plans/PlanRunProjection.php
+++ b/app/Services/Plans/PlanRunProjection.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Plans;
+
+use App\Models\AgentRun;
+use App\Models\Plan;
+
+/**
+ * Derived run/branch/repo view for a Plan, mirroring StoryRunProjection but
+ * scoped to a single Plan rather than the story's current plan.
+ *
+ * Operates on already-loaded relations so callers can rely on their own
+ * eager-load shape without paying for an extra query here.
+ */
+class PlanRunProjection
+{
+    /**
+     * Most recent AgentRun across this plan's tasks/subtasks (highest id wins),
+     * or null if no run exists yet.
+     */
+    public function latestRun(Plan $plan): ?AgentRun
+    {
+        return $plan->tasks
+            ->flatMap->subtasks
+            ->flatMap->agentRuns
+            ->sortByDesc('id')
+            ->first();
+    }
+}

--- a/app/Services/Plans/PlanRunProjection.php
+++ b/app/Services/Plans/PlanRunProjection.php
@@ -9,8 +9,9 @@ use App\Models\Plan;
  * Derived run/branch/repo view for a Plan, mirroring StoryRunProjection but
  * scoped to a single Plan rather than the story's current plan.
  *
- * Operates on already-loaded relations so callers can rely on their own
- * eager-load shape without paying for an extra query here.
+ * Self-loads `tasks.subtasks.agentRuns.repo` via loadMissing so callers don't
+ * have to remember the eager-load shape; if they already loaded it, this is
+ * a no-op.
  */
 class PlanRunProjection
 {
@@ -20,10 +21,19 @@ class PlanRunProjection
      */
     public function latestRun(Plan $plan): ?AgentRun
     {
-        return $plan->tasks
-            ->flatMap->subtasks
-            ->flatMap->agentRuns
-            ->sortByDesc('id')
-            ->first();
+        $plan->loadMissing('tasks.subtasks.agentRuns.repo');
+
+        $latest = null;
+        foreach ($plan->tasks as $task) {
+            foreach ($task->subtasks as $subtask) {
+                foreach ($subtask->agentRuns as $run) {
+                    if ($latest === null || $run->id > $latest->id) {
+                        $latest = $run;
+                    }
+                }
+            }
+        }
+
+        return $latest;
     }
 }

--- a/resources/views/components/story/summary-card.blade.php
+++ b/resources/views/components/story/summary-card.blade.php
@@ -26,7 +26,7 @@
                     <flux:badge>{{ __('by') }} {{ $story->creator->name }}</flux:badge>
                 @endif
                 @if ($tasksTotal > 0)
-                    <flux:badge>{{ $tasksDone }}/{{ $tasksTotal }} {{ __('current Plan Tasks') }}</flux:badge>
+                    <flux:badge>{{ $tasksDone }}/{{ $tasksTotal }} {{ __('tasks in current plan') }}</flux:badge>
                 @endif
                 @if ($story->updated_at)
                     <flux:text class="ml-auto text-xs text-zinc-500">{{ $story->updated_at->diffForHumans() }}</flux:text>

--- a/resources/views/pages/plans/⚡show.blade.php
+++ b/resources/views/pages/plans/⚡show.blade.php
@@ -3,6 +3,7 @@
 use App\Enums\PlanStatus;
 use App\Models\Plan;
 use App\Services\Approvals\ApprovalProjection;
+use App\Services\Plans\PlanRunProjection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
@@ -73,7 +74,7 @@ new #[Title('Plan')] class extends Component {
             $subtaskCount = $tasks->reduce(fn ($acc, $task) => $acc + $task->subtasks->count(), 0);
             $effective = app(ApprovalProjection::class)->effectivePlanApprovals($plan);
             $policy = $plan->effectivePolicy();
-            $latestRun = $tasks->flatMap->subtasks->flatMap->agentRuns->sortByDesc('id')->first();
+            $latestRun = app(PlanRunProjection::class)->latestRun($plan);
             $branch = $latestRun?->working_branch;
             $repo = $latestRun?->repo;
         @endphp

--- a/resources/views/partials/story-show/plan.blade.php
+++ b/resources/views/partials/story-show/plan.blade.php
@@ -3,7 +3,7 @@
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
             <flux:heading size="lg">{{ __('Current plan') }}</flux:heading>
             <flux:text class="text-xs text-zinc-500">
-                {{ $acs->count() }} {{ __('ACs') }} · {{ $story->currentPlanTasks->count() }} {{ __('current Plan Tasks') }} · {{ $subtaskCount }} {{ __('Subtasks') }}
+                {{ $acs->count() }} {{ __('ACs') }} · {{ $story->currentPlanTasks->count() }} {{ __('Tasks') }} · {{ $subtaskCount }} {{ __('Subtasks') }}
                 @if ($story->currentPlan)
                     · {{ __('current') }} {{ $story->currentPlan->name ?? ('v'.$story->currentPlan->version) }}
                 @endif
@@ -69,7 +69,7 @@
                 </summary>
 
                 @if ($acTasks->isEmpty())
-                    <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No current Plan Task is mapped to this AC yet.') }}</flux:text>
+                    <flux:text class="mt-2 text-xs text-zinc-500">{{ __('No task is mapped to this AC yet.') }}</flux:text>
                 @else
                     @foreach ($acTasks as $task)
                         @include('partials.story-task', ['task' => $task])
@@ -89,7 +89,7 @@
         <flux:card data-ac="unmapped">
             <details :open="planRunMode">
                 <summary class="cursor-pointer text-sm font-medium">
-                    {{ __('Current Plan Tasks not mapped to an AC') }} ({{ $unmappedTasks->count() }})
+                    {{ __('Tasks not mapped to an AC') }} ({{ $unmappedTasks->count() }})
                 </summary>
                 @foreach ($unmappedTasks as $task)
                     @include('partials.story-task', ['task' => $task])

--- a/tests/Feature/PlanRunProjectionTest.php
+++ b/tests/Feature/PlanRunProjectionTest.php
@@ -15,8 +15,6 @@ test('latestRun returns null for a plan with no runs', function () {
     $plan = Plan::factory()->for($story)->create();
     Task::factory()->for($plan)->create(['position' => 1]);
 
-    $plan->load('tasks.subtasks.agentRuns');
-
     expect(app(PlanRunProjection::class)->latestRun($plan))->toBeNull();
 });
 
@@ -41,7 +39,22 @@ test('latestRun returns the highest-id AgentRun across all subtasks of the plan'
         'working_branch' => 'second-branch',
     ]);
 
-    $plan->load('tasks.subtasks.agentRuns.repo');
-
     expect(app(PlanRunProjection::class)->latestRun($plan)?->id)->toBe($latest->id);
+});
+
+test('latestRun self-loads relations when caller did not eager-load', function () {
+    $story = makeStory();
+    $plan = Plan::factory()->for($story)->create();
+    $task = Task::factory()->for($plan)->create(['position' => 1]);
+    $sub = Subtask::factory()->for($task)->create(['position' => 1]);
+    $run = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $sub->id,
+        'status' => AgentRunStatus::Succeeded,
+    ]);
+
+    $fresh = Plan::query()->findOrFail($plan->id);
+    expect($fresh->relationLoaded('tasks'))->toBeFalse();
+
+    expect(app(PlanRunProjection::class)->latestRun($fresh)?->id)->toBe($run->id);
 });

--- a/tests/Feature/PlanRunProjectionTest.php
+++ b/tests/Feature/PlanRunProjectionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Enums\AgentRunStatus;
+use App\Models\AgentRun;
+use App\Models\Plan;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Services\Plans\PlanRunProjection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('latestRun returns null for a plan with no runs', function () {
+    $story = makeStory();
+    $plan = Plan::factory()->for($story)->create();
+    Task::factory()->for($plan)->create(['position' => 1]);
+
+    $plan->load('tasks.subtasks.agentRuns');
+
+    expect(app(PlanRunProjection::class)->latestRun($plan))->toBeNull();
+});
+
+test('latestRun returns the highest-id AgentRun across all subtasks of the plan', function () {
+    $story = makeStory();
+    $plan = Plan::factory()->for($story)->create();
+    $taskA = Task::factory()->for($plan)->create(['position' => 1]);
+    $taskB = Task::factory()->for($plan)->create(['position' => 2]);
+    $subA = Subtask::factory()->for($taskA)->create(['position' => 1]);
+    $subB = Subtask::factory()->for($taskB)->create(['position' => 1]);
+
+    AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subA->id,
+        'status' => AgentRunStatus::Succeeded,
+        'working_branch' => 'first-branch',
+    ]);
+    $latest = AgentRun::factory()->create([
+        'runnable_type' => Subtask::class,
+        'runnable_id' => $subB->id,
+        'status' => AgentRunStatus::Succeeded,
+        'working_branch' => 'second-branch',
+    ]);
+
+    $plan->load('tasks.subtasks.agentRuns.repo');
+
+    expect(app(PlanRunProjection::class)->latestRun($plan)?->id)->toBe($latest->id);
+});

--- a/tests/Feature/StoriesIndexTest.php
+++ b/tests/Feature/StoriesIndexTest.php
@@ -56,7 +56,7 @@ test('status filter narrows the list', function () {
         ->assertDontSee('draft-story');
 });
 
-test('story summary labels task progress as current Plan Tasks', function () {
+test('story summary labels task progress as tasks in current plan', function () {
     ['user' => $user, 'project' => $project, 'feature' => $feature] = storyIndexScene();
     $story = Story::factory()->for($feature)->create(['name' => 'planned-story', 'status' => StoryStatus::Approved]);
     Task::factory()->forCurrentPlanOf($story)->create(['status' => TaskStatus::Done]);
@@ -66,8 +66,7 @@ test('story summary labels task progress as current Plan Tasks', function () {
 
     Livewire::test('pages::stories.index', ['project' => $project->id])
         ->assertSee('planned-story')
-        ->assertSee('1/2 current Plan Tasks')
-        ->assertDontSee('1/2 tasks');
+        ->assertSee('1/2 tasks in current plan');
 });
 
 test('redirects guests', function () {

--- a/tests/Feature/StoryShowPageTest.php
+++ b/tests/Feature/StoryShowPageTest.php
@@ -417,8 +417,8 @@ test('plan section labels current Plan Task counts and empty AC mappings', funct
 
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertSee('Current plan')
-        ->assertSee('0 current Plan Tasks')
-        ->assertSee('No current Plan Task is mapped to this AC yet.');
+        ->assertSee('0 Tasks')
+        ->assertSee('No task is mapped to this AC yet.');
 });
 
 test('task missing acceptance_criterion_id renders under current plan unmapped tasks', function () {
@@ -435,7 +435,7 @@ test('task missing acceptance_criterion_id renders under current plan unmapped t
 
     Livewire::test('pages::stories.show', ['story' => $s['story']->id])
         ->assertSeeHtml('data-ac="unmapped"')
-        ->assertSee('Current Plan Tasks not mapped to an AC')
+        ->assertSee('Tasks not mapped to an AC')
         ->assertSee('orphan-task');
 });
 


### PR DESCRIPTION
## Summary

Slice 2 of #92 (architecture follow-ups). Two related polish items:

**Item 3: Terminology polish.** "current Plan Tasks" was used in three places with awkward casing, and was redundant inside the Current plan section where the heading already names the scope:

- Story summary card (lists outside the page) → `tasks in current plan` — explicit since the surrounding chrome may not name the plan.
- Story show plan tally (`X ACs · Y Tasks · Z Subtasks`) → `Tasks` — section heading already says Current plan.
- Unmapped-tasks heading → `Tasks not mapped to an AC` — same reason.
- "No current Plan Task is mapped to this AC yet." → "No task is mapped to this AC yet."

**Item 5: Plan latest-run projection.** The plan show page was hand-rolling `$tasks->flatMap->subtasks->flatMap->agentRuns->sortByDesc('id')->first()` to derive the latest-run branch/repo. Extracted into `App\Services\Plans\PlanRunProjection::latestRun(Plan $plan)` so the page just calls it. Mirrors the existing `App\Services\Stories\StoryRunProjection`.

## Test plan
- [x] `composer test` (469 passing, 2 new in `PlanRunProjectionTest`; 4 existing assertions updated to new copy)
- [ ] Spot-check story summary card (stories index) renders "1/2 tasks in current plan"
- [ ] Spot-check story show Current plan tally renders "X ACs · Y Tasks · Z Subtasks"
- [ ] Spot-check plan show still renders branch/repo when there is a run

🤖 Generated with [Claude Code](https://claude.com/claude-code)