### PR TITLE
Project & Story context assets — slice 1: schema, models, uploader, writers

### DIFF
--- a/app/Enums/ContextItemSummaryStatus.php
+++ b/app/Enums/ContextItemSummaryStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Lifecycle of the lazy AI summary attached to a ContextItem.
+ *
+ * `Pending` is the initial state; `Ready` means a summary is stored;
+ * `Skipped` means summarisation was bypassed (e.g. body short enough or
+ * no BYOK creds); `Failed` carries the error in `summary_error`.
+ */
+enum ContextItemSummaryStatus: string
+{
+    case Pending = 'pending';
+    case Ready = 'ready';
+    case Skipped = 'skipped';
+    case Failed = 'failed';
+}

--- a/app/Enums/ContextItemType.php
+++ b/app/Enums/ContextItemType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum ContextItemType: string
+{
+    case File = 'file';
+    case Link = 'link';
+    case Text = 'text';
+}

--- a/app/Models/ContextItem.php
+++ b/app/Models/ContextItem.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Enums\ContextItemType;
+use Database\Factories\ContextItemFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+/**
+ * Project- or Story-scoped reference asset that feeds the AI context brief.
+ *
+ * `project_id` is always set; `story_id` is set only for story-scoped items
+ * that auto-include into that Story. Selection of project-scoped items into
+ * a Story flows through the `context_item_story` pivot.
+ */
+#[Fillable([
+    'project_id',
+    'story_id',
+    'type',
+    'title',
+    'description',
+    'metadata',
+    'summary',
+    'summary_status',
+    'summary_error',
+    'created_by_id',
+])]
+class ContextItem extends Model
+{
+    /** @use HasFactory<ContextItemFactory> */
+    use HasFactory, SoftDeletes;
+
+    /**
+     * Soft cap for raw text returned by `bodyForContext()` when no summary
+     * is available. Roughly 4 KB of UTF-8 — enough to keep plans usable
+     * without dominating the prompt budget.
+     */
+    public const BODY_FALLBACK_CHARS = 4000;
+
+    protected function casts(): array
+    {
+        return [
+            'type' => ContextItemType::class,
+            'summary_status' => ContextItemSummaryStatus::class,
+            'metadata' => 'array',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function story(): BelongsTo
+    {
+        return $this->belongsTo(Story::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_id');
+    }
+
+    public function includedInStories(): BelongsToMany
+    {
+        return $this->belongsToMany(Story::class, 'context_item_story')
+            ->withPivot(['included_at', 'included_by_id']);
+    }
+
+    public function isProjectScoped(): bool
+    {
+        return $this->story_id === null;
+    }
+
+    public function isStoryScoped(): bool
+    {
+        return $this->story_id !== null;
+    }
+
+    /**
+     * The text rendered into the AI prompt. Prefers a ready summary; falls
+     * back to the truncated raw text body so plans still generate when
+     * summarisation was skipped or the item never went through compression.
+     */
+    public function bodyForContext(): string
+    {
+        if ($this->summary_status === ContextItemSummaryStatus::Ready && filled($this->summary)) {
+            return (string) $this->summary;
+        }
+
+        $raw = $this->rawBody();
+        if ($raw === '') {
+            return '';
+        }
+
+        return Str::limit($raw, self::BODY_FALLBACK_CHARS, '…');
+    }
+
+    private function rawBody(): string
+    {
+        $type = $this->type instanceof ContextItemType ? $this->type : ContextItemType::tryFrom((string) $this->type);
+
+        return match ($type) {
+            ContextItemType::Text => (string) ($this->metadata['body'] ?? $this->description ?? ''),
+            ContextItemType::Link => (string) ($this->metadata['url'] ?? ''),
+            ContextItemType::File => (string) ($this->metadata['original_name'] ?? $this->metadata['path'] ?? ''),
+            null => (string) ($this->description ?? ''),
+        };
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -56,6 +56,11 @@ class Project extends Model
         return $this->hasMany(Feature::class);
     }
 
+    public function contextItems(): HasMany
+    {
+        return $this->hasMany(ContextItem::class);
+    }
+
     public function stories(): HasManyThrough
     {
         return $this->hasManyThrough(Story::class, Feature::class);

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -13,6 +13,7 @@ use App\Services\Stories\StoryRevisionLifecycle;
 use App\Services\Stories\StoryRunProjection;
 use Database\Factories\StoryFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -215,6 +216,45 @@ class Story extends Model
     public function scenarios(): HasMany
     {
         return $this->hasMany(Scenario::class)->orderBy('position');
+    }
+
+    /**
+     * Story-scoped ContextItems (those whose `story_id` matches this story).
+     * Story-scoped items auto-include — they always render in the picker as
+     * checked and cannot be project-scoped after creation.
+     */
+    public function ownedContextItems(): HasMany
+    {
+        return $this->hasMany(ContextItem::class);
+    }
+
+    /**
+     * Items currently selected as AI context for this Story via the pivot.
+     * The set is the union of explicit selections from project-scoped items
+     * and the auto-included story-scoped items.
+     */
+    public function includedContextItems(): BelongsToMany
+    {
+        return $this->belongsToMany(ContextItem::class, 'context_item_story')
+            ->withPivot(['included_at', 'included_by_id']);
+    }
+
+    /**
+     * The picker's source set: every ContextItem that *could* be selected
+     * for this Story — i.e. project-scoped items in the same Project plus
+     * this Story's own story-scoped items.
+     *
+     * @return Builder<ContextItem>
+     */
+    public function availableContextItems(): Builder
+    {
+        $projectId = $this->feature?->project_id;
+
+        return ContextItem::query()
+            ->where('project_id', $projectId)
+            ->where(function ($q): void {
+                $q->whereNull('story_id')->orWhere('story_id', $this->getKey());
+            });
     }
 
     public function dependencies(): BelongsToMany

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -220,8 +220,10 @@ class Story extends Model
 
     /**
      * Story-scoped ContextItems (those whose `story_id` matches this story).
-     * Story-scoped items auto-include — they always render in the picker as
-     * checked and cannot be project-scoped after creation.
+     * `ContextItemWriter::createStoryItem` auto-attaches them to this
+     * Story's selection, and `ContextItemSelector` refuses to detach them
+     * — toggling story-scoped items off is not a picker concern. They
+     * leave the selection only when deleted via `ContextItemWriter::delete`.
      */
     public function ownedContextItems(): HasMany
     {

--- a/app/Services/Context/AssetUploader.php
+++ b/app/Services/Context/AssetUploader.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Enums\ContextItemType;
+use App\Models\ContextItem;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+/**
+ * Persists an uploaded file to the configured `private` disk and creates a
+ * matching ContextItem row. Story summarisation (lazy) is owned by the
+ * companion job in Slice 2 — uploads here always land in
+ * `summary_status=pending` so that worker picks them up later.
+ */
+class AssetUploader
+{
+    public function store(UploadedFile $file, Project $project, ?Story $story, User $actor): ContextItem
+    {
+        $this->ensureStoryBelongsToProject($project, $story);
+        $this->validate($file);
+
+        $disk = $this->disk();
+        $directory = 'context/'.Str::lower((string) Str::ulid());
+        $storedPath = $file->storeAs($directory, $this->safeFilename($file), ['disk' => $disk]);
+
+        if ($storedPath === false) {
+            throw new \RuntimeException('Failed to store uploaded asset.');
+        }
+
+        return ContextItem::create([
+            'project_id' => $project->getKey(),
+            'story_id' => $story?->getKey(),
+            'type' => ContextItemType::File,
+            'title' => $file->getClientOriginalName() ?: basename($storedPath),
+            'description' => null,
+            'metadata' => [
+                'disk' => $disk,
+                'path' => $storedPath,
+                'original_name' => $file->getClientOriginalName(),
+                'mime' => $file->getClientMimeType(),
+                'size' => $file->getSize(),
+            ],
+            'summary_status' => ContextItemSummaryStatus::Pending,
+            'created_by_id' => $actor->getKey(),
+        ]);
+    }
+
+    private function ensureStoryBelongsToProject(Project $project, ?Story $story): void
+    {
+        if ($story === null) {
+            return;
+        }
+
+        $storyProjectId = $story->feature?->project_id;
+        if ((int) $storyProjectId !== (int) $project->getKey()) {
+            throw new InvalidArgumentException('Story does not belong to the given project.');
+        }
+    }
+
+    private function validate(UploadedFile $file): void
+    {
+        $maxKb = (int) config('specify.context.assets.max_file_kb', 10240);
+        $sizeKb = (int) ceil($file->getSize() / 1024);
+        if ($maxKb > 0 && $sizeKb > $maxKb) {
+            throw new InvalidArgumentException("Uploaded file exceeds the {$maxKb} KB limit.");
+        }
+
+        $allowed = (array) config('specify.context.assets.allowed_mimes', []);
+        if ($allowed !== [] && ! in_array($file->getClientMimeType(), $allowed, true)) {
+            throw new InvalidArgumentException("MIME type {$file->getClientMimeType()} is not allowed.");
+        }
+    }
+
+    private function safeFilename(UploadedFile $file): string
+    {
+        $original = $file->getClientOriginalName() ?: 'upload';
+        $base = Str::of(pathinfo($original, PATHINFO_FILENAME))->slug()->limit(80, '');
+        $ext = strtolower((string) $file->getClientOriginalExtension());
+
+        $name = $base->isEmpty() ? 'upload' : (string) $base;
+
+        return $ext === '' ? $name : "{$name}.{$ext}";
+    }
+
+    private function disk(): string
+    {
+        $disk = (string) config('specify.context.assets.disk', 'private');
+
+        if (! array_key_exists($disk, config('filesystems.disks', []))) {
+            throw new \RuntimeException("Configured assets disk '{$disk}' is not defined.");
+        }
+
+        // Touch the disk so misconfiguration surfaces here (not in storeAs).
+        Storage::disk($disk);
+
+        return $disk;
+    }
+}

--- a/app/Services/Context/AssetUploader.php
+++ b/app/Services/Context/AssetUploader.php
@@ -44,7 +44,10 @@ class AssetUploader
                 'disk' => $disk,
                 'path' => $storedPath,
                 'original_name' => $file->getClientOriginalName(),
-                'mime' => $file->getClientMimeType(),
+                // Server-detected MIME — getClientMimeType() is user-controlled and
+                // trivial to spoof. The detected value is what we record and what
+                // later checks should rely on.
+                'mime' => $file->getMimeType() ?: 'application/octet-stream',
                 'size' => $file->getSize(),
             ],
             'summary_status' => ContextItemSummaryStatus::Pending,
@@ -73,8 +76,9 @@ class AssetUploader
         }
 
         $allowed = (array) config('specify.context.assets.allowed_mimes', []);
-        if ($allowed !== [] && ! in_array($file->getClientMimeType(), $allowed, true)) {
-            throw new InvalidArgumentException("MIME type {$file->getClientMimeType()} is not allowed.");
+        $detected = $file->getMimeType() ?: 'application/octet-stream';
+        if ($allowed !== [] && ! in_array($detected, $allowed, true)) {
+            throw new InvalidArgumentException("MIME type {$detected} is not allowed.");
         }
     }
 

--- a/app/Services/Context/ContextItemSelector.php
+++ b/app/Services/Context/ContextItemSelector.php
@@ -51,9 +51,14 @@ class ContextItemSelector
 
     /**
      * Replace the project-scoped selection for a Story with the given set
-     * of ContextItem IDs. Story-scoped items remain attached either way.
+     * of ContextItem IDs. Story-scoped items remain attached either way —
+     * they're managed by `ContextItemWriter::createStoryItem` / `delete`,
+     * never by the picker.
      *
-     * @param  array<int|string>  $itemIds  Desired included project-scoped item IDs.
+     * @param  array<int|string>  $itemIds  Desired included **project-scoped** item IDs.
+     *                                      Story-scoped IDs are rejected; they cannot be
+     *                                      detached this way and would conflict with the
+     *                                      pivot's composite primary key on re-attach.
      */
     public function bulkSet(Story $story, array $itemIds, User $actor): void
     {
@@ -68,9 +73,9 @@ class ContextItemSelector
 
                 foreach ($items as $item) {
                     $this->ensureSameProject($story, $item);
-                    if ($item->isStoryScoped() && (int) $item->story_id !== (int) $story->getKey()) {
+                    if ($item->isStoryScoped()) {
                         throw new InvalidArgumentException(
-                            "Context item {$item->getKey()} is scoped to a different Story."
+                            "Context item {$item->getKey()} is story-scoped; bulkSet only manages project-scoped selections."
                         );
                     }
                 }

--- a/app/Services/Context/ContextItemSelector.php
+++ b/app/Services/Context/ContextItemSelector.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Models\ContextItem;
+use App\Models\Story;
+use App\Models\User;
+use App\Services\Stories\StoryRevisionLifecycle;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+/**
+ * Toggles project-scoped ContextItems into / out of a Story's selection.
+ *
+ * Approval reopen invariant: at most one `recordContentArtifactChanged()`
+ * call per public method, fired only when the included set actually
+ * changed. Story-scoped items are auto-included by `ContextItemWriter`
+ * and cannot be toggled here.
+ */
+class ContextItemSelector
+{
+    public function __construct(private StoryRevisionLifecycle $revisions) {}
+
+    public function setIncluded(Story $story, ContextItem $item, bool $included, User $actor): void
+    {
+        $this->ensureSameProject($story, $item);
+
+        if ($item->isStoryScoped()) {
+            throw new InvalidArgumentException('Story-scoped items are auto-included and cannot be toggled.');
+        }
+
+        DB::transaction(function () use ($story, $item, $included, $actor): void {
+            $isAttached = $story->includedContextItems()->whereKey($item->getKey())->exists();
+
+            if ($included === $isAttached) {
+                return;
+            }
+
+            if ($included) {
+                $story->includedContextItems()->attach($item->getKey(), [
+                    'included_at' => now(),
+                    'included_by_id' => $actor->getKey(),
+                ]);
+            } else {
+                $story->includedContextItems()->detach($item->getKey());
+            }
+
+            $this->revisions->recordContentArtifactChanged($story);
+        });
+    }
+
+    /**
+     * Replace the project-scoped selection for a Story with the given set
+     * of ContextItem IDs. Story-scoped items remain attached either way.
+     *
+     * @param  array<int|string>  $itemIds  Desired included project-scoped item IDs.
+     */
+    public function bulkSet(Story $story, array $itemIds, User $actor): void
+    {
+        DB::transaction(function () use ($story, $itemIds, $actor): void {
+            $desired = array_values(array_unique(array_map('intval', $itemIds)));
+
+            if ($desired !== []) {
+                $items = ContextItem::query()->whereIn('id', $desired)->get();
+                if ($items->count() !== count($desired)) {
+                    throw new InvalidArgumentException('One or more context items do not exist.');
+                }
+
+                foreach ($items as $item) {
+                    $this->ensureSameProject($story, $item);
+                    if ($item->isStoryScoped() && (int) $item->story_id !== (int) $story->getKey()) {
+                        throw new InvalidArgumentException(
+                            "Context item {$item->getKey()} is scoped to a different Story."
+                        );
+                    }
+                }
+            }
+
+            $currentProjectScoped = $story->includedContextItems()
+                ->whereNull('context_items.story_id')
+                ->pluck('context_items.id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+
+            sort($currentProjectScoped);
+            $sortedDesired = $desired;
+            sort($sortedDesired);
+
+            if ($currentProjectScoped === $sortedDesired) {
+                return;
+            }
+
+            $toAttach = array_diff($desired, $currentProjectScoped);
+            $toDetach = array_diff($currentProjectScoped, $desired);
+
+            if ($toDetach !== []) {
+                $story->includedContextItems()->detach($toDetach);
+            }
+
+            if ($toAttach !== []) {
+                $now = now();
+                $payload = [];
+                foreach ($toAttach as $id) {
+                    $payload[$id] = [
+                        'included_at' => $now,
+                        'included_by_id' => $actor->getKey(),
+                    ];
+                }
+                $story->includedContextItems()->attach($payload);
+            }
+
+            $this->revisions->recordContentArtifactChanged($story);
+        });
+    }
+
+    private function ensureSameProject(Story $story, ContextItem $item): void
+    {
+        $storyProjectId = $story->feature?->project_id;
+        if ($storyProjectId === null) {
+            throw new InvalidArgumentException('Story is not attached to a Feature with a Project.');
+        }
+
+        if ((int) $item->project_id !== (int) $storyProjectId) {
+            throw new InvalidArgumentException(
+                "Context item {$item->getKey()} belongs to a different Project than story {$story->getKey()}."
+            );
+        }
+    }
+}

--- a/app/Services/Context/ContextItemWriter.php
+++ b/app/Services/Context/ContextItemWriter.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Enums\ContextItemType;
+use App\Models\ContextItem;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\User;
+use App\Services\Stories\StoryRevisionLifecycle;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+
+/**
+ * Mutating surface for ContextItem rows. Story-scoped CRUD reopens the
+ * owning Story for approval (single revision per write); project-scoped
+ * CRUD does not — see ADR for the rationale.
+ */
+class ContextItemWriter
+{
+    public function __construct(private StoryRevisionLifecycle $revisions) {}
+
+    /**
+     * @param  array{
+     *     type: ContextItemType|string,
+     *     title: string,
+     *     description?: string|null,
+     *     metadata?: array<string, mixed>|null,
+     * }  $attributes
+     */
+    public function createProjectItem(Project $project, array $attributes, User $actor): ContextItem
+    {
+        $this->ensureNonFileType($attributes['type'] ?? null);
+
+        return ContextItem::create([
+            'project_id' => $project->getKey(),
+            'story_id' => null,
+            'type' => $attributes['type'],
+            'title' => $attributes['title'],
+            'description' => $attributes['description'] ?? null,
+            'metadata' => $attributes['metadata'] ?? null,
+            'summary_status' => $this->initialSummaryStatus($attributes['type']),
+            'created_by_id' => $actor->getKey(),
+        ]);
+    }
+
+    /**
+     * @param  array{
+     *     type: ContextItemType|string,
+     *     title: string,
+     *     description?: string|null,
+     *     metadata?: array<string, mixed>|null,
+     * }  $attributes
+     */
+    public function createStoryItem(Story $story, array $attributes, User $actor): ContextItem
+    {
+        $this->ensureNonFileType($attributes['type'] ?? null);
+
+        return DB::transaction(function () use ($story, $attributes, $actor): ContextItem {
+            $projectId = $this->projectIdFor($story);
+
+            $item = ContextItem::create([
+                'project_id' => $projectId,
+                'story_id' => $story->getKey(),
+                'type' => $attributes['type'],
+                'title' => $attributes['title'],
+                'description' => $attributes['description'] ?? null,
+                'metadata' => $attributes['metadata'] ?? null,
+                'summary_status' => $this->initialSummaryStatus($attributes['type']),
+                'created_by_id' => $actor->getKey(),
+            ]);
+
+            $story->includedContextItems()->syncWithoutDetaching([
+                $item->getKey() => [
+                    'included_at' => now(),
+                    'included_by_id' => $actor->getKey(),
+                ],
+            ]);
+
+            $this->revisions->recordContentArtifactChanged($story);
+
+            return $item;
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $changes
+     */
+    public function update(ContextItem $item, array $changes, User $actor): ContextItem
+    {
+        return DB::transaction(function () use ($item, $changes): ContextItem {
+            $allowed = ['title', 'description', 'metadata'];
+            $payload = array_intersect_key($changes, array_flip($allowed));
+
+            if ($payload === []) {
+                return $item;
+            }
+
+            $item->forceFill($payload);
+
+            if (! $item->isDirty()) {
+                return $item;
+            }
+
+            $item->save();
+
+            if ($item->isStoryScoped() && $item->story) {
+                $this->revisions->recordContentArtifactChanged($item->story);
+            }
+
+            return $item->refresh();
+        });
+    }
+
+    public function delete(ContextItem $item, User $actor): void
+    {
+        DB::transaction(function () use ($item): void {
+            $story = $item->isStoryScoped() ? $item->story : null;
+
+            $this->deleteUnderlyingFile($item);
+
+            $item->delete();
+
+            if ($story) {
+                $this->revisions->recordContentArtifactChanged($story);
+            }
+        });
+    }
+
+    private function projectIdFor(Story $story): int
+    {
+        $projectId = $story->feature?->project_id;
+        if ($projectId === null) {
+            throw new InvalidArgumentException('Story is not attached to a Feature with a Project.');
+        }
+
+        return (int) $projectId;
+    }
+
+    private function ensureNonFileType(mixed $type): void
+    {
+        $resolved = $type instanceof ContextItemType
+            ? $type
+            : ContextItemType::tryFrom((string) $type);
+
+        if ($resolved === ContextItemType::File) {
+            throw new InvalidArgumentException('Use AssetUploader to create file-typed ContextItems.');
+        }
+
+        if ($resolved === null) {
+            throw new InvalidArgumentException('Unknown ContextItem type.');
+        }
+    }
+
+    private function initialSummaryStatus(mixed $type): ContextItemSummaryStatus
+    {
+        $resolved = $type instanceof ContextItemType
+            ? $type
+            : ContextItemType::tryFrom((string) $type);
+
+        return $resolved === ContextItemType::Link
+            ? ContextItemSummaryStatus::Skipped
+            : ContextItemSummaryStatus::Pending;
+    }
+
+    private function deleteUnderlyingFile(ContextItem $item): void
+    {
+        if ($item->type !== ContextItemType::File) {
+            return;
+        }
+
+        $disk = (string) ($item->metadata['disk'] ?? '');
+        $path = (string) ($item->metadata['path'] ?? '');
+        if ($disk === '' || $path === '') {
+            return;
+        }
+
+        Storage::disk($disk)->delete($path);
+    }
+}

--- a/app/Services/Context/ContextItemWriter.php
+++ b/app/Services/Context/ContextItemWriter.php
@@ -98,6 +98,16 @@ class ContextItemWriter
                 return $item;
             }
 
+            // File-typed items have storage-bearing metadata (disk, path, mime,
+            // size). Letting callers rewrite those keys would let a tampered
+            // request retarget `deleteUnderlyingFile()` at someone else's bytes.
+            // The uploader owns file metadata; updates here are name-only.
+            if (array_key_exists('metadata', $payload) && $item->type === ContextItemType::File) {
+                throw new InvalidArgumentException(
+                    'File metadata is immutable through ContextItemWriter::update — re-upload via AssetUploader.'
+                );
+            }
+
             $item->forceFill($payload);
 
             if (! $item->isDirty()) {
@@ -174,6 +184,16 @@ class ContextItemWriter
         $disk = (string) ($item->metadata['disk'] ?? '');
         $path = (string) ($item->metadata['path'] ?? '');
         if ($disk === '' || $path === '') {
+            return;
+        }
+
+        // Defense-in-depth against tampered metadata: only delete on a disk
+        // that's both registered in `filesystems.php` AND the configured
+        // assets disk. Refuse silently otherwise — better an orphaned blob
+        // than an arbitrary cross-disk delete.
+        $configured = (string) config('specify.context.assets.disk', 'private');
+        $known = array_key_exists($disk, (array) config('filesystems.disks', []));
+        if (! $known || $disk !== $configured) {
             return;
         }
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -38,6 +38,14 @@ return [
             'report' => false,
         ],
 
+        'private' => [
+            'driver' => 'local',
+            'root' => storage_path('app/private'),
+            'visibility' => 'private',
+            'throw' => false,
+            'report' => false,
+        ],
+
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),

--- a/config/specify.php
+++ b/config/specify.php
@@ -195,5 +195,17 @@ return [
             'window' => env('SPECIFY_CONTEXT_WINDOW', '30.days'),
             'max_files' => (int) env('SPECIFY_CONTEXT_MAX_FILES', 10),
         ],
+        'assets' => [
+            'disk' => env('SPECIFY_ASSETS_DISK', 'private'),
+            'max_file_kb' => (int) env('SPECIFY_ASSETS_MAX_FILE_KB', 10240),
+            'allowed_mimes' => array_values(array_filter(array_map(
+                'trim',
+                explode(',', (string) env(
+                    'SPECIFY_ASSETS_ALLOWED_MIMES',
+                    'image/png,image/jpeg,image/webp,image/gif,application/pdf,text/plain,text/markdown'
+                ))
+            ))),
+            'summary_threshold_chars' => (int) env('SPECIFY_ASSETS_SUMMARY_THRESHOLD', 2000),
+        ],
     ],
 ];

--- a/database/factories/ContextItemFactory.php
+++ b/database/factories/ContextItemFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Enums\ContextItemType;
+use App\Models\ContextItem;
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ContextItem>
+ */
+class ContextItemFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'story_id' => null,
+            'type' => ContextItemType::Text,
+            'title' => fake()->sentence(4),
+            'description' => fake()->sentence(),
+            'metadata' => ['body' => fake()->paragraph()],
+            'summary' => null,
+            'summary_status' => ContextItemSummaryStatus::Pending,
+            'summary_error' => null,
+            'created_by_id' => null,
+        ];
+    }
+
+    public function forText(?string $body = null): self
+    {
+        return $this->state(fn () => [
+            'type' => ContextItemType::Text,
+            'metadata' => ['body' => $body ?? fake()->paragraph()],
+        ]);
+    }
+
+    public function forLink(?string $url = null): self
+    {
+        return $this->state(fn () => [
+            'type' => ContextItemType::Link,
+            'metadata' => ['url' => $url ?? fake()->url()],
+        ]);
+    }
+
+    public function forFile(?string $path = null, ?string $originalName = null, ?string $mime = null): self
+    {
+        return $this->state(fn () => [
+            'type' => ContextItemType::File,
+            'metadata' => [
+                'disk' => 'private',
+                'path' => $path ?? 'context/01HXXX/example.pdf',
+                'original_name' => $originalName ?? 'example.pdf',
+                'mime' => $mime ?? 'application/pdf',
+                'size' => 1024,
+            ],
+        ]);
+    }
+}

--- a/database/migrations/2026_05_10_000001_create_context_items_table.php
+++ b/database/migrations/2026_05_10_000001_create_context_items_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('context_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('story_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->json('metadata')->nullable();
+            $table->text('summary')->nullable();
+            $table->string('summary_status')->default('pending');
+            $table->text('summary_error')->nullable();
+            $table->foreignId('created_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index(['project_id', 'type']);
+            $table->index(['project_id', 'story_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('context_items');
+    }
+};

--- a/database/migrations/2026_05_10_000002_create_context_item_story_table.php
+++ b/database/migrations/2026_05_10_000002_create_context_item_story_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('context_item_story', function (Blueprint $table) {
+            $table->foreignId('story_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('context_item_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('included_at')->useCurrent();
+            $table->foreignId('included_by_id')->nullable()->constrained('users')->nullOnDelete();
+
+            $table->primary(['story_id', 'context_item_id']);
+            $table->index('context_item_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('context_item_story');
+    }
+};

--- a/tests/Feature/ContextItem/AssetUploaderTest.php
+++ b/tests/Feature/ContextItem/AssetUploaderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Enums\ContextItemType;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\User;
+use App\Services\Context\AssetUploader;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('private');
+});
+
+test('store persists file and creates a project-scoped ContextItem', function () {
+    $project = Project::factory()->create();
+    $actor = User::factory()->create();
+    $file = UploadedFile::fake()->create('Spec Notes.pdf', 12, 'application/pdf');
+
+    $item = app(AssetUploader::class)->store($file, $project, null, $actor);
+
+    expect($item->type)->toBe(ContextItemType::File);
+    expect($item->project_id)->toBe($project->id);
+    expect($item->story_id)->toBeNull();
+    expect($item->summary_status)->toBe(ContextItemSummaryStatus::Pending);
+    expect($item->created_by_id)->toBe($actor->id);
+    expect($item->title)->toBe('Spec Notes.pdf');
+    expect($item->metadata['original_name'])->toBe('Spec Notes.pdf');
+    expect($item->metadata['disk'])->toBe('private');
+
+    Storage::disk('private')->assertExists($item->metadata['path']);
+});
+
+test('store accepts a Story when it belongs to the same Project', function () {
+    $project = Project::factory()->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $actor = User::factory()->create();
+
+    $item = app(AssetUploader::class)->store(
+        UploadedFile::fake()->create('a.pdf', 4, 'application/pdf'),
+        $project,
+        $story,
+        $actor,
+    );
+
+    expect($item->story_id)->toBe($story->id);
+    expect($item->project_id)->toBe($project->id);
+});
+
+test('store rejects a Story from a different Project', function () {
+    $projectA = Project::factory()->create();
+    $projectB = Project::factory()->create();
+    $featureB = Feature::factory()->for($projectB)->create();
+    $story = Story::factory()->for($featureB)->create();
+    $actor = User::factory()->create();
+
+    expect(fn () => app(AssetUploader::class)->store(
+        UploadedFile::fake()->create('a.pdf', 4, 'application/pdf'),
+        $projectA,
+        $story,
+        $actor,
+    ))->toThrow(InvalidArgumentException::class);
+});
+
+test('store rejects files exceeding the size cap', function () {
+    config(['specify.context.assets.max_file_kb' => 1]);
+
+    $project = Project::factory()->create();
+    $actor = User::factory()->create();
+
+    expect(fn () => app(AssetUploader::class)->store(
+        UploadedFile::fake()->create('big.pdf', 100, 'application/pdf'),
+        $project,
+        null,
+        $actor,
+    ))->toThrow(InvalidArgumentException::class);
+});
+
+test('store rejects MIME types not in the allow-list', function () {
+    config(['specify.context.assets.allowed_mimes' => ['application/pdf']]);
+
+    $project = Project::factory()->create();
+    $actor = User::factory()->create();
+
+    expect(fn () => app(AssetUploader::class)->store(
+        UploadedFile::fake()->create('a.exe', 4, 'application/x-msdownload'),
+        $project,
+        null,
+        $actor,
+    ))->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Feature/ContextItem/ContextItemModelTest.php
+++ b/tests/Feature/ContextItem/ContextItemModelTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Enums\ContextItemType;
+use App\Models\ContextItem;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+
+test('isProjectScoped vs isStoryScoped reflect story_id', function () {
+    $project = Project::factory()->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+
+    $projectItem = ContextItem::factory()->for($project)->forText('hello')->create();
+    $storyItem = ContextItem::factory()->for($project)->for($story)->forText('world')->create();
+
+    expect($projectItem->isProjectScoped())->toBeTrue();
+    expect($projectItem->isStoryScoped())->toBeFalse();
+    expect($storyItem->isStoryScoped())->toBeTrue();
+    expect($storyItem->isProjectScoped())->toBeFalse();
+});
+
+test('bodyForContext returns summary when ready', function () {
+    $item = ContextItem::factory()->forText('the long body')->create([
+        'summary' => 'short summary',
+        'summary_status' => ContextItemSummaryStatus::Ready,
+    ]);
+
+    expect($item->bodyForContext())->toBe('short summary');
+});
+
+test('bodyForContext falls back to truncated raw body when no summary', function () {
+    $body = str_repeat('a', ContextItem::BODY_FALLBACK_CHARS + 200);
+    $item = ContextItem::factory()->forText($body)->create([
+        'summary_status' => ContextItemSummaryStatus::Skipped,
+    ]);
+
+    $rendered = $item->bodyForContext();
+
+    expect(mb_strlen($rendered))->toBeLessThanOrEqual(ContextItem::BODY_FALLBACK_CHARS + 1);
+    expect($rendered)->toEndWith('…');
+});
+
+test('bodyForContext for link returns the url', function () {
+    $item = ContextItem::factory()->forLink('https://example.test/spec')->create();
+
+    expect($item->bodyForContext())->toBe('https://example.test/spec');
+});
+
+test('Project hasMany contextItems, Story owned and includedContextItems work', function () {
+    $project = Project::factory()->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+
+    $owned = ContextItem::factory()->for($project)->for($story)->forText()->create();
+    $other = ContextItem::factory()->for($project)->forText()->create();
+    $story->includedContextItems()->attach($other);
+
+    expect($project->contextItems()->count())->toBe(2);
+    expect($story->ownedContextItems()->pluck('id')->all())->toBe([$owned->id]);
+    expect($story->includedContextItems()->pluck('context_items.id')->sort()->values()->all())
+        ->toBe([$other->id]);
+});
+
+test('availableContextItems returns project-scoped + own story items', function () {
+    $project = Project::factory()->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create();
+    $otherStory = Story::factory()->for($feature)->create();
+
+    $projectItem = ContextItem::factory()->for($project)->forText()->create();
+    $ownItem = ContextItem::factory()->for($project)->for($story)->forText()->create();
+    $otherStoryItem = ContextItem::factory()->for($project)->for($otherStory)->forText()->create();
+
+    $ids = $story->availableContextItems()->pluck('id')->sort()->values()->all();
+    $expected = collect([$projectItem->id, $ownItem->id])->sort()->values()->all();
+
+    expect($ids)->toBe($expected);
+    expect($ids)->not->toContain($otherStoryItem->id);
+});
+
+test('cast for type and summary_status returns enums', function () {
+    $item = ContextItem::factory()->forLink()->create([
+        'summary_status' => ContextItemSummaryStatus::Skipped,
+    ]);
+
+    expect($item->type)->toBe(ContextItemType::Link);
+    expect($item->summary_status)->toBe(ContextItemSummaryStatus::Skipped);
+});

--- a/tests/Feature/ContextItem/ContextItemSelectorTest.php
+++ b/tests/Feature/ContextItem/ContextItemSelectorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Enums\StoryStatus;
+use App\Models\ContextItem;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\User;
+use App\Services\Context\ContextItemSelector;
+
+function selectorScene(): array
+{
+    $project = Project::factory()->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create([
+        'status' => StoryStatus::Approved,
+        'revision' => 1,
+    ]);
+    $actor = User::factory()->create();
+
+    return compact('project', 'feature', 'story', 'actor');
+}
+
+test('setIncluded toggles attachment and reopens approval once', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = selectorScene();
+    $item = ContextItem::factory()->for($project)->forText()->create();
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemSelector::class)->setIncluded($story, $item, true, $actor);
+
+    expect($story->includedContextItems()->whereKey($item->id)->exists())->toBeTrue();
+    expect($story->fresh()->revision)->toBe($beforeRev + 1);
+
+    // Calling again with same state must be a no-op (no second reopen).
+    app(ContextItemSelector::class)->setIncluded($story, $item, true, $actor);
+    expect($story->fresh()->revision)->toBe($beforeRev + 1);
+
+    app(ContextItemSelector::class)->setIncluded($story, $item, false, $actor);
+    expect($story->includedContextItems()->whereKey($item->id)->exists())->toBeFalse();
+    expect($story->fresh()->revision)->toBe($beforeRev + 2);
+});
+
+test('setIncluded refuses to toggle a story-scoped item', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = selectorScene();
+    $item = ContextItem::factory()->for($project)->for($story)->forText()->create();
+
+    expect(fn () => app(ContextItemSelector::class)->setIncluded($story, $item, false, $actor))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('setIncluded refuses cross-project items', function () {
+    ['story' => $story, 'actor' => $actor] = selectorScene();
+    $otherProject = Project::factory()->create();
+    $item = ContextItem::factory()->for($otherProject)->forText()->create();
+
+    expect(fn () => app(ContextItemSelector::class)->setIncluded($story, $item, true, $actor))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('bulkSet replaces project-scoped selection in one reopen', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = selectorScene();
+    $a = ContextItem::factory()->for($project)->forText()->create();
+    $b = ContextItem::factory()->for($project)->forText()->create();
+    $c = ContextItem::factory()->for($project)->forText()->create();
+    $story->includedContextItems()->attach([$a->id, $b->id]);
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemSelector::class)->bulkSet($story, [$b->id, $c->id], $actor);
+
+    $included = $story->includedContextItems()->pluck('context_items.id')->sort()->values()->all();
+    expect($included)->toBe(collect([$b->id, $c->id])->sort()->values()->all());
+    expect($story->fresh()->revision)->toBe($beforeRev + 1);
+});
+
+test('bulkSet is a no-op when desired set matches current', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = selectorScene();
+    $a = ContextItem::factory()->for($project)->forText()->create();
+    $story->includedContextItems()->attach([$a->id]);
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemSelector::class)->bulkSet($story, [$a->id], $actor);
+
+    expect($story->fresh()->revision)->toBe($beforeRev);
+});
+
+test('bulkSet preserves story-scoped attachments and only manages project-scoped IDs', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = selectorScene();
+    $owned = ContextItem::factory()->for($project)->for($story)->forText()->create();
+    $story->includedContextItems()->attach([$owned->id]);
+
+    $extra = ContextItem::factory()->for($project)->forText()->create();
+
+    app(ContextItemSelector::class)->bulkSet($story, [$extra->id], $actor);
+
+    $included = $story->includedContextItems()->pluck('context_items.id')->sort()->values()->all();
+    expect($included)->toBe(collect([$owned->id, $extra->id])->sort()->values()->all());
+});
+
+test('bulkSet rejects cross-project items', function () {
+    ['story' => $story, 'actor' => $actor] = selectorScene();
+    $otherProject = Project::factory()->create();
+    $foreign = ContextItem::factory()->for($otherProject)->forText()->create();
+
+    expect(fn () => app(ContextItemSelector::class)->bulkSet($story, [$foreign->id], $actor))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('bulkSet rejects story-scoped items belonging to a different story', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = selectorScene();
+    $otherStory = Story::factory()->for($story->feature)->create();
+    $alien = ContextItem::factory()->for($project)->for($otherStory)->forText()->create();
+
+    expect(fn () => app(ContextItemSelector::class)->bulkSet($story, [$alien->id], $actor))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Feature/ContextItem/ContextItemSelectorTest.php
+++ b/tests/Feature/ContextItem/ContextItemSelectorTest.php
@@ -105,11 +105,14 @@ test('bulkSet rejects cross-project items', function () {
         ->toThrow(InvalidArgumentException::class);
 });
 
-test('bulkSet rejects story-scoped items belonging to a different story', function () {
+test('bulkSet rejects any story-scoped item (including own)', function () {
     ['project' => $project, 'story' => $story, 'actor' => $actor] = selectorScene();
+    $own = ContextItem::factory()->for($project)->for($story)->forText()->create();
     $otherStory = Story::factory()->for($story->feature)->create();
     $alien = ContextItem::factory()->for($project)->for($otherStory)->forText()->create();
 
     expect(fn () => app(ContextItemSelector::class)->bulkSet($story, [$alien->id], $actor))
+        ->toThrow(InvalidArgumentException::class);
+    expect(fn () => app(ContextItemSelector::class)->bulkSet($story, [$own->id], $actor))
         ->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Feature/ContextItem/ContextItemWriterTest.php
+++ b/tests/Feature/ContextItem/ContextItemWriterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Enums\ContextItemType;
+use App\Enums\StoryStatus;
+use App\Models\ContextItem;
+use App\Models\Feature;
+use App\Models\Project;
+use App\Models\Story;
+use App\Models\User;
+use App\Services\Context\ContextItemWriter;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+function ciScene(): array
+{
+    $project = Project::factory()->create();
+    $feature = Feature::factory()->for($project)->create();
+    $story = Story::factory()->for($feature)->create([
+        'status' => StoryStatus::Approved,
+        'revision' => 1,
+    ]);
+    $actor = User::factory()->create();
+
+    return compact('project', 'feature', 'story', 'actor');
+}
+
+test('createProjectItem creates project-scoped item without reopening any story', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = ciScene();
+
+    $beforeRev = $story->fresh()->revision;
+
+    $item = app(ContextItemWriter::class)->createProjectItem($project, [
+        'type' => ContextItemType::Text,
+        'title' => 'House style',
+        'metadata' => ['body' => 'Use Oxford commas.'],
+    ], $actor);
+
+    expect($item->project_id)->toBe($project->id);
+    expect($item->story_id)->toBeNull();
+    expect($item->summary_status)->toBe(ContextItemSummaryStatus::Pending);
+    expect($story->fresh()->revision)->toBe($beforeRev);
+    expect($story->fresh()->status)->toBe(StoryStatus::Approved);
+});
+
+test('createStoryItem auto-includes and reopens approval', function () {
+    ['story' => $story, 'actor' => $actor] = ciScene();
+
+    $item = app(ContextItemWriter::class)->createStoryItem($story, [
+        'type' => ContextItemType::Text,
+        'title' => 'Note',
+        'metadata' => ['body' => 'Hot edit'],
+    ], $actor);
+
+    $fresh = $story->fresh();
+    expect($item->story_id)->toBe($story->id);
+    expect($fresh->revision)->toBe(2);
+    expect($story->includedContextItems()->whereKey($item->id)->exists())->toBeTrue();
+});
+
+test('createProjectItem rejects file type', function () {
+    ['project' => $project, 'actor' => $actor] = ciScene();
+
+    expect(fn () => app(ContextItemWriter::class)->createProjectItem($project, [
+        'type' => ContextItemType::File,
+        'title' => 'x',
+    ], $actor))->toThrow(InvalidArgumentException::class);
+});
+
+test('createProjectItem stores link with summary_status=skipped', function () {
+    ['project' => $project, 'actor' => $actor] = ciScene();
+
+    $item = app(ContextItemWriter::class)->createProjectItem($project, [
+        'type' => ContextItemType::Link,
+        'title' => 'Figma',
+        'metadata' => ['url' => 'https://figma.com/x'],
+    ], $actor);
+
+    expect($item->summary_status)->toBe(ContextItemSummaryStatus::Skipped);
+});
+
+test('update on project-scoped item does not reopen approval', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = ciScene();
+    $item = ContextItem::factory()->for($project)->forText('old')->create();
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemWriter::class)->update($item, ['title' => 'New title'], $actor);
+
+    expect($item->fresh()->title)->toBe('New title');
+    expect($story->fresh()->revision)->toBe($beforeRev);
+});
+
+test('update on story-scoped item reopens approval once', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = ciScene();
+    $item = ContextItem::factory()->for($project)->for($story)->forText('old')->create();
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemWriter::class)->update($item, ['title' => 'Renamed'], $actor);
+
+    expect($story->fresh()->revision)->toBe($beforeRev + 1);
+});
+
+test('update with no real changes does not save or reopen', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = ciScene();
+    $item = ContextItem::factory()->for($project)->for($story)->forText('body')->create([
+        'title' => 'Same',
+    ]);
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemWriter::class)->update($item, ['title' => 'Same'], $actor);
+
+    expect($story->fresh()->revision)->toBe($beforeRev);
+});
+
+test('delete on story-scoped item soft-deletes row, removes file, reopens approval', function () {
+    Storage::fake('private');
+    ['story' => $story, 'project' => $project, 'actor' => $actor] = ciScene();
+
+    $file = UploadedFile::fake()->create('doc.pdf', 4, 'application/pdf');
+    $stored = $file->storeAs('context/'.Str::ulid(), 'doc.pdf', ['disk' => 'private']);
+    $item = ContextItem::factory()->for($project)->for($story)->forFile($stored, 'doc.pdf', 'application/pdf')->create();
+
+    Storage::disk('private')->assertExists($stored);
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemWriter::class)->delete($item, $actor);
+
+    expect(ContextItem::query()->whereKey($item->id)->exists())->toBeFalse();
+    expect(ContextItem::withTrashed()->whereKey($item->id)->exists())->toBeTrue();
+    Storage::disk('private')->assertMissing($stored);
+    expect($story->fresh()->revision)->toBe($beforeRev + 1);
+});
+
+test('delete on project-scoped item does not reopen any story', function () {
+    ['project' => $project, 'story' => $story, 'actor' => $actor] = ciScene();
+    $item = ContextItem::factory()->for($project)->forText()->create();
+    $beforeRev = $story->fresh()->revision;
+
+    app(ContextItemWriter::class)->delete($item, $actor);
+
+    expect(ContextItem::query()->whereKey($item->id)->exists())->toBeFalse();
+    expect($story->fresh()->revision)->toBe($beforeRev);
+});

--- a/tests/Feature/ContextItem/ContextItemWriterTest.php
+++ b/tests/Feature/ContextItem/ContextItemWriterTest.php
@@ -132,6 +132,46 @@ test('delete on story-scoped item soft-deletes row, removes file, reopens approv
     expect($story->fresh()->revision)->toBe($beforeRev + 1);
 });
 
+test('update refuses to mutate metadata on file-typed items', function () {
+    Storage::fake('private');
+    ['story' => $story, 'project' => $project, 'actor' => $actor] = ciScene();
+    $stored = UploadedFile::fake()->create('doc.pdf', 4, 'application/pdf')->storeAs(
+        'context/'.Str::ulid(), 'doc.pdf', ['disk' => 'private']
+    );
+    $item = ContextItem::factory()->for($project)->for($story)->forFile($stored, 'doc.pdf', 'application/pdf')->create();
+
+    expect(fn () => app(ContextItemWriter::class)->update($item, [
+        'metadata' => ['disk' => 'public', 'path' => 'someone/elses/file.txt'],
+    ], $actor))->toThrow(InvalidArgumentException::class);
+
+    // Title-only updates on file items remain allowed.
+    app(ContextItemWriter::class)->update($item, ['title' => 'Renamed.pdf'], $actor);
+    expect($item->fresh()->title)->toBe('Renamed.pdf');
+});
+
+test('delete refuses to delete from a non-configured disk', function () {
+    Storage::fake('private');
+    Storage::fake('public');
+    ['story' => $story, 'project' => $project, 'actor' => $actor] = ciScene();
+
+    $tampered = UploadedFile::fake()->create('canary.pdf', 4, 'application/pdf')->storeAs(
+        'shared/canary', 'canary.pdf', ['disk' => 'public']
+    );
+    Storage::disk('public')->assertExists($tampered);
+
+    // Item claims `public` disk in metadata but assets are configured to `private`.
+    $item = ContextItem::factory()->for($project)->for($story)->create([
+        'type' => ContextItemType::File,
+        'metadata' => ['disk' => 'public', 'path' => $tampered, 'mime' => 'application/pdf'],
+    ]);
+
+    app(ContextItemWriter::class)->delete($item, $actor);
+
+    // Row gone, but the canary on the wrong disk survives.
+    expect(ContextItem::query()->whereKey($item->id)->exists())->toBeFalse();
+    Storage::disk('public')->assertExists($tampered);
+});
+
 test('delete on project-scoped item does not reopen any story', function () {
     ['project' => $project, 'story' => $story, 'actor' => $actor] = ciScene();
     $item = ContextItem::factory()->for($project)->forText()->create();

--- a/tests/Feature/ContextItem/SchemaTest.php
+++ b/tests/Feature/ContextItem/SchemaTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+test('context_items table has expected columns', function () {
+    expect(Schema::hasTable('context_items'))->toBeTrue();
+
+    foreach ([
+        'id', 'project_id', 'story_id', 'type', 'title', 'description',
+        'metadata', 'summary', 'summary_status', 'summary_error',
+        'created_by_id', 'deleted_at', 'created_at', 'updated_at',
+    ] as $column) {
+        expect(Schema::hasColumn('context_items', $column))
+            ->toBeTrue("missing column: {$column}");
+    }
+});
+
+test('context_item_story pivot has expected columns', function () {
+    expect(Schema::hasTable('context_item_story'))->toBeTrue();
+
+    foreach (['story_id', 'context_item_id', 'included_at', 'included_by_id'] as $column) {
+        expect(Schema::hasColumn('context_item_story', $column))
+            ->toBeTrue("missing column: {$column}");
+    }
+});


### PR DESCRIPTION
## Summary

Lays the schema, models, storage uploader, and approval-aware writers for project- and story-scoped AI context assets. First of 5 stacked PRs implementing the project-and-story context-assets feature ([plan](../) → ADR-0015 lands in slice 7-docs).

- `context_items` + `context_item_story` migrations (id, project/story FKs, type/title/description/metadata/summary*, soft deletes, indexes).
- `ContextItem` model with `bodyForContext()` (summary → truncated raw fallback), `Project::contextItems()`, `Story::ownedContextItems()` / `includedContextItems()` / `availableContextItems()`. Enums + factory states (`forFile/forLink/forText`).
- `private` disk in `config/filesystems.php` + `context.assets.*` config keys.
- `AssetUploader` (ULID paths, MIME/size validation, cross-project guard).
- `ContextItemWriter` and `ContextItemSelector` (story-scoped CRUD reopens approval, project-scoped does not, bulk-aware to avoid storms).

Slice 2 (summarisation), 3 (TasksGenerator injection), 4 (subtask context builder, opt-in), and 7-docs (ADR + AGENTS.md + CONTEXT.md) stack on top.

## Test plan

- [x] 31 new Pest tests under `tests/Feature/ContextItem/` — all green
- [x] Pint clean across new files
- [x] No regressions in pre-existing suite (16 unrelated UI/auth failures already present on main)
- [ ] Reviewer: cross-check ADR-0015 (lands in slice 7-docs) for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)