### PR TITLE
Project & Story context assets — slice 7: ADR-0015 + onboarding docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Specify is a Laravel 13 system where humans approve AI actions on code repos. **
 | Add an MCP tool | `app/Mcp/Tools/` (follow the existing `#[Description]` + `handle()` shape) |
 | Edit an agent's system prompt | `prompts/*.md` (loaded by `App\Services\Prompts\PromptLoader`) |
 | Tune the per-subtask context brief | `app/Services/Context/` (`ContextBuilder` interface + `RecencyContextBuilder`) |
+| Add or change a Project / Story context asset | [ADR-0015](docs/adr/0015-project-and-story-context-assets.md), `app/Services/Context/` (`AssetUploader`, `ContextItemWriter`, `ContextItemSelector`), `app/Jobs/SummariseContextItemJob.php` |
 | Run the suite | `composer test` (Pint check + Pest) |
 
 ## Specify-specific rules
@@ -28,6 +29,7 @@ Specify is a Laravel 13 system where humans approve AI actions on code repos. **
 - **PR opening is non-fatal.** A failed PR creation must record `pull_request_error` on the AgentRun and let the run still succeed (ADR-0004). Don't fail the run on PR errors.
 - **`AgentRun` is append-only.** `StoryApproval` and `PlanApproval` are immutable. Treat them as audit logs — corrections happen by writing new rows, never by mutating old ones.
 - **"The database" means the Laravel app DB.** Per-run git working directories under `storage/app/runs/...` are filesystem state, not database state.
+- **Story-scoped context CRUD reopens approval; project-scoped does not.** ContextItem mutations follow the same revision-bump rules as `AcceptanceCriterion` / `Scenario` — see ADR-0015. Never bypass `ContextItemSelector` for pivot writes; the bulk path is what keeps approval-reopens to one per save.
 
 ## Framework guidance — ask Boost
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,8 @@ Living document. Terms are added as they're sharpened during design discussions.
 
 - **Team** — workspace-scoped, M:N with User via `team_user`.
 - **Repo** — workspace-scoped, attached to Projects via `project_repo`. Carries `provider`, encrypted `access_token`, and `webhook_secret`.
+- **ContextItem** — product-owner reference asset (file / link / text) attached to a Project (shared) or a single Story (scoped). Story-scoped items auto-include and reopen Story approval on CRUD; project-scoped items do not. See ADR-0015.
+- **Story context selection** — the set of ContextItems a Story has selected, recorded in `context_item_story`. Toggling inclusion reopens Story approval — exactly once per `bulkSet` save. The picker's source is `Story::availableContextItems()` (project-scoped + own).
 - **ApprovalPolicy** — cascade `workspace -> project -> story` with a `required_approvals` threshold. Resolved policy decides how many Approve decisions a Story or Plan needs; Plans use their Story's effective policy. StoryApproval gates the product contract and PlanApproval gates execution against the current Plan. The threshold is surfaced in the UI as tally pills (`Approved · 2/2`, `Pending · 1/2`, `Changes requested`). The approval rail shows immutable **decision logs** (Approve / ChangesRequested / Reject / Revoke, approver, time) rather than flat approver lists. ChangesRequested resets the relevant tally — the editor must surface this consequence before the click. Reject is terminal and lives in a "more" menu with a hard confirm. **Story authors cannot approve their own Stories** — the Approve button is hidden for the author. When threshold > 1, the rail lists eligible approvers.
 
 ## Runs and race mode

