### PR TITLE
Project & Story context assets — slice 3: TasksGenerator injection

### DIFF
--- a/app/Ai/Agents/TasksGenerator.php
+++ b/app/Ai/Agents/TasksGenerator.php
@@ -27,9 +27,16 @@ class TasksGenerator implements Agent, HasStructuredOutput
         return app(PromptLoader::class)->load('tasks-generator');
     }
 
+    /**
+     * Hard cap on the rendered "Selected context assets" block. Keeps the
+     * plan-generation prompt within budget when many large assets are
+     * selected; items past the cap are dropped with a truncation marker.
+     */
+    public const CONTEXT_ASSETS_CAP_BYTES = 8192;
+
     public function buildPrompt(): string
     {
-        $story = $this->story->loadMissing('feature.project', 'acceptanceCriteria', 'scenarios.acceptanceCriterion');
+        $story = $this->story->loadMissing('feature.project', 'acceptanceCriteria', 'scenarios.acceptanceCriterion', 'includedContextItems');
 
         $criteria = $story->acceptanceCriteria
             ->sortBy('position')
@@ -55,6 +62,8 @@ SCENARIO;
             })
             ->implode("\n\n");
 
+        $contextAssets = $this->renderContextAssetsBlock($story);
+
         return <<<PROMPT
 Project: {$story->feature->project->name}
 Feature: {$story->feature->name}
@@ -68,9 +77,48 @@ Acceptance Criteria (position. text):
 
 Scenarios (position. Given / When / Then):
 {$scenarios}
-
+{$contextAssets}
 Generate an implementation plan that fully satisfies the acceptance criteria and scenarios above. Shape Tasks around coherent implementation work that may span acceptance criteria, scenarios, or shared enabling work. Each Task must have one or more Subtasks.
 PROMPT;
+    }
+
+    private function renderContextAssetsBlock(Story $story): string
+    {
+        $items = $story->includedContextItems;
+        if ($items->isEmpty()) {
+            return '';
+        }
+
+        $rendered = [];
+        $usedBytes = 0;
+        $droppedTitles = [];
+
+        foreach ($items as $item) {
+            $type = $item->type?->value ?? 'unknown';
+            $body = trim($item->bodyForContext());
+            $entry = "### {$item->title} ({$type})\n".($body === '' ? '(no extractable body)' : $body)."\n";
+            $entryBytes = strlen($entry);
+
+            if ($usedBytes + $entryBytes > self::CONTEXT_ASSETS_CAP_BYTES) {
+                $droppedTitles[] = $item->title;
+
+                continue;
+            }
+
+            $rendered[] = $entry;
+            $usedBytes += $entryBytes;
+        }
+
+        if ($rendered === [] && $droppedTitles === []) {
+            return '';
+        }
+
+        $body = implode("\n", $rendered);
+        $note = $droppedTitles === []
+            ? ''
+            : "\n_Truncated: dropped ".count($droppedTitles).' item(s) over the '.self::CONTEXT_ASSETS_CAP_BYTES."-byte cap._\n";
+
+        return "\n## Selected context assets\n\n{$body}{$note}\n";
     }
 
     public function schema(JsonSchema $schema): array

--- a/app/Ai/Agents/TasksGenerator.php
+++ b/app/Ai/Agents/TasksGenerator.php
@@ -89,9 +89,18 @@ PROMPT;
             return '';
         }
 
+        // Cap accounts for the wrapping header and the worst-case truncation
+        // note as well as item bodies — the entire block stays under the cap,
+        // not just the sum of items.
+        $header = "\n## Selected context assets\n\n";
+        $noteTemplate = "\n_Truncated: dropped %d item(s) over the ".self::CONTEXT_ASSETS_CAP_BYTES."-byte cap._\n";
+        $worstCaseNote = sprintf($noteTemplate, $items->count());
+        $overhead = strlen($header) + strlen($worstCaseNote) + 1; // +1 for trailing newline
+        $itemBudget = self::CONTEXT_ASSETS_CAP_BYTES - $overhead;
+
         $rendered = [];
         $usedBytes = 0;
