### PR TITLE
Project & Story context assets — slice 4: subtask context builder (opt-in)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace App\Providers;
 
+use App\Services\Context\CompositeContextBuilder;
 use App\Services\Context\ContextBuilder;
 use App\Services\Context\NullContextBuilder;
 use App\Services\Context\RecencyContextBuilder;
+use App\Services\Context\SelectedAssetsContextBuilder;
 use App\Services\Executors\Executor;
 use App\Services\Executors\ExecutorFactory;
 use App\Services\Prompts\PromptLoader;
@@ -40,11 +42,14 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(ContextBuilder::class, function () {
             $driver = config('specify.context.builder', 'recency');
 
+            $recency = fn () => new RecencyContextBuilder(
+                window: (string) config('specify.context.recency.window', '30.days'),
+                maxFiles: (int) config('specify.context.recency.max_files', 10),
+            );
+
             return match ($driver) {
-                'recency' => new RecencyContextBuilder(
-                    window: (string) config('specify.context.recency.window', '30.days'),
-                    maxFiles: (int) config('specify.context.recency.max_files', 10),
-                ),
+                'recency' => $recency(),
+                'composite' => new CompositeContextBuilder($recency(), new SelectedAssetsContextBuilder),
                 'null', null, '' => new NullContextBuilder,
                 default => throw new InvalidArgumentException("Unknown context builder [{$driver}]."),
             };

--- a/app/Services/Context/CompositeContextBuilder.php
+++ b/app/Services/Context/CompositeContextBuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Models\Repo;
+use App\Models\Subtask;
+
+/**
+ * Chains multiple ContextBuilders, concatenating their non-empty briefs in
+ * order with a blank line between sections. Empty briefs are dropped, so a
+ * builder that has nothing to say doesn't leave dead whitespace in the
+ * prompt.
+ */
+class CompositeContextBuilder implements ContextBuilder
+{
+    /** @var list<ContextBuilder> */
+    private array $builders;
+
+    public function __construct(ContextBuilder ...$builders)
+    {
+        $this->builders = array_values($builders);
+    }
+
+    public function build(Subtask $subtask, ?string $workingDir, ?Repo $repo): string
+    {
+        $briefs = [];
+        foreach ($this->builders as $builder) {
+            $brief = trim($builder->build($subtask, $workingDir, $repo));
+            if ($brief !== '') {
+                $briefs[] = $brief;
+            }
+        }
+
+        return implode("\n\n", $briefs);
+    }
+}

--- a/app/Services/Context/SelectedAssetsContextBuilder.php
+++ b/app/Services/Context/SelectedAssetsContextBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services\Context;
+
+use App\Models\Repo;
+use App\Models\Subtask;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Per-subtask context brief that surfaces the Story's selected ContextItems.
+ *
+ * Resolves Subtask → Task → Plan → Story → includedContextItems and emits a
+ * `<context-brief>`-shaped block clamped to 4 KB. Built but not wired by
+ * default (see `AppServiceProvider` — only the `composite` driver enables it
+ * alongside `RecencyContextBuilder`).
+ */
+class SelectedAssetsContextBuilder implements ContextBuilder
+{
+    public const MAX_BYTES = 4096;
+
+    public function build(Subtask $subtask, ?string $workingDir, ?Repo $repo): string
+    {
+        try {
+            $story = $subtask->task?->plan?->story;
+            if ($story === null) {
+                return '';
+            }
+
+            $items = $story->includedContextItems()->get();
+            if ($items->isEmpty()) {
+                return '';
+            }
+
+            $rendered = [];
+            $usedBytes = 0;
+            $dropped = 0;
+
+            foreach ($items as $item) {
+                $type = $item->type?->value ?? 'unknown';
+                $body = trim($item->bodyForContext());
+                $entry = "### {$item->title} ({$type})\n".($body === '' ? '(no extractable body)' : $body);
+                $entryBytes = strlen($entry) + 2; // separator allowance
+
+                if ($usedBytes + $entryBytes > self::MAX_BYTES) {
+                    $dropped++;
+
+                    continue;
+                }
+
+                $rendered[] = $entry;
+                $usedBytes += $entryBytes;
+            }
+
+            if ($rendered === []) {
+                return '';
+            }
+
+            $body = implode("\n\n", $rendered);
+            $note = $dropped === 0
+                ? ''
+                : "\n\n_Truncated: {$dropped} item(s) over the ".self::MAX_BYTES.'-byte cap._';
+
+            return "<context-brief>\n\n## Selected context assets\n\n{$body}{$note}\n\n</context-brief>";
+        } catch (Throwable $e) {
+            Log::warning('specify.context.selected_assets.failed', [
+                'subtask_id' => $subtask->getKey(),
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            return '';
+        }
+    }
+}

--- a/app/Services/Context/SelectedAssetsContextBuilder.php
+++ b/app/Services/Context/SelectedAssetsContextBuilder.php
@@ -32,6 +32,18 @@ class SelectedAssetsContextBuilder implements ContextBuilder
                 return '';
             }
 
+            // Cap accounts for the wrapping `<context-brief>` tag, the
+            // header, and the worst-case truncation note as well as item
+            // entries — the ENTIRE rendered brief stays under MAX_BYTES,
+            // matching RecencyContextBuilder's strict-clamp behaviour.
+            $openTag = "<context-brief>\n\n";
+            $closeTag = "\n\n</context-brief>";
+            $header = "## Selected context assets\n\n";
+            $noteTemplate = "\n\n_Truncated: %d item(s) over the ".self::MAX_BYTES.'-byte cap._';
+            $worstCaseNote = sprintf($noteTemplate, $items->count());
+            $overhead = strlen($openTag) + strlen($closeTag) + strlen($header) + strlen($worstCaseNote);
+            $itemBudget = self::MAX_BYTES - $overhead;
+
             $rendered = [];
             $usedBytes = 0;
             $dropped = 0;
@@ -40,9 +52,9 @@ class SelectedAssetsContextBuilder implements ContextBuilder
                 $type = $item->type?->value ?? 'unknown';
                 $body = trim($item->bodyForContext());
                 $entry = "### {$item->title} ({$type})\n".($body === '' ? '(no extractable body)' : $body);
-                $entryBytes = strlen($entry) + 2; // separator allowance
+                $entryBytes = strlen($entry) + 2; // "\n\n" separator allowance
 
-                if ($usedBytes + $entryBytes > self::MAX_BYTES) {
+                if ($usedBytes + $entryBytes > $itemBudget) {
                     $dropped++;
 
                     continue;
@@ -57,11 +69,9 @@ class SelectedAssetsContextBuilder implements ContextBuilder
             }
 
             $body = implode("\n\n", $rendered);
-            $note = $dropped === 0
-                ? ''
-                : "\n\n_Truncated: {$dropped} item(s) over the ".self::MAX_BYTES.'-byte cap._';
+            $note = $dropped === 0 ? '' : sprintf($noteTemplate, $dropped);
 
-            return "<context-brief>\n\n## Selected context assets\n\n{$body}{$note}\n\n</context-brief>";
+            return $openTag.$header.$body.$note.$closeTag;
         } catch (Throwable $e) {
             Log::warning('specify.context.selected_assets.failed', [
                 'subtask_id' => $subtask->getKey(),

--- a/config/specify.php
+++ b/config/specify.php
@@ -151,7 +151,9 @@ return [
     | Per-subtask context brief prepended to the executor prompt. "recency"
     | (default) emits a small markdown block with files mentioned in the
     | Subtask description, recent commits touching them, and prior failed
-    | runs on the same Subtask. "null" disables the brief entirely.
+    | runs on the same Subtask. "composite" chains "recency" with the
+    | story's selected ContextItems (4 KB cap each). "null" disables the
+    | brief entirely.
     |
     */
 

--- a/config/specify.php
+++ b/config/specify.php
@@ -152,8 +152,8 @@ return [
     | (default) emits a small markdown block with files mentioned in the
     | Subtask description, recent commits touching them, and prior failed
     | runs on the same Subtask. "composite" chains "recency" with the
-    | story's selected ContextItems (4 KB cap each). "null" disables the
-    | brief entirely.
+    | story's selected ContextItems — each builder's brief is clamped to
+    | 4 KB before they're concatenated. "null" disables the brief entirely.
     |
     */
 

--- a/tests/Feature/ContextItem/SelectedAssetsContextBuilderTest.php
+++ b/tests/Feature/ContextItem/SelectedAssetsContextBuilderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use App\Enums\ContextItemSummaryStatus;
+use App\Models\ContextItem;
+use App\Models\Plan;
+use App\Models\Story;
+use App\Models\Subtask;
+use App\Models\Task;
+use App\Services\Context\CompositeContextBuilder;
+use App\Services\Context\ContextBuilder;
+use App\Services\Context\NullContextBuilder;
+use App\Services\Context\RecencyContextBuilder;
+use App\Services\Context\SelectedAssetsContextBuilder;
+
+function subtaskWithStory(): array
+{
+    $story = Story::factory()->create();
+    $plan = Plan::factory()->for($story)->create();
+    $task = Task::factory()->forCurrentPlanOf($story)->create([
+        'plan_id' => $plan->id,
+        'position' => 1,
+    ]);
+    $subtask = Subtask::factory()->for($task)->create(['position' => 1, 'name' => 's']);
+
+    return [$story, $subtask];
+}
+
+test('builder returns empty when no items are included', function () {
+    [$story, $subtask] = subtaskWithStory();
+
+    $brief = (new SelectedAssetsContextBuilder)->build($subtask, null, null);
+
+    expect($brief)->toBe('');
+});
+
+test('builder renders included items inside a context-brief tag', function () {
+    [$story, $subtask] = subtaskWithStory();
+    $project = $story->feature->project;
+    $a = ContextItem::factory()->for($project)->forText('alpha body')->create([
+        'title' => 'Alpha',
+        'summary' => 'alpha summary',
+        'summary_status' => ContextItemSummaryStatus::Ready,
+    ]);
+    $story->includedContextItems()->attach($a->id);
+
+    $brief = (new SelectedAssetsContextBuilder)->build($subtask, null, null);
+
+    expect($brief)->toStartWith('<context-brief>');
+    expect($brief)->toEndWith('</context-brief>');
+    expect($brief)->toContain('### Alpha (text)');
+    expect($brief)->toContain('alpha summary');
+});
+
+test('builder clamps to MAX_BYTES with a truncation note', function () {
+    [$story, $subtask] = subtaskWithStory();
+    $project = $story->feature->project;
+    $bigBody = str_repeat('lorem ipsum dolor ', 100); // ~1.8 KB each — three of these blow the 4 KB cap
+
+    foreach (range(1, 3) as $i) {
+        $item = ContextItem::factory()->for($project)->forText($bigBody)->create([
+            'title' => "Big {$i}",
+            'summary' => $bigBody,
+            'summary_status' => ContextItemSummaryStatus::Ready,
+        ]);
+        $story->includedContextItems()->attach($item->id);
+    }
+
+    $brief = (new SelectedAssetsContextBuilder)->build($subtask, null, null);
+
+    expect(strlen($brief))->toBeLessThan(SelectedAssetsContextBuilder::MAX_BYTES + 256);
+    expect($brief)->toContain('Truncated:');
+});
+
+test('CompositeContextBuilder concatenates non-empty briefs and skips empties', function () {
+    [, $subtask] = subtaskWithStory();
+
+    $alwaysEmpty = new NullContextBuilder;
+    $alwaysSomething = new class implements ContextBuilder
+    {
+        public function build($subtask, $workingDir, $repo): string
+        {
+            return 'HELLO';
+        }
+    };
+
+    $composite = new CompositeContextBuilder($alwaysEmpty, $alwaysSomething, $alwaysEmpty);
+
+    expect($composite->build($subtask, null, null))->toBe('HELLO');
+});
+
+test('composite driver wires Recency + SelectedAssets and stays opt-in (default is recency)', function () {
+    config(['specify.context.builder' => 'composite']);
+    app()->forgetInstance(ContextBuilder::class);
+
+    $builder = app(ContextBuilder::class);
+
+    expect($builder)->toBeInstanceOf(CompositeContextBuilder::class);
+});
+
+test('default driver remains recency', function () {
+    config(['specify.context.builder' => 'recency']);
+    app()->forgetInstance(ContextBuilder::class);
+
+    $builder = app(ContextBuilder::class);
+
+    expect($builder)->toBeInstanceOf(RecencyContextBuilder::class);
+});

--- a/tests/Feature/ContextItem/SelectedAssetsContextBuilderTest.php
+++ b/tests/Feature/ContextItem/SelectedAssetsContextBuilderTest.php
@@ -67,7 +67,10 @@ test('builder clamps to MAX_BYTES with a truncation note', function () {
 
     $brief = (new SelectedAssetsContextBuilder)->build($subtask, null, null);
 
-    expect(strlen($brief))->toBeLessThan(SelectedAssetsContextBuilder::MAX_BYTES + 256);
+    // Cap accounting now bounds the entire rendered brief (wrapper tags,
+    // header, body, and the worst-case truncation note). Assert the strict
+    // bound rather than a loose slack — that's the contract.
+    expect(strlen($brief))->toBeLessThanOrEqual(SelectedAssetsContextBuilder::MAX_BYTES);
     expect($brief)->toContain('Truncated:');
 });
 


### PR DESCRIPTION
## Summary

Stacked on **slice 3**. Builds the second-half of the context flow but ships it **opt-in** — default runtime behaviour is unchanged.

- `SelectedAssetsContextBuilder` — implements `ContextBuilder`; resolves Subtask → Task → Plan → Story → `includedContextItems`; emits a `<context-brief>`-shaped block clamped to 4 KB.
- `CompositeContextBuilder` — chains a list of `ContextBuilder`s, dropping empty briefs.
- `AppServiceProvider`'s `ContextBuilder` driver switch gains a `composite` case (chains `RecencyContextBuilder` + `SelectedAssetsContextBuilder`).
- **Default stays `recency`.** Operators opt in by setting `SPECIFY_CONTEXT_BUILDER=composite`.

## Test plan

- [x] 6 new Pest tests in `SelectedAssetsContextBuilderTest.php` (including a default-driver-still-recency regression test) — all green
- [x] Existing `ContextBuilderTest` still passes
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)