--- a/docs/adr/0015-project-and-story-context-assets.md
+++ b/docs/adr/0015-project-and-story-context-assets.md
@@ -1,0 +1,116 @@
+# 0015. Project- and Story-scoped context assets
+
+Date: 2026-05-10
+Status: Accepted
+
+## Context
+
+Until this ADR, Specify had no first-class place for the briefing material a
+product owner brings to a Story: reference images, walkthrough captures,
+PDFs, links to Figma / Stitch / Sketch, free-form notes. Two earlier
+attempts (#1, #44) shipped a Project-only schema but were closed unmerged.
+
+The AI agents that power plan generation and Subtask execution worked off a
+4 KB recency-and-mentions brief (`RecencyContextBuilder`). They had no way
+to cite product-owner context the human had explicitly chosen to surface.
+
+We needed a place to store assets, a per-Story selection mechanism, and an
+injection point into the AI flow — without breaking the approval invariants
+that gate Story / Plan changes.
+
+## Decision
+
+Adopt a `ContextItem` aggregate with two scopes and an explicit per-Story
+selection.
+
+### Storage and scope
+
+- **Dual scope.** A `ContextItem` belongs to a `Project` (shared) or a
+  single `Story` (scoped). `project_id` is always set; `story_id` is set
+  only for story-scoped items.
+- **Selection per Story.** A pivot (`context_item_story`) records which
+  items a Story has selected. The picker shows
+  `Story::availableContextItems()` — the union of project-scoped items in
+  the same Project plus this Story's own story-scoped items. Story-scoped
+  items are auto-included on creation and cannot be toggled off.
+- **Types.** `file`, `link`, `text`. No video in v1.
+
+### Approval-reopen invariants
+
+- **Story-scoped CRUD reopens Story approval.** Creating, updating, or
+  deleting a story-scoped `ContextItem` calls
+  `StoryRevisionLifecycle::recordContentArtifactChanged($story)` — the same
+  helper `AcceptanceCriterion` and `Scenario` writers use. One call per
+  write.
+- **Project-scoped CRUD does not reopen any Story.** Even if a project
+  asset is currently included by N Stories, editing it leaves their
+  approvals intact. This is the v1 trade-off — re-fanning out approval
+  storms across many Stories on every project asset edit is worse than
+  letting the included copies drift.
+- **Toggling inclusion reopens Story approval.** `ContextItemSelector` is
+  the only legal mutator for the pivot. `setIncluded()` and `bulkSet()`
+  each call `recordContentArtifactChanged` at most once per public-method
+  invocation, only when the included set actually changed. The picker uses
+  `bulkSet` to avoid per-checkbox approval storms.
+
+### Storage on a single `private` disk
+
+A new `private` disk in `config/filesystems.php` backs all uploads. In
+local dev it points at `storage/app/private`; in hosted runtime the same
+disk name is repointed at S3 with no code change.
+
+Files are stored under `context/{ulid}/{slugified-name}`. On
+`ContextItem` delete the underlying file is hard-deleted at the disk; the
+DB row is soft-deleted for audit. Document what hard-delete means before
+this is migrated to S3 (versioning rules differ).
+
+### Lazy, bounded summarisation
+
+Long bodies are compressed by `ContextSummariser` (laravel/ai) via
+`ContextCompressor`, dispatched as `SummariseContextItemJob`:
+
+- The job uses the **creator's** BYOK credential. Missing creds are not a
+  failure — they collapse to `summary_status='skipped'`. `bodyForContext()`
+  then falls back to a truncated raw body so plan generation still works.
+- Short text (under `specify.context.assets.summary_threshold_chars`,
+  default 2000) is marked `Skipped` at create time — no point summarising.
+- Summarisation runs eagerly on upload / create / body-change. There is no
+  background re-summarise.
+
+### Injection points
+
+- **v1 = plan generation only.** `TasksGenerator::buildPrompt()` appends a
+  `## Selected context assets` block from
+  `$story->includedContextItems()`. The block is hard-capped at 8 KB —
+  items past the cap are dropped with a truncation marker.
+- **Subtask execution** (`SelectedAssetsContextBuilder` +
+  `CompositeContextBuilder`) is **built but not default-wired**. Operators
+  opt in by setting `SPECIFY_CONTEXT_BUILDER=composite`. The default
+  remains `recency` — runtime behaviour for existing deployments is
+  unchanged.
+
+## Consequences
+
+**Approval semantics stay clean.** The same revision-bump path used by
+acceptance criteria and scenarios now also covers selected context. The
+`bulkSet`-once-per-save contract avoids approval-reopen storms on the
+picker.
+
+**Plan-generation prompts can grow.** Plans regenerated with rich context
+bundles will produce more tightly-scoped Tasks, but only up to the 8 KB
+cap. Reviewers should expect a UI warning when they're about to overflow.
+
+**File leakage on delete.** Soft-delete + hard-file-delete is asymmetric:
+the audit row survives but the bytes are gone. This is intentional — we
+do not want abandoned PDFs or screenshots accumulating on the disk. When
+this moves to S3, the equivalent is a single-version delete (no version
+history retention).
+
+**No automatic re-summarisation.** A summarisation that finished `Failed`
+stays Failed until a user edits the body. Acceptable in v1; revisit if
+operators see flapping providers.
+
+**Project-scoped CRUD leaks edits to included Stories.** A project owner
+who edits a referenced Style Guide will not reopen the Stories that cite
+it. Document this in the picker copy ("changes to project-scoped items
+do not reopen Story approval"). Revisit if reviewers report drift.

--- a/docs/adr/0015-project-and-story-context-assets.md
+++ b/docs/adr/0015-project-and-story-context-assets.md
@@ -74,8 +74,14 @@ Long bodies are compressed by `ContextSummariser` (laravel/ai) via
   then falls back to a truncated raw body so plan generation still works.
 - Short text (under `specify.context.assets.summary_threshold_chars`,
   default 2000) is marked `Skipped` at create time — no point summarising.
-- Summarisation runs eagerly on upload / create / body-change. There is no
-  background re-summarise.
+- **Text items only in v1.** `SummariseContextItemJob` only runs for text
+  bodies; link items are `Skipped` at create time. File uploads also land
+  `Skipped` because there is no extraction pipeline yet — `AssetUploader`
+  writes the row with `summary_status=skipped` and does not dispatch.
+  When PDF / image extraction lands, the extractor will flip the row to
+  `Pending` and dispatch from there.
+- Summarisation runs eagerly on text create / text body-change. There is
+  no background re-summarise.
 
 ### Injection points
 


### PR DESCRIPTION
## Summary

Stacked on **slice 4**. Records the load-bearing decisions and threads them into agent onboarding so future Claude sessions know where to look.

- `docs/adr/0015-project-and-story-context-assets.md` — dual scope, selection-reopens-approval, project-scoped CRUD does not reopen, plan-generation-only injection in v1, opt-in subtask-execution injection.
- `AGENTS.md` (CLAUDE.md symlinks here): new quick-start row pointing to ADR-0015 + the writer/uploader/selector files; new Specify rule that codifies the approval-reopen invariant.
- `CONTEXT.md`: new glossary entries for **ContextItem** and **Story context selection**.

## Test plan

- [x] No code changes — docs-only
- [ ] Reviewer: re-read ADR-0015 against the implementation in slices 1-4
- [ ] Reviewer: confirm `AGENTS.md` row reads naturally next to existing rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)