-        $droppedTitles = [];
+        $droppedCount = 0;
 
         foreach ($items as $item) {
             $type = $item->type?->value ?? 'unknown';
@@ -99,8 +108,8 @@ PROMPT;
             $entry = "### {$item->title} ({$type})\n".($body === '' ? '(no extractable body)' : $body)."\n";
             $entryBytes = strlen($entry);
 
-            if ($usedBytes + $entryBytes > self::CONTEXT_ASSETS_CAP_BYTES) {
-                $droppedTitles[] = $item->title;
+            if ($usedBytes + $entryBytes > $itemBudget) {
+                $droppedCount++;
 
                 continue;
             }
@@ -109,16 +118,10 @@ PROMPT;
             $usedBytes += $entryBytes;
         }
 
-        if ($rendered === [] && $droppedTitles === []) {
-            return '';
-        }
-
         $body = implode("\n", $rendered);
-        $note = $droppedTitles === []
-            ? ''
-            : "\n_Truncated: dropped ".count($droppedTitles).' item(s) over the '.self::CONTEXT_ASSETS_CAP_BYTES."-byte cap._\n";
+        $note = $droppedCount === 0 ? '' : sprintf($noteTemplate, $droppedCount);
 
-        return "\n## Selected context assets\n\n{$body}{$note}\n";
+        return $header.$body.$note."\n";
     }
 
     public function schema(JsonSchema $schema): array

--- a/prompts/tasks-generator.md
+++ b/prompts/tasks-generator.md
@@ -23,6 +23,11 @@ Constraints:
   dependencies.
 - Never duplicate work. If two Tasks would touch the same surface in conflicting
   ways, sequence them via `depends_on`.
+- If the prompt includes a `## Selected context assets` block, those are
+  reference materials the product owner explicitly attached to this Story
+  (style guides, design notes, links). Treat them as authoritative source
+  for naming, constraints, and design intent. Reflect them in Task and
+  Subtask descriptions where they apply, but don't restate them.
 - The summary should be a single paragraph capturing the overall strategy.
 
 Do not include implementation snippets, code, or shell commands in Task or

--- a/tests/Feature/ContextItem/TasksGeneratorContextTest.php
+++ b/tests/Feature/ContextItem/TasksGeneratorContextTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Ai\Agents\TasksGenerator;
+use App\Enums\ContextItemSummaryStatus;
+use App\Models\AcceptanceCriterion;
+use App\Models\ContextItem;
+use App\Models\Project;
+use App\Models\Story;
+
+function tgScene(): Story
+{
+    $project = Project::factory()->create();
+    $story = Story::factory()->create();
+    AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'first']);
+
+    return $story;
+}
+
+test('buildPrompt omits the assets block when no items are included', function () {
+    $story = tgScene();
+
+    $prompt = (new TasksGenerator($story))->buildPrompt();
+
+    expect($prompt)->not->toContain('## Selected context assets');
+});
+
+test('buildPrompt renders titles + bodies of included context assets', function () {
+    $story = tgScene();
+    $project = $story->feature->project;
+
+    $a = ContextItem::factory()->for($project)->forText('alpha body')->create([
+        'title' => 'Style guide',
+        'summary' => 'STYLE SUMMARY',
+        'summary_status' => ContextItemSummaryStatus::Ready,
+    ]);
+    $b = ContextItem::factory()->for($project)->forLink('https://figma.com/x')->create([
+        'title' => 'Figma file',
+    ]);
+    $story->includedContextItems()->attach([$a->id, $b->id]);
+
+    $prompt = (new TasksGenerator($story))->buildPrompt();
+
+    expect($prompt)->toContain('## Selected context assets');
+    expect($prompt)->toContain('### Style guide (text)');
+    expect($prompt)->toContain('STYLE SUMMARY');
+    expect($prompt)->toContain('### Figma file (link)');
+    expect($prompt)->toContain('https://figma.com/x');
+});
+
+test('buildPrompt enforces the byte cap and notes truncation', function () {
+    $story = tgScene();
+    $project = $story->feature->project;
+
+    $bigBody = str_repeat('lorem ipsum dolor sit amet ', 400); // ~10 KB
+    $a = ContextItem::factory()->for($project)->forText($bigBody)->create([
+        'title' => 'Big A',
+        'summary' => $bigBody,
+        'summary_status' => ContextItemSummaryStatus::Ready,
+    ]);
+    $b = ContextItem::factory()->for($project)->forText($bigBody)->create([
+        'title' => 'Big B',
+        'summary' => $bigBody,
+        'summary_status' => ContextItemSummaryStatus::Ready,
+    ]);
+    $story->includedContextItems()->attach([$a->id, $b->id]);
+
+    $prompt = (new TasksGenerator($story))->buildPrompt();
+
+    expect($prompt)->toContain('## Selected context assets');
+    expect($prompt)->toContain('Truncated:');
+
+    // Block (between header and the next blank line + truncation marker) is bounded
+    // by the cap; full prompt is naturally larger because of story framing copy.
+    $blockPosition = strpos($prompt, '## Selected context assets');
+    $blockEnd = strpos($prompt, 'Generate an implementation plan');
+    expect($blockEnd - $blockPosition)->toBeLessThan(TasksGenerator::CONTEXT_ASSETS_CAP_BYTES + 512);
+});
+
+test('buildPrompt prefers summary over raw body when summary is ready', function () {
+    $story = tgScene();
+    $project = $story->feature->project;
+    $item = ContextItem::factory()->for($project)->forText('the long raw body would normally appear')->create([
+        'title' => 'House style',
+        'summary' => 'condensed summary line',
+        'summary_status' => ContextItemSummaryStatus::Ready,
+    ]);
+    $story->includedContextItems()->attach($item->id);
+
+    $prompt = (new TasksGenerator($story))->buildPrompt();
+
+    expect($prompt)->toContain('condensed summary line');
+    expect($prompt)->not->toContain('the long raw body would normally appear');
+});

