### PR TITLE
Disable noisy Claude Code hooks; ignore .claude/worktrees/

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,37 +10,6 @@
         ],
         "matcher": "Bash"
       }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-on-edit.sh"
-          }
-        ],
-        "matcher": "Write|Edit"
-      }
-    ],
-    "PostCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-compact-reinject.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-before-stop.sh"
-          }
-        ]
-      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log
 *.swp
 .playwright-mcp/
 *.png
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Drop three hook entries from \`.claude/settings.json\` that were producing more noise than value during agent sessions:

- **PostToolUse** (\`format-on-edit.sh\`) — rewrote files mid-edit, forcing reread cycles.
- **PostCompact** (\`post-compact-reinject.sh\`) — echoed the full \`CLAUDE.md\` back into the transcript on every compact.
- **Stop** (\`verify-before-stop.sh\`) — kept tripping during exploratory turns where a dirty tree is normal mid-investigation.

\`PreToolUse\` (\`block-force-push.sh\`) stays on — it's the one guardrail with no false-positive history (segment-aware parser, allows \`--force-with-lease\`, only blocks protected branches).

The hook scripts themselves remain in \`.claude/hooks/\` so they can be re-enabled if needed.

Also adds \`.claude/worktrees/\` to \`.gitignore\` — local agent-isolation scratch directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)