--- a/tests/Feature/ContextItem/TasksGeneratorContextTest.php
+++ b/tests/Feature/ContextItem/TasksGeneratorContextTest.php
@@ -4,12 +4,10 @@ use App\Ai\Agents\TasksGenerator;
 use App\Enums\ContextItemSummaryStatus;
 use App\Models\AcceptanceCriterion;
 use App\Models\ContextItem;
-use App\Models\Project;
 use App\Models\Story;
 
 function tgScene(): Story
 {
-    $project = Project::factory()->create();
     $story = Story::factory()->create();
     AcceptanceCriterion::factory()->for($story)->create(['position' => 1, 'statement' => 'first']);
 
@@ -69,11 +67,12 @@ test('buildPrompt enforces the byte cap and notes truncation', function () {
     expect($prompt)->toContain('## Selected context assets');
     expect($prompt)->toContain('Truncated:');
 
-    // Block (between header and the next blank line + truncation marker) is bounded
-    // by the cap; full prompt is naturally larger because of story framing copy.
+    // Block (between header and the closing-instructions tail) stays within
+    // the cap. Use strrpos so a context body that happens to contain the
+    // closing-instructions phrase doesn't mismeasure the block.
     $blockPosition = strpos($prompt, '## Selected context assets');
-    $blockEnd = strpos($prompt, 'Generate an implementation plan');
-    expect($blockEnd - $blockPosition)->toBeLessThan(TasksGenerator::CONTEXT_ASSETS_CAP_BYTES + 512);
+    $blockEnd = strrpos($prompt, 'Generate an implementation plan');
+    expect($blockEnd - $blockPosition)->toBeLessThan(TasksGenerator::CONTEXT_ASSETS_CAP_BYTES + 256);
 });
 
 test('buildPrompt prefers summary over raw body when summary is ready', function () {


### PR DESCRIPTION
## Summary

Stacked on **slice 2**. Wires the v1 injection point: plan generation now sees the Story's selected context assets.

- `TasksGenerator::buildPrompt()` appends a \`## Selected context assets\` block from `\$story->includedContextItems()`.
- Each item rendered via `bodyForContext()` (summary preferred, raw fallback).
- Hard cap: \`TasksGenerator::CONTEXT_ASSETS_CAP_BYTES\` = 8192. Items past the cap are dropped with a truncation marker, so plan generation never blows the prompt budget.

Subtask-execution injection lands in slice 4 (built but not default-wired).

## Test plan

- [x] 4 new Pest tests in `TasksGeneratorContextTest.php` — all green
- [x] Existing `TaskGenerationTest` still passes (5 tests)
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)